### PR TITLE
[E-08b] Move AiO first-pass cache state behind one owner

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-07 and the E-08a Contract are complete; the next
-  bounded unit is the separate E-08b AiO first-pass cache owner Move.
+  owns Phase E. E-01 through E-07, E-08a, and E-08b are complete; the next bounded
+  unit is the separate E-08c narrow RuntimeServices/bootstrap composition Move.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-08a: E-06e / PR #551 at
-  `b84fba7ed976e0775f241c5ff4350b47e77ceac9`.
+- Reviewed code baseline before E-08b: E-08a / PR #552 at
+  `2c5aefeae16dd0f1411516f659bfef6659712243`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -40,13 +40,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md).
 - E-08 AiO first-pass cache ownership Contract and bounded Move queue:
   [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md).
-- First READY task after E-08a: a separate #187 E-08b cache owner Move only.
+- First READY task after E-08b: a separate #187 E-08c narrow cache composition Move
+  only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-08a authorizes only the separate E-08b Move. It does not authorize E-08c or later
+- E-08b authorizes only the separate E-08c Move. It does not authorize E-08d or later
   Phase E work, root removal, release, or Registry.
 
 ## Current code boundary

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,13 +2,12 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-07, and the production-free E-08a Contract are
-  completed; the D-14
+- Status: D-08, E-01 through E-07, E-08a, and the E-08b owner Move are completed;
+  the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-08a:
-  `dev@b84fba7ed976e0775f241c5ff4350b47e77ceac9` after E-06e / PR #551.
-- Document baseline: completed production-free E-08a AiO first-pass cache ownership
-  Contract.
+- Code-review base before E-08b:
+  `dev@2c5aefeae16dd0f1411516f659bfef6659712243` after E-08a / PR #552.
+- Document baseline: completed E-08b AiO first-pass cache mutable owner Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -17,7 +16,8 @@
   E-06b snapshot owner Move, the E-06c canonical service/internal caller Move, the
   E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
-  ownership Contract, and the next bounded E-08b owner Move.
+  ownership Contract, the E-08b owner Move, and the next bounded E-08c composition
+  Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -427,8 +427,11 @@ E-07a/E-07b were already completed through #323 as the E-02 bridge. Do not repea
 them. E-08a reconciles the one E-01 AiO cache entry with the six mutable module
 states, freezes the seven direct root aliases and legacy runtime/stage injection
 path, and selects one private `_AIOFirstPassCacheStore` default instance as the
-owner target without production changes. The queue is E-08a Contract, E-08b owner
-Move, E-08c narrow RuntimeServices/bootstrap composition, and E-08d completion
-audit. The next READY unit is E-08b only from latest origin/dev. Do not start E-08c
-or later work, E-09 cleanup, D-14 retirement, release, or Registry work inside E-08b.
+owner target without production changes. E-08b moves all six mutable states behind
+that default owner, removes the raw enabled/generation/metrics/lock globals, and
+retains mapping/order only as exact owner aliases for root identity and call-time
+replacement seams. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
+RuntimeServices/bootstrap composition, and E-08d completion audit. The next READY
+unit is E-08c only from latest origin/dev. Do not start E-08d, E-09 cleanup, D-14
+retirement, release, or Registry work inside E-08c.
 ```

--- a/docs/architecture/python-runtime-e08-aio-cache-contract.md
+++ b/docs/architecture/python-runtime-e08-aio-cache-contract.md
@@ -7,7 +7,9 @@ E-08a is a production-free Contract created from
 wildcard ownership audit and the already-completed E-07 Comfy provider bridge. It
 freezes the AiO first-pass cache process state, policy and behavior authorities,
 typed caller boundary, root compatibility identities, cleanup semantics, and the only
-authorized bounded Move order.
+authorized bounded Move order. E-08b implements the selected owner from
+`dev@2c5aefeae16dd0f1411516f659bfef6659712243` without changing cache
+behavior or runtime composition.
 
 The executable source is
 `tests/fixtures/python_aio_first_pass_cache_contract.v1.json`, checked by
@@ -15,8 +17,8 @@ The executable source is
 cache, benchmark, First-pass stage, legacy-generation, package, analyzer, and import-
 boundary tests remain the behavior authorities.
 
-E-08 changes ownership only. It does not reopen #169 cache policy, stage execution,
-workflow results, or queue/live evidence.
+E-08 changes ownership only. E-08b changes one production module and does not reopen
+#169 cache policy, stage execution, workflow results, or queue/live evidence.
 
 ## Completed #169 behavior boundary
 
@@ -60,7 +62,7 @@ resource revision, stage fallback, stale-capture, and metric semantics.
 
 ## Target owner and compatibility injection
 
-E-08b targets one private
+E-08b installs one private
 `easyuse_anima.aio.first_pass_cache._AIOFirstPassCacheStore` referenced by
 `_DEFAULT_AIO_FIRST_PASS_CACHE`. It owns entries, order, enabled state, generation,
 metrics, and the `RLock`.
@@ -77,10 +79,12 @@ The canonical module functions remain the compatibility and feature facades. Roo
 - `_put_aio_first_pass_cache`.
 
 The root does not gain lock, generation, metrics, clear, reset, or runtime-owner
-aliases. Existing replacement mapping/order and policy/clock/helper tests require
-either the same call-time behavior or an explicit isolated-owner injection seam
-before raw globals move. E-08b must not silently capture import-time patched values
-or retain a second production mapping, order list, lock, generation, or metrics dict.
+aliases. The module-level mapping and order names are compatibility aliases to the
+exact default owner's objects. Canonical facades pass those names into the owner at
+call time, preserving replacement mapping/order tests without a second production
+owner. Policy, clock, entry capture, size, and clone helpers remain dynamically
+resolved. Isolated stores own distinct collections, metrics, generation, enabled
+state, and locks.
 
 ## Cleanup and concurrency
 
@@ -120,8 +124,9 @@ import the complete runtime.
 
 1. **E-08a Contract — complete:** current state, #169 behavior authorities, one
    target owner, caller and root seams, cleanup, and Move order are versioned.
-2. **E-08b Move — mutable cache owner:** entries, order, enabled state, generation,
-   metrics, and `RLock` move behind one feature-private default owner.
+2. **E-08b Move — mutable cache owner — complete:** entries, order, enabled state,
+   generation, metrics, and `RLock` are behind one feature-private default owner;
+   direct aliases and call-time replacement seams remain executable evidence.
 3. **E-08c Move — bootstrap composition:** install the exact default owner behind one
    feature-specific narrow RuntimeServices capability without changing the existing
    `FirstPassRuntime` caller path.
@@ -158,11 +163,14 @@ E-08a focused validation covers the executable Contract, E-01 reconciliation, di
 cache/concurrency/metrics behavior, benchmark and mutation-isolation evidence,
 First-pass stage and legacy adapter behavior, package/no-host import, import
 boundaries/analyzer, JSON/Python syntax, document links, and `git diff --check`.
+E-08b additionally covers isolated-owner separation, exact default mapping/order
+identity, raw module-state removal, facade delegation, preserved replacement seams,
+and actual-code inventory/analyzer evidence.
 
-Run the official full profile once on the final candidate SHA. E-08a changes no
-production Python, analyzer baseline, import closure, archive contents, metadata, or
-host-visible behavior, so the E-06d validate/pack/isolated-live evidence remains
-valid.
+Run the official full profile once on the final candidate SHA. E-08b changes only
+private in-module ownership and does not change import closure, archive contents,
+metadata, or host-visible behavior, so the E-06d validate/pack/isolated-live evidence
+remains valid unless a promotion gate proves otherwise.
 
 ## Stop conditions
 
@@ -174,4 +182,4 @@ behavior changes; canonical feature code must import root/runtime/bootstrap; pac
 import starts host I/O; or E-09 shutdown must be implemented to finish E-08.
 
 Direct source, #169, E-01, and concurrency tests select one owner and one bounded
-Move sequence. E-08a therefore does not trigger additional PRO review.
+Move sequence. E-08a and E-08b therefore do not trigger additional PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -36,7 +36,7 @@ E-01 drift gate until classified.
 
 | Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
 | --- | --- | --- | --- |
-| `aio-first-pass-cache` | canonical AiO first-pass cache module with one six-state process-lifetime boundary and count/byte/TTL bounds | one `RLock`; clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08a contracted; E-08b next |
+| `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; module mapping/order names are exact compatibility aliases | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08b complete; E-08c next |
 | `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
 | `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
