### PR TITLE
[E-06e] Wildcard runtime ownership completion audit

### DIFF
--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,19 +2,20 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-05, E-06a, E-06b, E-06c, and E-06d are completed; the D-14
+- Status: D-08 and E-01 through E-07 are completed; the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-06d:
-  `dev@a51787ce60340bdb9adecd7fbbedb4dd482bbaa4` after E-06c / PR #549.
-- Document baseline: completed E-06d narrow wildcard RuntimeServices/bootstrap composition Move.
+- Code-review base before E-06e:
+  `dev@1919f1670a7074a33d1f51612bf70b830f76f57e` after E-06d / PR #550.
+- Document baseline: completed production-free E-06e wildcard ownership audit Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
   the E-05c index-store owner Move, the E-05d composition Move, the E-05e
   completion audit Contract, the E-06a wildcard snapshot ownership Contract, the
   E-06b snapshot owner Move, the E-06c canonical service/internal caller Move, the
-  E-06d narrow RuntimeServices/bootstrap composition Move, and the next bounded
-  E-06e completion audit Contract.
+  E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
+  audit Contract, the completed E-07 bridge, and the next bounded E-08a AiO
+  first-pass cache ownership Contract.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -415,7 +416,13 @@ E-06d types the exact `_DEFAULT_WILDCARD_SNAPSHOTS` identity behind one private
 `RuntimeServices.wildcard_snapshots`. Feature modules do not import the runtime,
 and initialize order/retry plus wildcard-directory lifecycle remain unchanged.
 
-Start only a separate production-free #187 E-06e wildcard ownership completion
-audit Contract from latest origin/dev. Do not start later Phase E work, E-09 cleanup,
-D-14 retirement, release, or Registry work inside E-06e.
+E-06e reconciles the single E-01 wildcard entry with the exact default owner,
+records completed-cache-only cleanup, preserves feature import direction,
+package/no-host safety, direct root identities, and the narrow runtime binding, and
+records zero ambiguous wildcard state without production changes. E-06 is complete.
+
+E-07a/E-07b were already completed through #323 as the E-02 bridge. Do not repeat
+them. The next READY unit is a separate production-free #187 E-08a AiO first-pass
+cache ownership Contract from latest origin/dev. Do not start E-08 production Moves,
+E-09 cleanup, D-14 retirement, release, or Registry work inside E-08a.
 ```

--- a/docs/architecture/python-runtime-e06-wildcard-contract.md
+++ b/docs/architecture/python-runtime-e06-wildcard-contract.md
@@ -7,6 +7,8 @@ E-06a is a production-free Contract created from
 autocomplete ownership audit. It freezes the verified wildcard snapshot LRU,
 building-key single-flight state, Condition, source-state rescan/publication loop,
 direct callers, compatibility seams, and the only authorized bounded Move order.
+E-06e completes that sequence with a production-free audit from
+`dev@1919f1670a7074a33d1f51612bf70b830f76f57e`.
 
 The executable source is
 `tests/fixtures/python_wildcard_runtime_contract.v1.json`, checked by
@@ -115,6 +117,28 @@ The port describes only `snapshot_for_roots`; it creates no wrapper or replaceme
 owner. Feature code does not receive or import the complete `RuntimeServices` object,
 and canonical/root callers keep their existing call-time resolver paths.
 
+## Completion audit
+
+E-06e reconciles the E-01 `wildcard-snapshot-cache` entry with exactly one
+feature-private owner:
+`easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS`. No raw root cache,
+building set, Condition, wrapper owner, or replacement runtime identity remains.
+The owner exposes completed-cache-only idempotent `clear()` while active admission,
+waiter settlement, and whole-runtime reverse cleanup remain unchanged; whole-runtime
+ordering and wildcard-directory lifecycle stay assigned to E-09.
+
+All canonical wildcard feature modules remain free of root `wildcard_engine`,
+`RuntimeServices`, and bootstrap back-references. Package/no-host evidence covers
+import-time host and directory I/O. Root private snapshot names remain direct imports
+of the canonical identities, and the runtime field is the exact default owner behind
+the narrow `WildcardSnapshotPort`. The executable audit therefore records
+`ambiguous_state_owners=[]` and changes no production file.
+
+The earlier “before E-07” wording described logical feature order. The E-02a/E-07a/
+E-07b Comfy provider bridge was already completed through #323, so the next remaining
+owner after E-06 is the separate E-08a AiO first-pass cache ownership Contract. This
+queue correction does not reopen or repeat E-07.
+
 ## Bounded Move queue
 
 1. **E-06a Contract — complete:** current state, behavior authorities, one target
@@ -129,8 +153,9 @@ and canonical/root callers keep their existing call-time resolver paths.
 4. **E-06d Move — bootstrap composition — complete:** install the exact default owner
    behind one feature-specific narrow wildcard capability without changing
    initialization or directory lifecycle.
-5. **E-06e Contract — completion audit:** reconcile E-01, cleanup, import direction,
-   root identities, and zero ambiguous wildcard snapshot state before E-07.
+5. **E-06e Contract — completion audit — complete:** reconcile E-01, cleanup,
+   import direction, root identities, and zero ambiguous wildcard snapshot state
+   before the next remaining E-08 owner.
 
 Each Move is a separate PR and rollback boundary. The sequence separates state
 ownership, canonical caller direction, process composition, and final audit instead
@@ -170,7 +195,11 @@ seams, canonical internal import direction, direct node/Prompt Studio/seed behav
 and shipped archive/no-host closure. E-06d covers the narrow port shape, exact
 default-owner identity in the installed runtime, bootstrap reuse, feature import
 direction, and unchanged directory initialization order/retry behavior. It adds no
-new public surface or cleanup policy.
+new public surface or cleanup policy. E-06e additionally covers exact E-01 owner
+reconciliation, the cleanup disposition, feature import safety, direct root identity
+bindings, and zero ambiguous wildcard state. Because E-06e changes no production,
+import closure, metadata, or host-visible behavior, E-06d package/live/validate/pack
+evidence remains valid.
 
 Run the official full profile once on each final candidate SHA. E-06c adds one shipped
 private module and changes canonical import closure without changing dependencies,

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -50,10 +50,10 @@ E-01 drift gate until classified.
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
 | `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
 | `root-translation-route-worker` | bootstrap composes the lazy single-thread executor; root retains its compatibility reference | internal `RLock`; idempotent `atexit` shutdown only | E-04d complete |
-| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete capabilities | bootstrap-serialized install; private-global test reset, no whole-runtime close | E-09 |
+| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete/wildcard capabilities | bootstrap-serialized install; private-global test reset, no whole-runtime close | E-09 |
 | `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; idempotent service close clears cache | E-04c complete |
 | `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
-| `wildcard-snapshot-cache` | canonical private default snapshot-store owner | one owned `Condition`; completed-cache-only `clear()` preserves active builds | E-06b complete |
+| `wildcard-snapshot-cache` | canonical private default snapshot-store owner, directly injected through the narrow runtime port | one owned `Condition`; completed-cache-only `clear()` preserves active builds | E-06 complete; E-06e audited |
 
 The fixture contains exact symbols, tests, owner, lifetime, thread-safety, and
 reset/close status. This table is a review index, not a second machine-readable
@@ -160,5 +160,10 @@ cleanup. E-06b moves the LRU, building-key set, Condition, and capacity behind t
 exact default owner; root delegates with call-time source/build seams and retains no
 raw duplicate lifecycle globals. E-06c moves the snapshot-backed service facade and
 canonical internal callers to `easyuse_anima.wildcard` without a root back-reference.
-E-06a through E-06c are complete; the next bounded unit is the separate E-06d narrow
-RuntimeServices/bootstrap composition Move.
+E-06d injects the exact default owner through one narrow runtime port without a
+wrapper or replacement identity. The production-free E-06e audit reconciles the
+single E-01 entry with that owner, records completed-cache-only cleanup, preserves
+feature import direction, package/no-host safety, and direct root identities, and
+records zero ambiguous wildcard state. E-06 is complete. Because the E-02a/E-07a/
+E-07b Comfy provider bridge was already completed through #323, the next remaining
+bounded owner is the separate E-08a AiO first-pass cache ownership Contract.

--- a/tests/fixtures/python_wildcard_runtime_contract.v1.json
+++ b/tests/fixtures/python_wildcard_runtime_contract.v1.json
@@ -53,6 +53,61 @@
       ]
     }
   ],
