### PR TITLE
[E-06d] Compose wildcard snapshot runtime port

### DIFF
--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,18 +2,19 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-05, E-06a, E-06b, and E-06c are completed; the D-14
+- Status: D-08, E-01 through E-05, E-06a, E-06b, E-06c, and E-06d are completed; the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-06c:
-  `dev@12e2d1d07cd1f9747cdf87d3e620943684f1e489` after E-06b / PR #548.
-- Document baseline: completed E-06c canonical wildcard service/internal caller Move.
+- Code-review base before E-06d:
+  `dev@a51787ce60340bdb9adecd7fbbedb4dd482bbaa4` after E-06c / PR #549.
+- Document baseline: completed E-06d narrow wildcard RuntimeServices/bootstrap composition Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
   the E-05c index-store owner Move, the E-05d composition Move, the E-05e
   completion audit Contract, the E-06a wildcard snapshot ownership Contract, the
-  E-06b snapshot owner Move, the E-06c canonical service/internal caller Move, and
-  the next bounded E-06d narrow RuntimeServices/bootstrap composition Move.
+  E-06b snapshot owner Move, the E-06c canonical service/internal caller Move, the
+  E-06d narrow RuntimeServices/bootstrap composition Move, and the next bounded
+  E-06e completion audit Contract.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -409,7 +410,12 @@ E-06c installs a root-independent private wildcard service, converts canonical n
 Prompt Studio, and seed consumers away from root `wildcard_engine`, and retains root
 signatures, behavior, exact snapshot identities, and call-time source/build seams.
 
-Start only a separate #187 E-06d feature-specific narrow RuntimeServices/bootstrap
-composition Move from latest origin/dev. Do not start E-06e or later Phase E work,
-E-09 cleanup, D-14 retirement, release, or Registry work inside E-06d.
+E-06d types the exact `_DEFAULT_WILDCARD_SNAPSHOTS` identity behind one private
+`WildcardSnapshotPort` and installs it directly as
+`RuntimeServices.wildcard_snapshots`. Feature modules do not import the runtime,
+and initialize order/retry plus wildcard-directory lifecycle remain unchanged.
+
+Start only a separate production-free #187 E-06e wildcard ownership completion
+audit Contract from latest origin/dev. Do not start later Phase E work, E-09 cleanup,
+D-14 retirement, release, or Registry work inside E-06e.
 ```

--- a/docs/architecture/python-runtime-e06-wildcard-contract.md
+++ b/docs/architecture/python-runtime-e06-wildcard-contract.md
@@ -108,9 +108,12 @@ expansion, and service owners directly. Their module-local patch names remain
 patchable, and all list/signature/expansion behavior is unchanged.
 
 E-06c completes the remaining lifecycle/service facade and internal caller Move while
-retaining the root compatibility surface. E-06d next installs only one
-feature-specific narrow wildcard snapshot capability backed by the exact default
-owner. Feature code does not receive or import the complete `RuntimeServices` object.
+retaining the root compatibility surface. E-06d installs the exact
+`_DEFAULT_WILDCARD_SNAPSHOTS` identity directly as the private
+`RuntimeServices.wildcard_snapshots` capability typed by `WildcardSnapshotPort`.
+The port describes only `snapshot_for_roots`; it creates no wrapper or replacement
+owner. Feature code does not receive or import the complete `RuntimeServices` object,
+and canonical/root callers keep their existing call-time resolver paths.
 
 ## Bounded Move queue
 
@@ -123,9 +126,9 @@ owner. Feature code does not receive or import the complete `RuntimeServices` ob
 3. **E-06c Move — canonical service and internal callers — complete:** canonicalize the
    lifecycle/service facade, convert internal consumers to that owner, and retain the
    exact root compatibility surface.
-4. **E-06d Move — bootstrap composition:** install the exact default owner behind one
-   feature-specific narrow wildcard capability without changing initialization or
-   directory lifecycle.
+4. **E-06d Move — bootstrap composition — complete:** install the exact default owner
+   behind one feature-specific narrow wildcard capability without changing
+   initialization or directory lifecycle.
 5. **E-06e Contract — completion audit:** reconcile E-01, cleanup, import direction,
    root identities, and zero ambiguous wildcard snapshot state before E-07.
 
@@ -164,7 +167,10 @@ import boundaries/analyzer, JSON/Python syntax, document links, and `git diff
 settlement, exact root/default identity, raw-state removal, and actual-code analyzer
 inventory. E-06c covers canonical/root service parity, root signatures and dynamic
 seams, canonical internal import direction, direct node/Prompt Studio/seed behavior,