@@ -174,4 +174,10 @@ and selects one private `_AIOFirstPassCacheStore` instance named
 `_DEFAULT_AIO_FIRST_PASS_CACHE` as the E-08b target. It preserves the seven direct
 root aliases and the legacy runtime/stage injection path, and fixes the queue as
 E-08a Contract, E-08b owner Move, E-08c narrow RuntimeServices/bootstrap
-composition, and E-08d completion audit. The next bounded unit is E-08b only.
+composition, and E-08d completion audit.
+
+E-08b installs the selected private default owner. The former raw enabled,
+generation, metrics, and lock globals are removed; mapping/order remain only as exact
+aliases to the owner's objects so root identities and call-time replacement evidence
+remain intact. Isolated stores share no collection, metric dictionary, generation,
+enabled state, or lock. The next bounded unit is E-08c only.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -56,20 +56,20 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-08a: E-06e / PR #551 at
-  `b84fba7ed976e0775f241c5ff4350b47e77ceac9`.
+- Reviewed code baseline before E-08b: E-08a / PR #552 at
+  `2c5aefeae16dd0f1411516f659bfef6659712243`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-07 and the production-free E-08a Contract are complete. The next
-  work is only a separate #187 E-08b AiO first-pass cache owner Move. The #323
+- E-01 through E-07, E-08a, and the E-08b owner Move are complete. The next work is
+  only a separate #187 E-08c narrow AiO cache composition Move. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root compatibility aliases or start E-08c through E-10, release, or
+- Do not remove root compatibility aliases or start E-08d through E-10, release, or
   Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -161,7 +161,8 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-08a freezes the current
-  AiO first-pass cache state and compatibility boundary; use that evidence only to
-  start the separate E-08b owner Move. Do not infer E-08c, E-09 cleanup, release
+- D-14 readiness is recorded and authorizes no removal. E-08b installs the selected
+  AiO first-pass cache owner and preserves the compatibility boundary; use that
+  evidence only to start the separate E-08c composition Move. Do not infer E-08d,
+  E-09 cleanup, release
   publication, or Registry actions.

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -26,7 +26,6 @@ AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
 AIO_FIRST_PASS_CACHE_MAX_BYTES = 512 * 1024 * 1024
 AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES = 256 * 1024 * 1024
 AIO_FIRST_PASS_CACHE_TTL_SECONDS = 300.0
-_AIO_FIRST_PASS_CACHE_ENABLED = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,19 +72,189 @@ class _AIOFirstPassCacheMetrics:
     evictions: int
 
 