+  "completion_audit": {
+    "ambiguous_state_owners": [],
+    "classification": "Contract",
+    "cleanup_dispositions": [
+      {
+        "feature_cleanup": "_WildcardSnapshotStore.clear idempotently clears completed snapshots while active building keys and waiter settlement remain intact",
+        "owner": "wildcard-snapshots",
+        "remaining_phase": "E-09",
+        "status": "feature-cleanup-complete"
+      }
+    ],
+    "e01_reconciliation": [
+      {
+        "completed_phase": "E-06b-complete",
+        "e01_entry": "wildcard-snapshot-cache",
+        "owner": "wildcard-snapshots"
+      }
+    ],
+    "import_safety": {
+      "evidence": [
+        "tests/test_python_package_skeleton.py"
+      ],
+      "feature_modules": [
+        "easyuse_anima/wildcard/expansion.py",
+        "easyuse_anima/wildcard/mode.py",
+        "easyuse_anima/wildcard/ports.py",
+        "easyuse_anima/wildcard/seed.py",
+        "easyuse_anima/wildcard/service.py",
+        "easyuse_anima/wildcard/snapshot.py",
+        "easyuse_anima/wildcard/sources.py"
+      ],
+      "forbidden_imports": [
+        "bootstrap",
+        "easyuse_anima.bootstrap",
+        "easyuse_anima.runtime",
+        "runtime",
+        "wildcard_engine"
+      ],
+      "host_io_at_import": false
+    },
+    "next_phase": "E-08a AiO first-pass cache ownership Contract",
+    "production_changes": 0,
+    "root_identity_bindings": [
+      {
+        "canonical_module": "easyuse_anima.wildcard.snapshot",
+        "root_module": "wildcard_engine.py",
+        "symbols": [
+          "_DEFAULT_WILDCARD_SNAPSHOTS",
+          "_SNAPSHOT_CACHE_LIMIT",
+          "_WildcardSnapshot",
+          "_build_wildcard_snapshot"
+        ]
+      }
+    ]
+  },
   "decisions": {
     "default_root_initialization": "Bootstrap wildcard-directory initialization and its retry state remain E-09 and are not part of the snapshot owner.",
     "generic_cache_condition_port": "rejected",
@@ -93,10 +148,10 @@
     },
     {
       "classification": "Contract",
-      "goal": "Reconcile E-01, cleanup, import direction, root identities, and zero ambiguous wildcard snapshot state before E-07.",
+      "goal": "Reconcile E-01, cleanup, import direction, root identities, and zero ambiguous wildcard snapshot state before the next remaining E-08 owner.",
       "id": "E-06e",
       "name": "wildcard ownership completion audit",
-      "status": "queued"
+      "status": "complete"
     }
   ],
   "internal_consumers": [
@@ -265,5 +320,5 @@
     }
   },
   "schema_version": 1,
-  "scope": "E-06 wildcard verified-snapshot LRU, source-rescan publication, and Condition single-flight ownership"
+  "scope": "Completed E-06 wildcard ownership sequence through the production-free E-06e audit"
 }

--- a/tests/test_python_wildcard_runtime_contract.py
+++ b/tests/test_python_wildcard_runtime_contract.py
@@ -194,6 +194,7 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
             {
                 "classification",
                 "compatibility_surfaces",
+                "completion_audit",
                 "decisions",
                 "internal_consumers",
                 "move_queue",
@@ -218,7 +219,7 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "complete", "complete", "queued"],
+            ["complete", "complete", "complete", "complete", "complete"],
         )
         self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
@@ -227,6 +228,105 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
         for owner in self.fixture["owners"]:
             for evidence in owner["evidence"]:
                 self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_completion_audit_reconciles_cleanup_import_and_root_identity(self):