-and shipped archive/no-host closure.
+and shipped archive/no-host closure. E-06d covers the narrow port shape, exact
+default-owner identity in the installed runtime, bootstrap reuse, feature import
+direction, and unchanged directory initialization order/retry behavior. It adds no
+new public surface or cleanup policy.
 
 Run the official full profile once on each final candidate SHA. E-06c adds one shipped
 private module and changes canonical import closure without changing dependencies,

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -66,6 +66,7 @@ from .translation.service import (
     PromptTranslationService,
     _install_default_translation_service,
 )
+from .wildcard.snapshot import _DEFAULT_WILDCARD_SNAPSHOTS
 
 _LOGGER = logging.getLogger("ComfyUI-EasyUseAnima")
 _INITIALIZE_LOCK = threading.Lock()
@@ -260,6 +261,7 @@ def initialize(
                     snapshots=_DEFAULT_AUTOCOMPLETE_SNAPSHOTS,
                     index_store=_DEFAULT_AUTOCOMPLETE_INDEX_STORE,
                 ),
+                wildcard_snapshots=_DEFAULT_WILDCARD_SNAPSHOTS,
             )
             install_runtime(runtime)
             _install_default_translation_service(runtime.translation)

--- a/easyuse_anima/runtime.py
+++ b/easyuse_anima/runtime.py
@@ -10,6 +10,7 @@ from .autocomplete.ports import AutocompletePort
 from .infrastructure.comfy.provider import ComfyHostProvider
 from .seed.reservation import SeedReservationService
 from .translation.ports import PromptTranslationPort
+from .wildcard.ports import WildcardSnapshotPort
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +44,7 @@ class RuntimeServices:
     clock: Clock
     translation: PromptTranslationPort
     autocomplete: AutocompletePort
+    wildcard_snapshots: WildcardSnapshotPort
 
 
 _RUNTIME_SERVICES: RuntimeServices | None = None