-_AIO_FIRST_PASS_CACHE: dict[
+_AIOFirstPassCacheMapping = dict[
     str,
     _AIOFirstPassCacheEntry | dict[str, Any],
-] = {}
-_AIO_FIRST_PASS_CACHE_ORDER: list[str] = []
-_AIO_FIRST_PASS_CACHE_LOCK = RLock()
-_AIO_FIRST_PASS_CACHE_GENERATION = 0
-_AIO_FIRST_PASS_CACHE_METRICS = {
-    "hits": 0,
-    "misses": 0,
-    "skips": 0,
-    "evictions": 0,
-}
+]
+
+
+class _AIOFirstPassCacheStore:
+    def __init__(self) -> None:
+        self._cache: _AIOFirstPassCacheMapping = {}
+        self._order: list[str] = []
+        self._enabled = True
+        self._generation = 0
+        self._metrics = {
+            "hits": 0,
+            "misses": 0,
+            "skips": 0,
+            "evictions": 0,
+        }
+        self._lock = RLock()
+
+    @property
+    def enabled(self) -> bool:
+        with self._lock:
+            return self._enabled
+
+    def _collections(
+        self,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+        order: list[str] | None = None,
+    ) -> tuple[_AIOFirstPassCacheMapping, list[str]]:
+        return (
+            self._cache if cache is None else cache,
+            self._order if order is None else order,
+        )
+
+    def total_bytes(
+        self,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+    ) -> int:
+        entries, _ = self._collections(cache=cache)
+        with self._lock:
+            return sum(
+                _aio_first_pass_cache_entry_size_bytes(entry)
+                for entry in entries.values()
+            )
+
+    def metrics_snapshot(self) -> _AIOFirstPassCacheMetrics:
+        with self._lock:
+            return _AIOFirstPassCacheMetrics(
+                hits=self._metrics["hits"],
+                misses=self._metrics["misses"],
+                skips=self._metrics["skips"],
+                evictions=self._metrics["evictions"],
+            )
+
+    def reset_metrics(self) -> None:
+        with self._lock:
+            for name in self._metrics:
+                self._metrics[name] = 0
+
+    def record_metric(self, name: str) -> None:
+        with self._lock:
+            self._metrics[name] += 1
+
+    def clear(
+        self,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+        order: list[str] | None = None,
+    ) -> None:
+        entries, keys = self._collections(cache=cache, order=order)
+        with self._lock:
+            self._generation += 1
+            entries.clear()
+            keys.clear()
+
+    def set_enabled(
+        self,
+        enabled: bool,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+        order: list[str] | None = None,
+    ) -> None:
+        entries, keys = self._collections(cache=cache, order=order)
+        next_enabled = bool(enabled)
+        with self._lock:
+            if next_enabled != self._enabled:
+                self._generation += 1
+            self._enabled = next_enabled
+            if not self._enabled:
+                entries.clear()
+                keys.clear()
+
+    def get(
+        self,
+        cache_key: str,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+        order: list[str] | None = None,
+    ):
+        entries, keys = self._collections(cache=cache, order=order)
+        with self._lock:
+            if not self._enabled:
+                self._metrics["skips"] += 1
+                return None
+            entry = entries.get(cache_key)
+            if not entry:
+                self._metrics["misses"] += 1
+                return None
+            if isinstance(entry, _AIOFirstPassCacheEntry):
+                now = _aio_first_pass_cache_now()
+                if now - entry.created_at >= AIO_FIRST_PASS_CACHE_TTL_SECONDS:
+                    entries.pop(cache_key, None)
+                    if cache_key in keys:
+                        keys.remove(cache_key)
+                    self._metrics["misses"] += 1
+                    self._metrics["evictions"] += 1
+                    return None
+                entry = replace(entry, last_access_at=now)
+                entries[cache_key] = entry
+            if cache_key in keys:
+                keys.remove(cache_key)
+            keys.append(cache_key)
+            self._metrics["hits"] += 1
+        if isinstance(entry, _AIOFirstPassCacheEntry):
+            return entry.checkout()
+        return (
+            _clone_aio_cache_value(entry["latent"]),
+            _clone_aio_cache_value(entry["image"]),
+        )
+
+    def put(
+        self,
+        cache_key: str,
+        latent,
+        image,
+        *,
+        cache: _AIOFirstPassCacheMapping | None = None,
+        order: list[str] | None = None,
+    ) -> None:
+        entries, keys = self._collections(cache=cache, order=order)
+        with self._lock:
+            if not self._enabled:
+                self._metrics["skips"] += 1
+                return
+            generation = self._generation
+        if (
+            _aio_cache_pair_size_bytes(latent, image)
+            > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
+        ):
+            self.record_metric("skips")
+            return
+        entry = _AIOFirstPassCacheEntry.capture(
+            latent,
+            image,
+            now=_aio_first_pass_cache_now(),
+        )
+        if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
+            self.record_metric("skips")
+            return
+        with self._lock:
+            if not self._enabled or generation != self._generation:
+                self._metrics["skips"] += 1
+                return
+            entries[cache_key] = entry
+            if cache_key in keys:
+                keys.remove(cache_key)
+            keys.append(cache_key)
+            while keys and (
+                len(keys) > AIO_FIRST_PASS_CACHE_MAX_ENTRIES
+                or self.total_bytes(cache=entries)
+                > AIO_FIRST_PASS_CACHE_MAX_BYTES
+            ):
+                old_key = keys.pop(0)
+                entries.pop(old_key, None)
+                self._metrics["evictions"] += 1
+
+
+_DEFAULT_AIO_FIRST_PASS_CACHE = _AIOFirstPassCacheStore()
+_AIO_FIRST_PASS_CACHE = _DEFAULT_AIO_FIRST_PASS_CACHE._cache
+_AIO_FIRST_PASS_CACHE_ORDER = _DEFAULT_AIO_FIRST_PASS_CACHE._order
 
 
 def _clone_aio_cache_value(value):