+        audit = self.fixture["completion_audit"]
+        owners = {owner["id"]: owner for owner in self.fixture["owners"]}
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+
+        self.assertEqual(audit["classification"], "Contract")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertEqual(audit["ambiguous_state_owners"], [])
+        self.assertEqual(
+            len({owner["current_owner"] for owner in owners.values()}),
+            len(owners),
+        )
+        self.assertEqual(
+            audit["next_phase"],
+            "E-08a AiO first-pass cache ownership Contract",
+        )
+
+        reconciliations = {
+            item["e01_entry"]: item
+            for item in audit["e01_reconciliation"]
+        }
+        self.assertEqual(
+            set(reconciliations),
+            {
+                e01_entry
+                for owner in owners.values()
+                for e01_entry in owner["e01_entries"]
+            },
+        )
+        for e01_entry, reconciliation in reconciliations.items():
+            with self.subTest(e01_entry=e01_entry):
+                owner = owners[reconciliation["owner"]]
+                self.assertIn(e01_entry, owner["e01_entries"])
+                self.assertEqual(
+                    e01_entries[e01_entry]["owner"],
+                    owner["current_owner"],
+                )
+                self.assertEqual(
+                    e01_entries[e01_entry]["target_phase"],
+                    reconciliation["completed_phase"],
+                )
+
+        cleanup = {
+            item["owner"]: item
+            for item in audit["cleanup_dispositions"]
+        }
+        self.assertEqual(set(cleanup), set(owners))
+        self.assertEqual(
+            cleanup["wildcard-snapshots"]["status"],
+            "feature-cleanup-complete",
+        )
+        self.assertEqual(
+            {item["remaining_phase"] for item in cleanup.values()},
+            {"E-09"},
+        )
+
+        import_safety = audit["import_safety"]
+        self.assertFalse(import_safety["host_io_at_import"])
+        for evidence in import_safety["evidence"]:
+            self.assertTrue((ROOT / evidence).is_file(), evidence)
+        forbidden = set(import_safety["forbidden_imports"])
+        for module in import_safety["feature_modules"]:
+            imports = {
+                node.module
+                for node in ast.walk(_tree(module))
+                if isinstance(node, ast.ImportFrom) and node.module
+            } | {
+                alias.name
+                for node in ast.walk(_tree(module))
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            }
+            with self.subTest(module=module):
+                self.assertEqual(imports & forbidden, set())
+
+        identity_surfaces = {
+            surface["module"]: set(surface["symbols"])
+            for surface in self.fixture["compatibility_surfaces"]
+            if surface["kind"] == "identity_reexport"
+        }
+        audited_bindings: dict[str, set[str]] = {}
+        for binding in audit["root_identity_bindings"]:
+            root_module = binding["root_module"]
+            expected = {
+                (binding["canonical_module"], symbol)
+                for symbol in binding["symbols"]
+            }
+            with self.subTest(root_module=root_module):
+                self.assertEqual(
+                    expected - _imported_names(root_module),
+                    set(),
+                )
+            audited_bindings.setdefault(root_module, set()).update(
+                binding["symbols"]
+            )
+        self.assertEqual(audited_bindings, identity_surfaces)
 
     def test_e01_entry_reconciles_to_one_exact_target_owner(self):
         owner = self.fixture["owners"][0]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-06e production-free Contract입니다. E-01의 wildcard snapshot state를 E-06의 exact owner와 재조정하고, cleanup/import/root identity/runtime composition/ambiguous-owner 완료 조건을 executable fixture와 direct test로 고정합니다.

- Base: `1919f1670a7074a33d1f51612bf70b830f76f57e`
- Head: `6690bd9ed9671b402468003f93fabfb5e7187dd3`
- Production Python 변경: 없음
- Support 변경: E-06 fixture/test, E-06 contract, runtime state inventory, active resume document

## 결과

- E-06a~E-06e queue를 모두 complete로 고정
- `wildcard-snapshot-cache` 1건을 `_DEFAULT_WILDCARD_SNAPSHOTS` exact owner 1개와 재조정
- completed-cache-only `clear()`와 E-09 whole-runtime disposition 기록
- canonical wildcard feature의 root/runtime/bootstrap 역참조 금지 및 package/no-host evidence 고정
- root private snapshot identity의 direct canonical binding과 exact narrow runtime owner 고정
- `ambiguous_state_owners=[]`
- 이미 #323에서 완료된 E-07 bridge를 재실행하지 않고 다음 READY를 E-08a AiO first-pass cache ownership Contract로 바로잡음

## 보존 계약

Wildcard LRU/Condition/building-key admission·settlement, source rescan/publication, list/signature/expansion/selector/seed 결과, root call-time seams와 identities, RuntimeServices/bootstrap initialize 및 directory lifecycle, public surfaces와 analyzer baseline을 변경하지 않습니다.

## 검증

- changed Python syntax, JSON, Ruff fatal rules, `git diff --check`: 통과
- `PythonWildcardRuntimeContractTests`: 10
- `PythonRuntimeStateOwnershipContractTests`: 5
- `WildcardSnapshotStoreTests`: 2
- `WildcardServiceTests`: 4
- `WildcardEngineTests`: 51
- package/no-host: 1
- import-boundary: 10 + 6
- backend analyzer: 18
- final candidate official full 정확히 1회: Python 1,386 / frontend 120 / Pyright baseline ratchet / import-boundary 11 groups, 0 violations / project full 통과
- E-06e는 production/import closure/metadata/host-visible 변경이 없어 E-06d의 validate/pack/live evidence를 재사용

## 위험과 rollback

남은 lifecycle reverse-close 및 wildcard-directory cleanup은 계속 E-09 소유입니다. 이 PR은 support-only 한 commit이므로 rollback은 squash commit revert로 제한됩니다. Material PRO trigger는 없었습니다.

## Next

검토·merge 뒤 최신 `origin/dev`에서 별도 production-free E-08a AiO first-pass cache ownership Contract를 시작합니다. E-08 production Move, E-09, D-14, release/Registry는 이 PR 범위가 아닙니다.