--- a/easyuse_anima/wildcard/ports.py
+++ b/easyuse_anima/wildcard/ports.py
@@ -1,0 +1,24 @@
+"""Narrow process wildcard snapshot capability."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .snapshot import _WildcardSnapshot
+    from .sources import _WildcardSourceState
+
+
+class WildcardSnapshotPort(Protocol):
+    def snapshot_for_roots(
+        self,
+        roots: Iterable[Path],
+        *,
+        scan_sources: Callable[[tuple[Path, ...]], _WildcardSourceState],
+        build_snapshot: Callable[[_WildcardSourceState], _WildcardSnapshot],
+    ) -> _WildcardSnapshot: ...
+
+
+__all__ = ()

--- a/tests/comfy_host_fakes.py
+++ b/tests/comfy_host_fakes.py
@@ -53,6 +53,14 @@ class FakeAutocompleteService:
         )
 
 
+class FakeWildcardSnapshots:
+    def snapshot_for_roots(self, roots, *, scan_sources, build_snapshot):
+        raise AssertionError(
+            "unexpected wildcard snapshot resolution: "
+            f"{(roots, scan_sources, build_snapshot)!r}"
+        )
+
+
 class FakeComfyHostProvider:
     def __init__(
         self,
@@ -143,6 +151,7 @@ def _runtime_support(runtime_module):
             installed.clock,
             installed.translation,
             installed.autocomplete,
+            installed.wildcard_snapshots,
         )
     return (
         runtime_module.RuntimeConfig(
@@ -153,13 +162,16 @@ def _runtime_support(runtime_module):
         FakeClock(),
         FakeTranslationService(),
         FakeAutocompleteService(),
+        FakeWildcardSnapshots(),
     )
 
 
 @contextmanager
 def use_fake_comfy_host(root_module, provider):
     runtime_module = _runtime_module_for(root_module)
-    config, clock, translation, autocomplete = _runtime_support(runtime_module)
+    config, clock, translation, autocomplete, wildcard_snapshots = (
+        _runtime_support(runtime_module)
+    )
     runtime = runtime_module.RuntimeServices(
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
@@ -167,6 +179,7 @@ def use_fake_comfy_host(root_module, provider):
         clock=clock,
         translation=translation,
         autocomplete=autocomplete,
+        wildcard_snapshots=wildcard_snapshots,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield provider
@@ -196,7 +209,9 @@ def patch_comfy_helper(
         else FakeComfyHostProvider()
     )
     provider = _LayeredFakeComfyHostProvider(base, symbol, replacement)
-    config, clock, translation, autocomplete = _runtime_support(runtime_module)
+    config, clock, translation, autocomplete, wildcard_snapshots = (
+        _runtime_support(runtime_module)
+    )
     runtime = runtime_module.RuntimeServices(
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
@@ -204,6 +219,7 @@ def patch_comfy_helper(
         clock=clock,
         translation=translation,
         autocomplete=autocomplete,
+        wildcard_snapshots=wildcard_snapshots,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield replacement

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -17973,6 +17973,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_DEFAULT_WILDCARD_SNAPSHOTS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
+        "kind": "static_from",
+        "line": 69,
+        "name": "_DEFAULT_WILDCARD_SNAPSHOTS",
+        "optional": false,
+        "requested": ".wildcard.snapshot",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PACKAGE_DATA_DIR",
         "branch_context": [],
         "classification": "internal",
@@ -17980,7 +17998,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -17998,7 +18016,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_ROOT",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "PACKAGE_ROOT",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -18016,7 +18034,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -30168,6 +30186,24 @@
         "target": "easyuse_anima/translation/ports.py"
       },
       {
+        "alias": null,
+        "bound_name": "WildcardSnapshotPort",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".wildcard.ports:WildcardSnapshotPort",
+        "kind": "static_from",
+        "line": 13,
+        "name": "WildcardSnapshotPort",
+        "optional": false,
+        "requested": ".wildcard.ports",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py",
+        "target": "easyuse_anima/wildcard/ports.py"
+      },
+      {
         "alias": "_execution_identity",
         "bound_name": "_execution_identity",
         "branch_context": [],
@@ -33429,6 +33465,158 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Iterable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Iterable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Iterable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TYPE_CHECKING",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TYPE_CHECKING",
+        "kind": "static_from",
+        "line": 7,
+        "name": "TYPE_CHECKING",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSnapshot",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 9,
+            "type_checking": true
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "conditional": true,
+        "imported": ".snapshot:_WildcardSnapshot",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_WildcardSnapshot",
+        "optional": true,
+        "requested": ".snapshot",
+        "role": "optional_dependency",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceState",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 9,
+            "type_checking": true
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "conditional": true,
+        "imported": ".sources:_WildcardSourceState",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_WildcardSourceState",
+        "optional": true,
+        "requested": ".sources",
+        "role": "optional_dependency",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/ports.py",
+        "target": "easyuse_anima/wildcard/sources.py"
       },
       {
         "alias": null,
@@ -65912,6 +66100,10 @@
         "to": "easyuse_anima/translation/service.py"
       },
       {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
         "from": "easyuse_anima/image/detailer.py",
         "to": "easyuse_anima/image/geometry.py"
       },
@@ -66634,6 +66826,10 @@
       {
         "from": "easyuse_anima/runtime.py",
         "to": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "from": "easyuse_anima/runtime.py",
+        "to": "easyuse_anima/wildcard/ports.py"
       },
       {
         "from": "easyuse_anima/seed/__init__.py",
@@ -68087,6 +68283,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/wildcard/ports.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/wildcard/seed.py"
         ]
       },
@@ -68153,7 +68355,7 @@
     ]
   },
   "inventory": {
-    "module_count": 171,
+    "module_count": 172,
     "modules": [
       {
         "is_package": true,
@@ -69057,9 +69259,9 @@
       },
       {
         "is_package": false,
-        "loc": 284,
+        "loc": 286,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "8c0c009d70596f52f35a5ce6c2828815a673e0ae",
+        "normalized_git_blob_sha1": "b4994d7c3a0b05817005789acf0c167651f192dc",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 1,
@@ -69789,9 +69991,9 @@
       },
       {
         "is_package": false,
-        "loc": 83,
+        "loc": 85,
         "module": "easyuse_anima.runtime",
-        "normalized_git_blob_sha1": "b6e85007a5059760a37dd3cfb3a1e4b8c215cf57",
+        "normalized_git_blob_sha1": "feacbf426d89f090a530a4fc0ee76342c25744a6",
         "path": "easyuse_anima/runtime.py",
         "top_level": {
           "class_count": 4,
@@ -70073,6 +70275,18 @@
           "class_count": 3,
           "function_count": 2,
           "global_count": 10
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 24,
+        "module": "easyuse_anima.wildcard.ports",
+        "normalized_git_blob_sha1": "0b0493e22b9a81de0ff9d1efd49c99ddf619aaf7",
+        "path": "easyuse_anima/wildcard/ports.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 0,
+          "global_count": 1
         }
       },
       {
@@ -89203,6 +89417,72 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Iterable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TYPE_CHECKING",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/wildcard/seed.py"
       },
       {
@@ -90759,6 +91039,7 @@
       "easyuse_anima/wildcard/library.py",
       "easyuse_anima/wildcard/mode.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/ports.py",
       "easyuse_anima/wildcard/seed.py",
       "easyuse_anima/wildcard/selector.py",
       "easyuse_anima/wildcard/service.py",
@@ -90932,6 +91213,7 @@
       "easyuse_anima/wildcard/library.py",
       "easyuse_anima/wildcard/mode.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/ports.py",
       "easyuse_anima/wildcard/seed.py",
       "easyuse_anima/wildcard/selector.py",
       "easyuse_anima/wildcard/service.py",
@@ -92160,7 +92442,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 70,
+        "line": 71,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92169,7 +92451,7 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 71,
+        "line": 72,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92628,7 +92910,7 @@
         "column": 1,
         "context": "decorator:RuntimeConfig",
         "kind": "import_time_call",
-        "line": 15,
+        "line": 16,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -92637,7 +92919,7 @@
         "column": 1,
         "context": "decorator:RuntimeServices",
         "kind": "import_time_call",
-        "line": 36,
+        "line": 37,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -93118,7 +93400,7 @@
       },
       {
         "kind": "list",
-        "line": 284,
+        "line": 286,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -93447,7 +93729,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 71,
+        "line": 72,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/fixtures/python_wildcard_runtime_contract.v1.json
+++ b/tests/fixtures/python_wildcard_runtime_contract.v1.json
@@ -89,7 +89,7 @@
       "goal": "Compose the exact default snapshot owner behind one feature-specific narrow RuntimeServices wildcard capability without changing initialization or directory lifecycle.",
       "id": "E-06d",
       "name": "wildcard bootstrap composition",
-      "status": "queued"
+      "status": "complete"
     },
     {
       "classification": "Contract",
@@ -241,7 +241,29 @@
       ]
     }
   ],
-  "production_changes": 9,
+  "production_changes": 12,
+  "runtime_port": {
+    "bootstrap": {
+      "function": "initialize",
+      "module": "easyuse_anima/bootstrap.py",
+      "uses": [
+        "_DEFAULT_WILDCARD_SNAPSHOTS",
+        "RuntimeServices"
+      ]
+    },
+    "interface": {
+      "class": "WildcardSnapshotPort",
+      "methods": [
+        "snapshot_for_roots"
+      ],
+      "module": "easyuse_anima/wildcard/ports.py"
+    },
+    "owner": "easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS",
+    "runtime": {
+      "field": "wildcard_snapshots",
+      "module": "easyuse_anima/runtime.py"
+    }
+  },
   "schema_version": 1,
   "scope": "E-06 wildcard verified-snapshot LRU, source-rescan publication, and Condition single-flight ownership"
 }

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -17,6 +17,7 @@ from tests.comfy_host_fakes import (
     FakeComfyHostProvider,
     FakeSeedReservationService,
     FakeTranslationService,
+    FakeWildcardSnapshots,
 )
 
 
@@ -254,6 +255,7 @@ class ComfyHostWiringTests(unittest.TestCase):
             clock=FakeClock(),
             translation=FakeTranslationService(),
             autocomplete=FakeAutocompleteService(),
+            wildcard_snapshots=FakeWildcardSnapshots(),
         )
 
         self.assertEqual(
@@ -306,6 +308,7 @@ class ComfyHostWiringTests(unittest.TestCase):
             clock=FakeClock(),
             translation=FakeTranslationService(),
             autocomplete=FakeAutocompleteService(),
+            wildcard_snapshots=FakeWildcardSnapshots(),
         )
 
         require = resolve_comfy_host_helper(

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 171)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 171)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 171)
+        self.assertEqual(report["inventory"]["module_count"], 172)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 172)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 172)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -115,6 +115,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.wildcard.library",
     "easyuse_anima.wildcard.mode",
     "easyuse_anima.wildcard.models",
+    "easyuse_anima.wildcard.ports",
     "easyuse_anima.wildcard.seed",
     "easyuse_anima.wildcard.selector",
     "easyuse_anima.wildcard.snapshot",

--- a/tests/test_python_wildcard_runtime_contract.py
+++ b/tests/test_python_wildcard_runtime_contract.py
@@ -85,6 +85,13 @@ def _top_level_function(
     raise AssertionError(f"{module} has no top-level function {function_name}")
 
 
+def _top_level_class(module: str, class_name: str) -> ast.ClassDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == class_name:
+            return statement
+    raise AssertionError(f"{module} has no top-level class {class_name}")
+
+
 def _class_method(
     module: str,
     class_name: str,
@@ -193,13 +200,14 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
                 "owners",
                 "production_callers",
                 "production_changes",
+                "runtime_port",
                 "schema_version",
                 "scope",
             },
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 9)
+        self.assertEqual(self.fixture["production_changes"], 12)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-06a", "E-06b", "E-06c", "E-06d", "E-06e"],
@@ -210,7 +218,7 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "complete", "queued", "queued"],
+            ["complete", "complete", "complete", "complete", "queued"],
         )
         self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
@@ -426,6 +434,68 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
                         for binding in consumer["canonical_imports"]
                     }
                     - imported,
+                    set(),
+                )
+
+    def test_runtime_port_composes_the_exact_default_owner(self):
+        runtime_port = self.fixture["runtime_port"]
+        interface = runtime_port["interface"]
+        interface_methods = {
+            statement.name
+            for statement in _top_level_class(
+                interface["module"],
+                interface["class"],
+            ).body
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertEqual(interface_methods, set(interface["methods"]))
+
+        runtime = runtime_port["runtime"]
+        runtime_field = next(
+            statement
+            for statement in _top_level_class(
+                runtime["module"], "RuntimeServices"
+            ).body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == runtime["field"]
+        )
+        self.assertIsInstance(runtime_field.annotation, ast.Name)
+        self.assertEqual(runtime_field.annotation.id, interface["class"])
+
+        bootstrap = runtime_port["bootstrap"]
+        self.assertEqual(
+            set(bootstrap["uses"])
+            - _references(
+                _top_level_function(
+                    bootstrap["module"],
+                    bootstrap["function"],
+                )
+            ),
+            set(),
+        )
+        self.assertEqual(
+            runtime_port["owner"],
+            "easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS",
+        )
+
+        forbidden_modules = {"runtime", "bootstrap"}
+        for module in (
+            "easyuse_anima/wildcard/ports.py",
+            "easyuse_anima/wildcard/service.py",
+            *(
+                consumer["module"]
+                for consumer in self.fixture["internal_consumers"]
+            ),
+        ):
+            with self.subTest(module=module):
+                self.assertEqual(
+                    {
+                        imported_module
+                        for imported_module, _ in _imported_names(module)
+                        if imported_module.split(".")[-1]
+                        in forbidden_modules
+                    },
                     set(),
                 )
 

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -29,6 +29,7 @@ from easyuse_anima.runtime import (
 from easyuse_anima.seed.service import InMemorySeedReservationService
 from easyuse_anima.translation import service as translation_service
 from easyuse_anima.translation.service import PromptTranslationService
+from easyuse_anima.wildcard import snapshot as wildcard_snapshot
 
 
 class FakeComfyHostProvider:
@@ -65,6 +66,11 @@ class FakeAutocompleteService:
 
     def classify(self, text, limit=240, path=None):
         raise AssertionError((text, limit, path))
+
+
+class FakeWildcardSnapshots:
+    def snapshot_for_roots(self, roots, *, scan_sources, build_snapshot):
+        raise AssertionError((roots, scan_sources, build_snapshot))
 
 
 class RuntimeBaseContractTests(unittest.TestCase):
@@ -164,6 +170,7 @@ class RuntimeServicesTests(unittest.TestCase):
             clock=FakeClock(),
             translation=PromptTranslationService(),
             autocomplete=FakeAutocompleteService(),
+            wildcard_snapshots=FakeWildcardSnapshots(),
         )
 
     def test_runtime_value_is_frozen(self):
@@ -264,6 +271,10 @@ class RuntimeServicesTests(unittest.TestCase):
         self.assertIs(
             first.autocomplete.index_store,
             autocomplete_index._DEFAULT_AUTOCOMPLETE_INDEX_STORE,
+        )
+        self.assertIs(
+            first.wildcard_snapshots,
+            wildcard_snapshot._DEFAULT_WILDCARD_SNAPSHOTS,
         )
         with patch.object(bootstrap.time, "monotonic", return_value=12.5):
             self.assertEqual(first.clock.monotonic(), 12.5)


### PR DESCRIPTION
## 목적과 경계

#187 E-06d Move입니다. Exact `easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS` identity를 feature-specific private `WildcardSnapshotPort`로 타입화하고, bootstrap이 같은 owner를 `RuntimeServices.wildcard_snapshots`에 직접 조합합니다.

- Base: `a51787ce60340bdb9adecd7fbbedb4dd482bbaa4`
- Head: `7361c06d1d59abd3bc8fb8012ba7619b72c329c8`
- Production: `easyuse_anima/wildcard/ports.py`, `easyuse_anima/runtime.py`, `easyuse_anima/bootstrap.py`
- Support: RuntimeServices/comfy-host fakes, E-06 Contract, package/no-host, analyzer baseline, active docs

## 보존 계약

- exact default snapshot owner, LRU/Condition/single-flight/rescan/publication/clear semantics
- canonical/root wildcard call-time source/build seam과 public/root identities
- source/list/signature/expansion/selector/seed/node/API/workflow behavior
- RuntimeServices frozen/slotted/install-conflict semantics
- bootstrap initialize signature/order/retry/repeated runtime identity
- wildcard-directory initialization과 retry lifecycle
- feature module의 runtime/bootstrap back-reference 금지
- public `__all__` 및 root alias 변화 없음

## 검증

Focused:

- RuntimeServices 8, base contract 5, bootstrap 5
- E-06 Contract 9, E-01 5, E-05 10, translation runtime 7
- Wildcard service 4, engine 51, node 25, API 4
- import-boundary 10+6, package/no-host 1, analyzer 18
- 공용 runtime fake 영향: Comfy wiring 10, PromptBuilder 63, Regional 9, SAM3 8, AiO nodes 77
- changed-file syntax, JSON, fatal Ruff, new import blocks, `git diff --check`

Promotion:

- `comfy node validate`: pass
- `comfy node pack`: pass, 314 entries; wildcard port/runtime/bootstrap 포함
- isolated Codex test instance: source/install SHA256 일치, startup, `EasyUseAnimaWildcard` registration, wildcard API `status=ok` / 3 items 통과; 8194 process cleanup 완료; 사용자 instance 미접촉
- final SHA official full 1회: Python 1,385, frontend 120, Pyright baseline ratchet, import-boundary 11 groups / 0 violations, project full pass

## 위험과 rollback

새 capability는 wrapper/replacement owner 없이 기존 exact owner를 직접 참조합니다. Cleanup/whole-runtime close ordering과 wildcard-directory lifecycle은 E-09에 남아 있으며 이번 PR은 이를 구현하지 않습니다. Rollback은 이 squash commit 하나입니다.

## Next

병합 후 별도 production-free #187 E-06e wildcard ownership completion audit Contract만 진행합니다. E-09, D-14, release/Registry는 시작하지 않습니다.