@@ -195,54 +364,36 @@ def _aio_first_pass_cache_entry_size_bytes(entry) -> int:
 
 
 def _aio_first_pass_cache_total_bytes() -> int:
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        return sum(
-            _aio_first_pass_cache_entry_size_bytes(entry)
-            for entry in _AIO_FIRST_PASS_CACHE.values()
-        )
+    return _DEFAULT_AIO_FIRST_PASS_CACHE.total_bytes(
+        cache=_AIO_FIRST_PASS_CACHE,
+    )
 
 
 def _aio_first_pass_cache_metrics_snapshot() -> _AIOFirstPassCacheMetrics:
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        return _AIOFirstPassCacheMetrics(
-            hits=_AIO_FIRST_PASS_CACHE_METRICS["hits"],
-            misses=_AIO_FIRST_PASS_CACHE_METRICS["misses"],
-            skips=_AIO_FIRST_PASS_CACHE_METRICS["skips"],
-            evictions=_AIO_FIRST_PASS_CACHE_METRICS["evictions"],
-        )
+    return _DEFAULT_AIO_FIRST_PASS_CACHE.metrics_snapshot()
 
 
 def _reset_aio_first_pass_cache_metrics() -> None:
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        for name in _AIO_FIRST_PASS_CACHE_METRICS:
-            _AIO_FIRST_PASS_CACHE_METRICS[name] = 0
+    _DEFAULT_AIO_FIRST_PASS_CACHE.reset_metrics()
 
 
 def _record_aio_first_pass_cache_metric(name: str) -> None:
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        _AIO_FIRST_PASS_CACHE_METRICS[name] += 1
+    _DEFAULT_AIO_FIRST_PASS_CACHE.record_metric(name)
 
 
 def _clear_aio_first_pass_cache() -> None:
-    global _AIO_FIRST_PASS_CACHE_GENERATION
-
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        _AIO_FIRST_PASS_CACHE_GENERATION += 1
-        _AIO_FIRST_PASS_CACHE.clear()
-        _AIO_FIRST_PASS_CACHE_ORDER.clear()
+    _DEFAULT_AIO_FIRST_PASS_CACHE.clear(
+        cache=_AIO_FIRST_PASS_CACHE,
+        order=_AIO_FIRST_PASS_CACHE_ORDER,
+    )
 
 
 def _set_aio_first_pass_cache_enabled(enabled: bool) -> None:
-    global _AIO_FIRST_PASS_CACHE_ENABLED, _AIO_FIRST_PASS_CACHE_GENERATION
-
-    next_enabled = bool(enabled)
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        if next_enabled != _AIO_FIRST_PASS_CACHE_ENABLED:
-            _AIO_FIRST_PASS_CACHE_GENERATION += 1
-        _AIO_FIRST_PASS_CACHE_ENABLED = next_enabled
-        if not _AIO_FIRST_PASS_CACHE_ENABLED:
-            _AIO_FIRST_PASS_CACHE.clear()
-            _AIO_FIRST_PASS_CACHE_ORDER.clear()
+    _DEFAULT_AIO_FIRST_PASS_CACHE.set_enabled(
+        enabled,
+        cache=_AIO_FIRST_PASS_CACHE,
+        order=_AIO_FIRST_PASS_CACHE_ORDER,
+    )
 
 
 def _aio_first_pass_cache_now() -> float:
@@ -418,77 +569,21 @@ def _aio_first_pass_cache_key(
 
 
 def _get_aio_first_pass_cache(cache_key: str):
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        if not _AIO_FIRST_PASS_CACHE_ENABLED:
-            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
-            return None
-        entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
-        if not entry:
-            _AIO_FIRST_PASS_CACHE_METRICS["misses"] += 1
-            return None
-        if isinstance(entry, _AIOFirstPassCacheEntry):
-            now = _aio_first_pass_cache_now()
-            if now - entry.created_at >= AIO_FIRST_PASS_CACHE_TTL_SECONDS:
-                _AIO_FIRST_PASS_CACHE.pop(cache_key, None)
-                if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-                    _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
-                _AIO_FIRST_PASS_CACHE_METRICS["misses"] += 1
-                _AIO_FIRST_PASS_CACHE_METRICS["evictions"] += 1
-                return None
-            entry = replace(entry, last_access_at=now)
-            _AIO_FIRST_PASS_CACHE[cache_key] = entry
-        if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-            _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
-        _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
-        _AIO_FIRST_PASS_CACHE_METRICS["hits"] += 1
-    if isinstance(entry, _AIOFirstPassCacheEntry):
-        return entry.checkout()
-    return (
-        _clone_aio_cache_value(entry["latent"]),
-        _clone_aio_cache_value(entry["image"]),
+    return _DEFAULT_AIO_FIRST_PASS_CACHE.get(
+        cache_key,
+        cache=_AIO_FIRST_PASS_CACHE,
+        order=_AIO_FIRST_PASS_CACHE_ORDER,
     )
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        if not _AIO_FIRST_PASS_CACHE_ENABLED:
-            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
-            return
-        generation = _AIO_FIRST_PASS_CACHE_GENERATION
-    if (
-        _aio_cache_pair_size_bytes(latent, image)
-        > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
-    ):
-        _record_aio_first_pass_cache_metric("skips")
-        return
-    entry = _AIOFirstPassCacheEntry.capture(
+    _DEFAULT_AIO_FIRST_PASS_CACHE.put(
+        cache_key,
         latent,
         image,
-        now=_aio_first_pass_cache_now(),
+        cache=_AIO_FIRST_PASS_CACHE,
+        order=_AIO_FIRST_PASS_CACHE_ORDER,
     )
-    if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
-        _record_aio_first_pass_cache_metric("skips")
-        return
-    with _AIO_FIRST_PASS_CACHE_LOCK:
-        if (
-            not _AIO_FIRST_PASS_CACHE_ENABLED
-            or generation != _AIO_FIRST_PASS_CACHE_GENERATION
-        ):
-            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
-            return
-        _AIO_FIRST_PASS_CACHE[cache_key] = entry
-        if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-            _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
-        _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
-        while _AIO_FIRST_PASS_CACHE_ORDER and (
-            len(_AIO_FIRST_PASS_CACHE_ORDER)
-            > AIO_FIRST_PASS_CACHE_MAX_ENTRIES
-            or _aio_first_pass_cache_total_bytes()
-            > AIO_FIRST_PASS_CACHE_MAX_BYTES
-        ):
-            old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
-            _AIO_FIRST_PASS_CACHE.pop(old_key, None)
-            _AIO_FIRST_PASS_CACHE_METRICS["evictions"] += 1
 
 
 __all__ = ()

--- a/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
+++ b/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
@@ -108,7 +108,7 @@
       "goal": "Move entries, LRU order, enabled state, generation, metrics, and RLock behind one feature-private default owner while preserving all cache policy and concurrency behavior.",
       "id": "E-08b",
       "name": "AiO first-pass cache mutable owner",
-      "status": "queued"
+      "status": "complete"
     },
     {
       "classification": "Move",
@@ -128,24 +128,25 @@
   "owners": [
     {
       "cleanup": {
-        "current": "_clear_aio_first_pass_cache advances generation and clears entries/order while preserving enabled state and metrics; disable clears entries/order and invalidates stale capture; metrics reset changes metrics only.",
-        "target": "The default owner preserves the same independent clear, enable transition, and metrics-reset dispositions; whole-runtime reverse close and partial-failure ordering remain E-09."
+        "current": "The default owner clear advances its generation and clears entries/order while preserving enabled state and metrics; disable clears entries/order and invalidates stale capture; metrics reset changes metrics only.",
+        "target": "E-08b feature cleanup is complete; whole-runtime reverse close and partial-failure ordering remain E-09."
       },
       "components": [
         {
+          "class": "_AIOFirstPassCacheStore",
           "module": "easyuse_anima/aio/first_pass_cache.py",
-          "state_kind": "module",
+          "state_kind": "instance",
           "state_symbols": [
-            "_AIO_FIRST_PASS_CACHE",
-            "_AIO_FIRST_PASS_CACHE_ENABLED",
-            "_AIO_FIRST_PASS_CACHE_GENERATION",
-            "_AIO_FIRST_PASS_CACHE_LOCK",
-            "_AIO_FIRST_PASS_CACHE_METRICS",
-            "_AIO_FIRST_PASS_CACHE_ORDER"
+            "_cache",
+            "_enabled",
+            "_generation",
+            "_lock",
+            "_metrics",
+            "_order"
           ]
         }
       ],
-      "current_owner": "easyuse_anima.aio.first_pass_cache",
+      "current_owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
       "e01_entries": [
         "aio-first-pass-cache"
       ],
@@ -179,15 +180,10 @@
         "bounded benchmark clone counts, logical copy bytes, mutation isolation, latency, RSS, and 4K batch projections remain evidence"
       ],
       "state_symbols": [
-        "_AIO_FIRST_PASS_CACHE",
-        "_AIO_FIRST_PASS_CACHE_ENABLED",
-        "_AIO_FIRST_PASS_CACHE_GENERATION",
-        "_AIO_FIRST_PASS_CACHE_LOCK",
-        "_AIO_FIRST_PASS_CACHE_METRICS",
-        "_AIO_FIRST_PASS_CACHE_ORDER"
+        "_DEFAULT_AIO_FIRST_PASS_CACHE"
       ],
       "target_owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
-      "target_phase": "E-08b"
+      "target_phase": "E-08b-complete"
     }
   ],
   "production_callers": [
@@ -205,7 +201,7 @@
       ]
     }
   ],
-  "production_changes": 0,
+  "production_changes": 1,
   "schema_version": 1,
   "scope": "E-08 AiO first-pass cache process-state ownership, cleanup, callers, compatibility seams, and bounded Move order"
 }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -68539,14 +68539,14 @@
       },
       {
         "is_package": false,
-        "loc": 494,
+        "loc": 589,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "e6ff1d822f9627f9e7019c42d517b4e9ec6127dc",
+        "normalized_git_blob_sha1": "ff20474af2544f3c5105dc74627aac88f4536a58",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
-          "class_count": 2,
+          "class_count": 3,
           "function_count": 16,
-          "global_count": 11
+          "global_count": 9
         }
       },
       {
@@ -91452,7 +91452,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 32,
+        "line": 31,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -91461,16 +91461,16 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheMetrics",
         "kind": "import_time_call",
-        "line": 68,
+        "line": 67,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
       {
-        "callee": "RLock",
-        "column": 29,
-        "context": "assign:_AIO_FIRST_PASS_CACHE_LOCK",
+        "callee": "_AIOFirstPassCacheStore",
+        "column": 32,
+        "context": "assign:_DEFAULT_AIO_FIRST_PASS_CACHE",
         "kind": "import_time_call",
-        "line": 81,
+        "line": 255,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -93286,24 +93286,6 @@
       },
       {
         "kind": "dict",
-        "line": 76,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE"
-      },
-      {
-        "kind": "dict",
-        "line": 83,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE_METRICS"
-      },
-      {
-        "kind": "list",
-        "line": 80,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE_ORDER"
-      },
-      {
-        "kind": "dict",
         "line": 37,
         "module": "easyuse_anima/aio/generation_defaults.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
@@ -93678,42 +93660,12 @@
     "owner_candidates": [
       {
         "categories": [
-          "cache",
-          "mutable_container"
+          "cache"
         ],
-        "initializer": "Dict",
-        "line": 76,
+        "initializer": "_AIOFirstPassCacheStore",
+        "line": 255,
         "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE"
-      },
-      {
-        "categories": [
-          "lock"
-        ],
-        "initializer": "RLock",
-        "line": 81,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE_LOCK"
-      },
-      {
-        "categories": [
-          "cache",
-          "mutable_container"
-        ],
-        "initializer": "Dict",
-        "line": 83,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE_METRICS"
-      },
-      {
-        "categories": [
-          "cache",
-          "mutable_container"
-        ],
-        "initializer": "List",
-        "line": 80,
-        "module": "easyuse_anima/aio/first_pass_cache.py",
-        "name": "_AIO_FIRST_PASS_CACHE_ORDER"
+        "name": "_DEFAULT_AIO_FIRST_PASS_CACHE"
       },
       {
         "categories": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -148,20 +148,15 @@
   "entries": [
     {
       "categories": ["cache", "lock", "metrics"],
-      "cleanup": "_clear_aio_first_pass_cache clears entries/order and advances generation; tests also reset metrics and the enabled flag.",
+      "cleanup": "The default owner clear advances generation and clears entries/order; disable invalidates stale capture and clears entries/order; metrics reset remains independent.",
       "id": "aio-first-pass-cache",
       "lifetime": "Process lifetime from module import; entries are bounded by count, bytes, and TTL.",
       "module": "easyuse_anima/aio/first_pass_cache.py",
-      "owner": "easyuse_anima.aio.first_pass_cache",
+      "owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
       "symbols": [
-        "_AIO_FIRST_PASS_CACHE",
-        "_AIO_FIRST_PASS_CACHE_ENABLED",
-        "_AIO_FIRST_PASS_CACHE_GENERATION",
-        "_AIO_FIRST_PASS_CACHE_LOCK",
-        "_AIO_FIRST_PASS_CACHE_METRICS",
-        "_AIO_FIRST_PASS_CACHE_ORDER"
+        "_DEFAULT_AIO_FIRST_PASS_CACHE"
       ],
-      "target_phase": "E-08",
+      "target_phase": "E-08b-complete",
       "test_evidence": ["tests/test_aio_first_pass_cache.py", "tests/test_aio_first_pass_cache_benchmark.py"],
       "thread_safety": "One RLock protects enabled/generation/cache/order/metrics publication and mutation."
     },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -78,7 +78,35 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             first_pass_cache.AIO_FIRST_PASS_CACHE_TTL_SECONDS,
             300.0,
         )
-        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertTrue(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
+
+    def test_default_owner_holds_state_and_isolated_store_does_not_share_it(self):
+        owner = first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE, owner._cache)
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, owner._order)
+        for raw_name in (
+            "_AIO_FIRST_PASS_CACHE_ENABLED",
+            "_AIO_FIRST_PASS_CACHE_GENERATION",
+            "_AIO_FIRST_PASS_CACHE_LOCK",
+            "_AIO_FIRST_PASS_CACHE_METRICS",
+        ):
+            with self.subTest(raw_name=raw_name):
+                self.assertFalse(hasattr(first_pass_cache, raw_name))
+
+        isolated = first_pass_cache._AIOFirstPassCacheStore()
+        self.assertIsNot(isolated._cache, owner._cache)
+        self.assertIsNot(isolated._order, owner._order)
+        self.assertIsNot(isolated._metrics, owner._metrics)
+        self.assertIsNot(isolated._lock, owner._lock)
+
+        isolated.put("isolated", {"samples": [1]}, [2])
+        self.assertIn("isolated", isolated._cache)
+        self.assertNotIn("isolated", owner._cache)
+        isolated.clear()
+        self.assertEqual(isolated._cache, {})
+        self.assertEqual(isolated._order, [])
 
     def test_put_and_get_read_clock_once_and_replace_last_access(self):
         clock = Mock(side_effect=[10.0, 20.0])
@@ -193,7 +221,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, order)
         self.assertEqual(mapping, {})
         self.assertEqual(order, [])
-        self.assertFalse(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertFalse(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
 
         estimator = Mock(side_effect=AssertionError("estimator called"))
         clone = Mock(side_effect=AssertionError("clone called"))
@@ -244,12 +274,16 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
     def test_explicit_clear_is_idempotent_and_preserves_enabled_state(self):
         first_pass_cache._clear_aio_first_pass_cache()
         first_pass_cache._clear_aio_first_pass_cache()
-        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertTrue(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
 
         first_pass_cache._set_aio_first_pass_cache_enabled(False)
         first_pass_cache._clear_aio_first_pass_cache()
         first_pass_cache._clear_aio_first_pass_cache()
-        self.assertFalse(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertFalse(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
 
     def test_root_state_and_functions_are_direct_canonical_aliases(self):
         self.assertFalse(
@@ -318,7 +352,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, order)
         self.assertIs(mapping["entry"], entry)
         self.assertEqual(order, ["entry"])
-        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertTrue(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
 
     def test_metrics_count_hit_miss_skip_expiration_and_capacity_eviction(self):
         self.assertIsNone(
@@ -545,7 +581,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertFalse(put_thread.is_alive())
         self.assertFalse(disable_thread.is_alive())
         self.assertEqual(errors, [])
-        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertTrue(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
         self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
         self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
 
@@ -572,7 +610,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             )
 
         capture_entry.assert_called_once()
-        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertTrue(
+            first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE.enabled
+        )
         self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
         self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
 

--- a/tests/test_python_aio_first_pass_cache_contract.py
+++ b/tests/test_python_aio_first_pass_cache_contract.py
@@ -128,6 +128,18 @@ def _called(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     return called
 
 
+def _self_attributes(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    return {
+        node.attr
+        for node in ast.walk(function)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    }
+
+
 def _assignment_value(module: str, assigned_name: str) -> ast.expr:
     for statement in _tree(module).body:
         if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
@@ -202,7 +214,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(self.fixture["production_changes"], 1)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-08a", "E-08b", "E-08c", "E-08d"],
@@ -213,7 +225,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "queued", "queued", "queued"],
+            ["complete", "complete", "queued", "queued"],
         )
         self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
@@ -231,9 +243,9 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         entry = entries["aio-first-pass-cache"]
         self.assertEqual(entry["module"], owner["module"])
         self.assertEqual(entry["owner"], owner["current_owner"])
-        self.assertEqual(entry["target_phase"], "E-08")
+        self.assertEqual(entry["target_phase"], "E-08b-complete")
         self.assertEqual(set(entry["symbols"]), set(owner["state_symbols"]))
-        self.assertEqual(owner["target_phase"], "E-08b")
+        self.assertEqual(owner["target_phase"], "E-08b-complete")
         self.assertEqual(
             owner["target_owner"],
             "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
@@ -243,48 +255,117 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
             "rejected",
         )
 
-    def test_current_raw_state_shares_one_cache_specific_lock(self):
+    def test_default_owner_holds_all_cache_specific_mutable_state(self):
         module = "easyuse_anima/aio/first_pass_cache.py"
         owner = self.fixture["owners"][0]
         bindings = _top_level_bindings(module)
         self.assertEqual(set(owner["state_symbols"]) - bindings, set())
         self.assertEqual(set(owner["policy_symbols"]) - bindings, set())
         self.assertEqual(
-            _assignment_call(module, "_AIO_FIRST_PASS_CACHE_LOCK"),
-            "RLock",
+            _assignment_call(module, "_DEFAULT_AIO_FIRST_PASS_CACHE"),
+            "_AIOFirstPassCacheStore",
         )
-        self.assertIsInstance(
-            _assignment_value(module, "_AIO_FIRST_PASS_CACHE"),
-            ast.Dict,
-        )
-        self.assertIsInstance(
-            _assignment_value(module, "_AIO_FIRST_PASS_CACHE_ORDER"),
-            ast.List,
+        self.assertEqual(
+            ast.unparse(_assignment_value(module, "_AIO_FIRST_PASS_CACHE")),
+            "_DEFAULT_AIO_FIRST_PASS_CACHE._cache",
         )
         self.assertEqual(
             ast.unparse(
-                _assignment_value(module, "_AIO_FIRST_PASS_CACHE_ENABLED")
+                _assignment_value(module, "_AIO_FIRST_PASS_CACHE_ORDER")
             ),
-            "True",
-        )
-        self.assertEqual(
-            ast.unparse(
-                _assignment_value(module, "_AIO_FIRST_PASS_CACHE_GENERATION")
-            ),
-            "0",
-        )
-        metrics = _assignment_value(module, "_AIO_FIRST_PASS_CACHE_METRICS")
-        self.assertIsInstance(metrics, ast.Dict)
-        self.assertEqual(
-            {
-                key.value
-                for key in metrics.keys
-                if isinstance(key, ast.Constant)
-            },
-            {"hits", "misses", "skips", "evictions"},
+            "_DEFAULT_AIO_FIRST_PASS_CACHE._order",
         )
 
-        lifecycle_functions = (
+        component = owner["components"][0]
+        initializer = _class_method(
+            module,
+            component["class"],
+            "__init__",
+        )
+        self.assertEqual(
+            _self_attributes(initializer),
+            set(component["state_symbols"]),
+        )
+        self.assertIn("RLock", _called(initializer))
+        self.assertEqual(
+            {
+                "_AIO_FIRST_PASS_CACHE_ENABLED",
+                "_AIO_FIRST_PASS_CACHE_GENERATION",
+                "_AIO_FIRST_PASS_CACHE_LOCK",
+                "_AIO_FIRST_PASS_CACHE_METRICS",
+            }
+            & bindings,
+            set(),
+        )
+
+        method_attributes: set[str] = set()
+        for method_name in (
+            "_collections",
+            "total_bytes",
+            "metrics_snapshot",
+            "reset_metrics",
+            "record_metric",
+            "clear",
+            "set_enabled",
+            "get",
+            "put",
+        ):
+            method_attributes.update(
+                _self_attributes(
+                    _class_method(
+                        module,
+                        component["class"],
+                        method_name,
+                    )
+                )
+            )
+        self.assertEqual(
+            set(component["state_symbols"]) - method_attributes,
+            set(),
+        )
+
+    def test_cleanup_and_metrics_dispositions_are_current(self):
+        module = "easyuse_anima/aio/first_pass_cache.py"
+        owner_class = self.fixture["owners"][0]["components"][0]["class"]
+        clear = _class_method(module, owner_class, "clear")
+        self.assertTrue(
+            {"_generation", "_lock"} <= _self_attributes(clear)
+        )
+        self.assertEqual(
+            {"_enabled", "_metrics"} & _self_attributes(clear),
+            set(),
+        )
+        self.assertIn("clear", _called(clear))
+
+        enable = _class_method(
+            module,
+            owner_class,
+            "set_enabled",
+        )
+        self.assertTrue(
+            {"_enabled", "_generation", "_lock"}
+            <= _self_attributes(enable)
+        )
+        self.assertNotIn(
+            "_metrics",
+            _self_attributes(enable),
+        )
+
+        reset = _class_method(
+            module,
+            owner_class,
+            "reset_metrics",
+        )
+        self.assertTrue(
+            {"_lock", "_metrics"} <= _self_attributes(reset)
+        )
+        self.assertEqual(
+            {"_cache", "_enabled", "_generation", "_order"}
+            & _self_attributes(reset),
+            set(),
+        )
+
+        for facade in (
             "_aio_first_pass_cache_total_bytes",
             "_aio_first_pass_cache_metrics_snapshot",
             "_reset_aio_first_pass_cache_metrics",
@@ -293,85 +374,12 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
             "_set_aio_first_pass_cache_enabled",
             "_get_aio_first_pass_cache",
             "_put_aio_first_pass_cache",
-        )
-        references: set[str] = set()
-        for function_name in lifecycle_functions:
-            function_references = _references(
-                _top_level_function(module, function_name)
-            )
-            with self.subTest(function=function_name):
+        ):
+            with self.subTest(facade=facade):
                 self.assertIn(
-                    "_AIO_FIRST_PASS_CACHE_LOCK",
-                    function_references,
+                    "_DEFAULT_AIO_FIRST_PASS_CACHE",
+                    _references(_top_level_function(module, facade)),
                 )
-            references.update(function_references)
-        self.assertEqual(
-            set(owner["state_symbols"]) - references,
-            set(),
-        )
-
-    def test_cleanup_and_metrics_dispositions_are_current(self):
-        module = "easyuse_anima/aio/first_pass_cache.py"
-        clear = _top_level_function(module, "_clear_aio_first_pass_cache")
-        self.assertTrue(
-            {
-                "_AIO_FIRST_PASS_CACHE",
-                "_AIO_FIRST_PASS_CACHE_GENERATION",
-                "_AIO_FIRST_PASS_CACHE_LOCK",
-                "_AIO_FIRST_PASS_CACHE_ORDER",
-            }
-            <= _references(clear)
-        )
-        self.assertEqual(
-            {
-                "_AIO_FIRST_PASS_CACHE_ENABLED",
-                "_AIO_FIRST_PASS_CACHE_METRICS",
-            }
-            & _references(clear),
-            set(),
-        )
-        self.assertIn("clear", _called(clear))
-
-        enable = _top_level_function(
-            module,
-            "_set_aio_first_pass_cache_enabled",
-        )
-        self.assertTrue(
-            {
-                "_AIO_FIRST_PASS_CACHE",
-                "_AIO_FIRST_PASS_CACHE_ENABLED",
-                "_AIO_FIRST_PASS_CACHE_GENERATION",
-                "_AIO_FIRST_PASS_CACHE_LOCK",
-                "_AIO_FIRST_PASS_CACHE_ORDER",
-            }
-            <= _references(enable)
-        )
-        self.assertNotIn(
-            "_AIO_FIRST_PASS_CACHE_METRICS",
-            _references(enable),
-        )
-
-        reset = _top_level_function(
-            module,
-            "_reset_aio_first_pass_cache_metrics",
-        )
-        self.assertTrue(
-            {
-                "_AIO_FIRST_PASS_CACHE_LOCK",
-                "_AIO_FIRST_PASS_CACHE_METRICS",
-            }
-            <= _references(reset)
-        )
-        self.assertEqual(
-            {
-                "_AIO_FIRST_PASS_CACHE",
-                "_AIO_FIRST_PASS_CACHE_ENABLED",
-                "_AIO_FIRST_PASS_CACHE_GENERATION",
-                "_AIO_FIRST_PASS_CACHE_ORDER",
-            }
-            & _references(reset),
-            set(),
-        )
 
     def test_entry_policy_and_module_import_boundary_are_current(self):
         module = "easyuse_anima/aio/first_pass_cache.py"
@@ -485,6 +493,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
                 "_AIO_FIRST_PASS_CACHE_GENERATION",
                 "_AIO_FIRST_PASS_CACHE_LOCK",
                 "_AIO_FIRST_PASS_CACHE_METRICS",
+                "_DEFAULT_AIO_FIRST_PASS_CACHE",
                 "_aio_first_pass_cache_metrics_snapshot",
                 "_clear_aio_first_pass_cache",
                 "_reset_aio_first_pass_cache_metrics",

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -232,11 +232,7 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
             ("api.py", "register_routes"),
             (
                 "easyuse_anima/aio/first_pass_cache.py",
-                "_AIO_FIRST_PASS_CACHE_ENABLED",
-            ),
-            (
-                "easyuse_anima/aio/first_pass_cache.py",
-                "_AIO_FIRST_PASS_CACHE_GENERATION",
+                "_DEFAULT_AIO_FIRST_PASS_CACHE",
             ),
             ("easyuse_anima/api/file_io.py", "_FILE_IO_LIMITERS"),
             (


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-08b Move입니다. AiO first-pass cache의 entries, LRU order, enabled state, mutation generation, metrics, RLock을 one private `_AIOFirstPassCacheStore` default instance로 이동합니다.

- Base: `2c5aefeae16dd0f1411516f659bfef6659712243`
- Head: `25e8703594454da996278e429e17c85a10c71864`
- Production: `easyuse_anima/aio/first_pass_cache.py` 1 file
- Next: 별도 E-08c narrow RuntimeServices/bootstrap composition만 허용

## 구현과 보존 계약

- `_DEFAULT_AIO_FIRST_PASS_CACHE`가 cache/order/enabled/generation/metrics/RLock을 전부 소유합니다.
- module-level mapping/order 이름은 default owner 객체의 exact compatibility alias로 유지됩니다.
- canonical facade는 mapping/order를 owner에 call-time 전달하여 replacement seam을 보존합니다.
- raw enabled/generation/metrics/lock globals는 제거했습니다.
- policy/clock/entry capture/size/clone helper는 계속 call-time resolve됩니다.
- isolated store는 collection, metrics, generation, enabled state, lock을 공유하지 않습니다.

보존:
- #169 count/byte/single-entry/TTL/LRU/key/resource revision/clone/metrics behavior
- clone outside lock, stale-capture generation rejection, clear/disable/metrics semantics
- immutable capture/mutable checkout, legacy mapping fallback
- root 7개 direct canonical identity와 기존 `__all__`
- `FirstPassRuntime` get/put injection, stage/legacy/node/package/import behavior

## 검증

Focused:
- AiO cache owner/concurrency/compatibility 33
- E-08 executable Contract 8
- E-01 inventory 5
- cache benchmark 8
- first-pass stage 6
- legacy generation 31
- AiO node contract 10
- Python compatibility surface 19
- package skeleton 1
- import-boundary 10 + 6
- backend analyzer 18
- changed-file Python syntax/fatal Ruff, fixture JSON load, `git diff --check`

Final candidate official full exactly once:
- Python unittest 1,395 passed
- frontend 120 JavaScript files passed
- Pyright baseline ratchet passed
- import boundary 11 groups / 0 violations
- project full passed

Package/live evidence is reused because import closure, package contents, metadata, route/node/workflow shape, and host-visible behavior did not change.

## 위험과 rollback

주요 위험은 private root alias와 call-time replacement seam의 drift였고 direct identity/isolated-owner/concurrency tests로 고정했습니다. Rollback은 이 단일 Move commit revert입니다. E-08c에서 exact default owner를 narrow port로 조합할 수 없거나 feature back-reference가 필요하면 중단합니다.

Closes no issue; tracks #187.