### PR TITLE
E-08c: compose AiO first-pass cache runtime port

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-07, E-08a, and E-08b are complete; the next bounded
-  unit is the separate E-08c narrow RuntimeServices/bootstrap composition Move.
+  owns Phase E. E-01 through E-07 and E-08a through E-08c are complete; the next
+  bounded unit is the separate production-free E-08d completion audit Contract.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-08b: E-08a / PR #552 at
-  `2c5aefeae16dd0f1411516f659bfef6659712243`.
+- Reviewed code baseline before E-08c: E-08b / PR #553 at
+  `ac527cd5d1621a6f1fda694670be6e80f996579c`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -40,15 +40,15 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md).
 - E-08 AiO first-pass cache ownership Contract and bounded Move queue:
   [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md).
-- First READY task after E-08b: a separate #187 E-08c narrow cache composition Move
-  only.
+- First READY task after E-08c: a separate #187 production-free E-08d completion
+  audit Contract only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-08b authorizes only the separate E-08c Move. It does not authorize E-08d or later
-  Phase E work, root removal, release, or Registry.
+- E-08c authorizes only the separate E-08d completion audit. It does not authorize
+  E-09 or later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
 

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,12 +2,13 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-07, E-08a, and the E-08b owner Move are completed;
+- Status: D-08, E-01 through E-07, E-08a, E-08b, and the E-08c composition
+  Move are completed;
   the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-08b:
-  `dev@2c5aefeae16dd0f1411516f659bfef6659712243` after E-08a / PR #552.
-- Document baseline: completed E-08b AiO first-pass cache mutable owner Move.
+- Code-review base before E-08c:
+  `dev@ac527cd5d1621a6f1fda694670be6e80f996579c` after E-08b / PR #553.
+- Document baseline: completed E-08c AiO first-pass cache composition Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -16,8 +17,8 @@
   E-06b snapshot owner Move, the E-06c canonical service/internal caller Move, the
   E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
-  ownership Contract, the E-08b owner Move, and the next bounded E-08c composition
-  Move.
+  ownership Contract, the E-08b owner Move, the E-08c narrow composition Move, and
+  the next bounded E-08d completion audit Contract.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -430,8 +431,11 @@ path, and selects one private `_AIOFirstPassCacheStore` default instance as the
 owner target without production changes. E-08b moves all six mutable states behind
 that default owner, removes the raw enabled/generation/metrics/lock globals, and
 retains mapping/order only as exact owner aliases for root identity and call-time
-replacement seams. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
+replacement seams. E-08c adds one private `AIOFirstPassCachePort`, installs the exact
+default owner as `RuntimeServices.aio_first_pass_cache`, and preserves the existing
+`FirstPassRuntime` caller path, feature import direction, and repeated initialize
+behavior. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
 RuntimeServices/bootstrap composition, and E-08d completion audit. The next READY
-unit is E-08c only from latest origin/dev. Do not start E-08d, E-09 cleanup, D-14
-retirement, release, or Registry work inside E-08c.
+unit is the production-free E-08d Contract only after E-08c merges. Do not start
+E-09 cleanup, D-14 retirement, release, or Registry work inside E-08d.
 ```

--- a/docs/architecture/python-runtime-e08-aio-cache-contract.md
+++ b/docs/architecture/python-runtime-e08-aio-cache-contract.md
@@ -9,7 +9,9 @@ freezes the AiO first-pass cache process state, policy and behavior authorities,
 typed caller boundary, root compatibility identities, cleanup semantics, and the only
 authorized bounded Move order. E-08b implements the selected owner from
 `dev@2c5aefeae16dd0f1411516f659bfef6659712243` without changing cache
-behavior or runtime composition.
+behavior or runtime composition. E-08c composes that exact owner from
+`dev@ac527cd5d1621a6f1fda694670be6e80f996579c` behind one private narrow
+runtime port without changing the existing First-pass caller path.
 
 The executable source is
 `tests/fixtures/python_aio_first_pass_cache_contract.v1.json`, checked by
@@ -17,8 +19,9 @@ The executable source is
 cache, benchmark, First-pass stage, legacy-generation, package, analyzer, and import-
 boundary tests remain the behavior authorities.
 
-E-08 changes ownership only. E-08b changes one production module and does not reopen
-#169 cache policy, stage execution, workflow results, or queue/live evidence.
+E-08 changes ownership only. E-08b changes one production module; E-08c adds one
+private port module and updates runtime/bootstrap composition. Neither reopens #169
+cache policy, stage execution, workflow results, or queue/live evidence.
 
 ## Completed #169 behavior boundary
 
@@ -101,9 +104,9 @@ capture invalidates stale publication without waiting for capture. Clear does no
 for checkout cloning. Same-key overwrite is not an eviction, and clear, disable, or
 metrics reset does not invent eviction counts.
 
-E-08b preserves these feature cleanup dispositions. E-08c may expose only a narrow
-AiO cache capability backed by the exact default owner. Whole-runtime reverse close,
-partial-initialization cleanup, and shutdown idempotence remain E-09.
+E-08b preserves these feature cleanup dispositions. E-08c exposes only the `get` and
+`put` AiO cache capability backed by the exact default owner. Whole-runtime reverse
+close, partial-initialization cleanup, and shutdown idempotence remain E-09.
 
 ## Caller and import direction
 
@@ -115,10 +118,10 @@ key helper and injects canonical get/put callables into the existing frozen
 sampling; a miss samples and decodes; resize may re-encode; store remains best
 effort; metadata and preview order remain unchanged.
 
-The cache module, First-pass stage, and legacy orchestrator do not import root
-`nodes.py`, bootstrap, or `RuntimeServices`. E-08c must preserve that direction:
-bootstrap may compose the exact default owner, but feature code does not receive or
-import the complete runtime.
+The cache module, private port, First-pass stage, and legacy orchestrator do not
+import root `nodes.py`, bootstrap, or `RuntimeServices`. E-08c preserves that
+direction: bootstrap composes the exact default owner, but feature code does not
+receive or import the complete runtime.
 
 ## Bounded Move queue
 
@@ -127,9 +130,9 @@ import the complete runtime.
 2. **E-08b Move — mutable cache owner — complete:** entries, order, enabled state,
    generation, metrics, and `RLock` are behind one feature-private default owner;
    direct aliases and call-time replacement seams remain executable evidence.
-3. **E-08c Move — bootstrap composition:** install the exact default owner behind one
-   feature-specific narrow RuntimeServices capability without changing the existing
-   `FirstPassRuntime` caller path.
+3. **E-08c Move — bootstrap composition — complete:** the exact default owner is
+   installed behind one feature-specific narrow RuntimeServices capability without
+   changing the existing `FirstPassRuntime` caller path.
 4. **E-08d Contract — completion audit:** reconcile E-01, cleanup, import direction,
    root identities, runtime composition, and zero ambiguous AiO cache state before
    E-09.
@@ -167,10 +170,14 @@ E-08b additionally covers isolated-owner separation, exact default mapping/order
 identity, raw module-state removal, facade delegation, preserved replacement seams,
 and actual-code inventory/analyzer evidence.
 
-Run the official full profile once on the final candidate SHA. E-08b changes only
-private in-module ownership and does not change import closure, archive contents,
-metadata, or host-visible behavior, so the E-06d validate/pack/isolated-live evidence
-remains valid unless a promotion gate proves otherwise.
+E-08c additionally covers the private two-method port, required RuntimeServices
+field, exact bootstrap owner identity, repeated initialize reuse, fake-host wiring,
+package/no-host import, archive inclusion, and unchanged canonical stage injection.
+
+Run the official full profile once on the final candidate SHA. E-08c adds a shipped
+private port module, so run validate/pack and verify that the archive includes it.
+Reuse the existing isolated-live evidence unless a promotion gate proves material
+host-visible or startup drift.
 
 ## Stop conditions
 
@@ -182,4 +189,4 @@ behavior changes; canonical feature code must import root/runtime/bootstrap; pac
 import starts host I/O; or E-09 shutdown must be implemented to finish E-08.
 
 Direct source, #169, E-01, and concurrency tests select one owner and one bounded
-Move sequence. E-08a and E-08b therefore do not trigger additional PRO review.
+Move sequence. E-08a through E-08c therefore do not trigger additional PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -36,7 +36,7 @@ E-01 drift gate until classified.
 
 | Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
 | --- | --- | --- | --- |
-| `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; module mapping/order names are exact compatibility aliases | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08b complete; E-08c next |
+| `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; bootstrap installs that exact owner behind a narrow private runtime port | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08c complete; E-08d audit next |
 | `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
 | `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
@@ -180,4 +180,12 @@ E-08b installs the selected private default owner. The former raw enabled,
 generation, metrics, and lock globals are removed; mapping/order remain only as exact
 aliases to the owner's objects so root identities and call-time replacement evidence
 remain intact. Isolated stores share no collection, metric dictionary, generation,
-enabled state, or lock. The next bounded unit is E-08c only.
+enabled state, or lock.
+
+E-08c adds the private `AIOFirstPassCachePort` with only `get` and `put`, installs
+the exact `_DEFAULT_AIO_FIRST_PASS_CACHE` identity as
+`RuntimeServices.aio_first_pass_cache`, and leaves the existing canonical key/get/put
+to `FirstPassRuntime` to stage caller path unchanged. Feature code does not import
+the runtime or bootstrap, repeated initialize reuses the same installed runtime, and
+no root alias or public export changes. The next bounded unit is the production-free
+E-08d completion audit only.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -56,20 +56,20 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-08b: E-08a / PR #552 at
-  `2c5aefeae16dd0f1411516f659bfef6659712243`.
+- Reviewed code baseline before E-08c: E-08b / PR #553 at
+  `ac527cd5d1621a6f1fda694670be6e80f996579c`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-07, E-08a, and the E-08b owner Move are complete. The next work is
-  only a separate #187 E-08c narrow AiO cache composition Move. The #323
+- E-01 through E-07 and E-08a through E-08c are complete. The next work is only a
+  separate #187 production-free E-08d completion audit Contract. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root compatibility aliases or start E-08d through E-10, release, or
+- Do not remove root compatibility aliases or start E-09 through E-10, release, or
   Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -161,8 +161,8 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-08b installs the selected
-  AiO first-pass cache owner and preserves the compatibility boundary; use that
-  evidence only to start the separate E-08c composition Move. Do not infer E-08d,
-  E-09 cleanup, release
+- D-14 readiness is recorded and authorizes no removal. E-08c composes the exact
+  AiO first-pass cache owner behind a narrow private runtime port and preserves the
+  compatibility boundary; use that evidence only to start the separate E-08d
+  completion audit. Do not infer E-09 cleanup, release
   publication, or Registry actions.

--- a/easyuse_anima/aio/ports.py
+++ b/easyuse_anima/aio/ports.py
@@ -1,0 +1,14 @@
+"""Narrow process AiO first-pass cache capability."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class AIOFirstPassCachePort(Protocol):
+    def get(self, cache_key: str) -> tuple[Any, Any] | None: ...
+
+    def put(self, cache_key: str, latent: Any, image: Any) -> None: ...
+
+
+__all__ = ()

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -50,6 +50,7 @@ from .api.routes.translation_execution import (
 from .api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
+from .aio.first_pass_cache import _DEFAULT_AIO_FIRST_PASS_CACHE
 from .autocomplete.dataset import _DEFAULT_AUTOCOMPLETE_SNAPSHOTS
 from .autocomplete.index import _DEFAULT_AUTOCOMPLETE_INDEX_STORE
 from .autocomplete.service import _AutocompleteService
@@ -262,6 +263,7 @@ def initialize(
                     index_store=_DEFAULT_AUTOCOMPLETE_INDEX_STORE,
                 ),
                 wildcard_snapshots=_DEFAULT_WILDCARD_SNAPSHOTS,
+                aio_first_pass_cache=_DEFAULT_AIO_FIRST_PASS_CACHE,
             )
             install_runtime(runtime)
             _install_default_translation_service(runtime.translation)

--- a/easyuse_anima/runtime.py
+++ b/easyuse_anima/runtime.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from .aio.ports import AIOFirstPassCachePort
 from .autocomplete.ports import AutocompletePort
 from .infrastructure.comfy.provider import ComfyHostProvider
 from .seed.reservation import SeedReservationService
@@ -45,6 +46,7 @@ class RuntimeServices:
     translation: PromptTranslationPort
     autocomplete: AutocompletePort
     wildcard_snapshots: WildcardSnapshotPort
+    aio_first_pass_cache: AIOFirstPassCachePort
 
 
 _RUNTIME_SERVICES: RuntimeServices | None = None

--- a/tests/comfy_host_fakes.py
+++ b/tests/comfy_host_fakes.py
@@ -61,6 +61,17 @@ class FakeWildcardSnapshots:
         )
 
 
+class FakeAIOFirstPassCache:
+    def get(self, cache_key):
+        raise AssertionError(f"unexpected AiO first-pass cache get: {cache_key!r}")
+
+    def put(self, cache_key, latent, image):
+        raise AssertionError(
+            "unexpected AiO first-pass cache put: "
+            f"{(cache_key, latent, image)!r}"
+        )
+
+
 class FakeComfyHostProvider:
     def __init__(
         self,
@@ -152,6 +163,7 @@ def _runtime_support(runtime_module):
             installed.translation,
             installed.autocomplete,
             installed.wildcard_snapshots,
+            installed.aio_first_pass_cache,
         )
     return (
         runtime_module.RuntimeConfig(
@@ -163,13 +175,14 @@ def _runtime_support(runtime_module):
         FakeTranslationService(),
         FakeAutocompleteService(),
         FakeWildcardSnapshots(),
+        FakeAIOFirstPassCache(),
     )
 
 
 @contextmanager
 def use_fake_comfy_host(root_module, provider):
     runtime_module = _runtime_module_for(root_module)
-    config, clock, translation, autocomplete, wildcard_snapshots = (
+    config, clock, translation, autocomplete, wildcard_snapshots, aio_cache = (
         _runtime_support(runtime_module)
     )
     runtime = runtime_module.RuntimeServices(
@@ -180,6 +193,7 @@ def use_fake_comfy_host(root_module, provider):
         translation=translation,
         autocomplete=autocomplete,
         wildcard_snapshots=wildcard_snapshots,
+        aio_first_pass_cache=aio_cache,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield provider
@@ -209,7 +223,7 @@ def patch_comfy_helper(
         else FakeComfyHostProvider()
     )
     provider = _LayeredFakeComfyHostProvider(base, symbol, replacement)
-    config, clock, translation, autocomplete, wildcard_snapshots = (
+    config, clock, translation, autocomplete, wildcard_snapshots, aio_cache = (
         _runtime_support(runtime_module)
     )
     runtime = runtime_module.RuntimeServices(
@@ -220,6 +234,7 @@ def patch_comfy_helper(
         translation=translation,
         autocomplete=autocomplete,
         wildcard_snapshots=wildcard_snapshots,
+        aio_first_pass_cache=aio_cache,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield replacement

--- a/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
+++ b/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
@@ -79,10 +79,11 @@
     "policy_boundary": "Count, total-byte, single-entry, and absolute-TTL constants plus immutable entry/key/clone/size helpers are policy or behavior, not separate mutable runtime owners.",
     "resource_partition": "Entries, LRU order, enabled state, mutation generation, metrics, and their RLock form one AiO-specific owner because get, put, clear, disable, stale-capture rejection, and metric publication share one mutation invariant.",
     "root_compatibility": "The seven root private identities remain direct canonical aliases. Replacement mapping/order and policy/clock/helper tests require an equivalent call-time or isolated-owner injection seam before raw globals move.",
-    "runtime_composition": "After the owner Move, bootstrap installs the exact default owner behind one feature-specific narrow RuntimeServices capability without adding a feature-to-runtime back-reference."
+    "runtime_composition": "Bootstrap installs the exact default owner behind one feature-specific narrow RuntimeServices capability without adding a feature-to-runtime back-reference or changing the FirstPassRuntime caller path."
   },
   "import_direction": {
     "feature_modules": [
+      "easyuse_anima/aio/ports.py",
       "easyuse_anima/aio/first_pass_cache.py",
       "easyuse_anima/aio/generation_first_pass.py",
       "easyuse_anima/aio/legacy_generation.py"
@@ -115,7 +116,7 @@
       "goal": "Compose the exact default owner behind one feature-specific narrow RuntimeServices capability without changing the canonical FirstPassRuntime caller path.",
       "id": "E-08c",
       "name": "AiO first-pass cache bootstrap composition",
-      "status": "queued"
+      "status": "complete"
     },
     {
       "classification": "Contract",
@@ -201,7 +202,30 @@
       ]
     }
   ],
-  "production_changes": 1,
+  "production_changes": 4,
+  "runtime_port": {
+    "bootstrap": {
+      "function": "initialize",
+      "module": "easyuse_anima/bootstrap.py",
+      "uses": [
+        "_DEFAULT_AIO_FIRST_PASS_CACHE",
+        "RuntimeServices"
+      ]
+    },
+    "interface": {
+      "class": "AIOFirstPassCachePort",
+      "methods": [
+        "get",
+        "put"
+      ],
+      "module": "easyuse_anima/aio/ports.py"
+    },
+    "owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
+    "runtime": {
+      "field": "aio_first_pass_cache",
+      "module": "easyuse_anima/runtime.py"
+    }
+  },
   "schema_version": 1,
   "scope": "E-08 AiO first-pass cache process-state ownership, cleanup, callers, compatibility seams, and bounded Move order"
 }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -13651,6 +13651,57 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/aio/postprocess.py"
       },
       {
@@ -17721,6 +17772,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_DEFAULT_AIO_FIRST_PASS_CACHE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".aio.first_pass_cache:_DEFAULT_AIO_FIRST_PASS_CACHE",
+        "kind": "static_from",
+        "line": 53,
+        "name": "_DEFAULT_AIO_FIRST_PASS_CACHE",
+        "optional": false,
+        "requested": ".aio.first_pass_cache",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
         "branch_context": [],
         "classification": "internal",
@@ -17728,7 +17797,7 @@
         "conditional": false,
         "imported": ".autocomplete.dataset:_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
         "kind": "static_from",
-        "line": 53,
+        "line": 54,
         "name": "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
         "optional": false,
         "requested": ".autocomplete.dataset",
@@ -17746,7 +17815,7 @@
         "conditional": false,
         "imported": ".autocomplete.index:_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "kind": "static_from",
-        "line": 54,
+        "line": 55,
         "name": "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "optional": false,
         "requested": ".autocomplete.index",
@@ -17764,7 +17833,7 @@
         "conditional": false,
         "imported": ".autocomplete.service:_AutocompleteService",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_AutocompleteService",
         "optional": false,
         "requested": ".autocomplete.service",
@@ -17782,7 +17851,7 @@
         "conditional": false,
         "imported": ".infrastructure.comfy.provider:DefaultComfyHostProvider",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "DefaultComfyHostProvider",
         "optional": false,
         "requested": ".infrastructure.comfy.provider",
@@ -17800,7 +17869,7 @@
         "conditional": false,
         "imported": ".runtime:RuntimeConfig",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "RuntimeConfig",
         "optional": false,
         "requested": ".runtime",
@@ -17818,7 +17887,7 @@
         "conditional": false,
         "imported": ".runtime:RuntimeServices",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "RuntimeServices",
         "optional": false,
         "requested": ".runtime",
@@ -17836,7 +17905,7 @@
         "conditional": false,
         "imported": ".runtime:install_runtime",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "install_runtime",
         "optional": false,
         "requested": ".runtime",
@@ -17854,7 +17923,7 @@
         "conditional": false,
         "imported": ".seed.service:InMemorySeedReservationService",
         "kind": "static_from",
-        "line": 58,
+        "line": 59,
         "name": "InMemorySeedReservationService",
         "optional": false,
         "requested": ".seed.service",
@@ -17872,7 +17941,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationBusyError",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17890,7 +17959,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationCancelledError",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17908,7 +17977,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationTimeoutError",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17926,7 +17995,7 @@
         "conditional": false,
         "imported": ".translation.service:BoundedTranslationCache",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "BoundedTranslationCache",
         "optional": false,
         "requested": ".translation.service",
@@ -17944,7 +18013,7 @@
         "conditional": false,
         "imported": ".translation.service:PromptTranslationService",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "PromptTranslationService",
         "optional": false,
         "requested": ".translation.service",
@@ -17962,7 +18031,7 @@
         "conditional": false,
         "imported": ".translation.service:_install_default_translation_service",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_install_default_translation_service",
         "optional": false,
         "requested": ".translation.service",
@@ -17980,7 +18049,7 @@
         "conditional": false,
         "imported": ".wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_DEFAULT_WILDCARD_SNAPSHOTS",
         "optional": false,
         "requested": ".wildcard.snapshot",
@@ -17998,7 +18067,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -18016,7 +18085,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_ROOT",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "PACKAGE_ROOT",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -18034,7 +18103,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -30115,6 +30184,24 @@
       },
       {
         "alias": null,
+        "bound_name": "AIOFirstPassCachePort",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".aio.ports:AIOFirstPassCachePort",
+        "kind": "static_from",
+        "line": 9,
+        "name": "AIOFirstPassCachePort",
+        "optional": false,
+        "requested": ".aio.ports",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py",
+        "target": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AutocompletePort",
         "branch_context": [],
         "classification": "internal",
@@ -30122,7 +30209,7 @@
         "conditional": false,
         "imported": ".autocomplete.ports:AutocompletePort",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "AutocompletePort",
         "optional": false,
         "requested": ".autocomplete.ports",
@@ -30140,7 +30227,7 @@
         "conditional": false,
         "imported": ".infrastructure.comfy.provider:ComfyHostProvider",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "ComfyHostProvider",
         "optional": false,
         "requested": ".infrastructure.comfy.provider",
@@ -30158,7 +30245,7 @@
         "conditional": false,
         "imported": ".seed.reservation:SeedReservationService",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "SeedReservationService",
         "optional": false,
         "requested": ".seed.reservation",
@@ -30176,7 +30263,7 @@
         "conditional": false,
         "imported": ".translation.ports:PromptTranslationPort",
         "kind": "static_from",
-        "line": 12,
+        "line": 13,
         "name": "PromptTranslationPort",
         "optional": false,
         "requested": ".translation.ports",
@@ -30194,7 +30281,7 @@
         "conditional": false,
         "imported": ".wildcard.ports:WildcardSnapshotPort",
         "kind": "static_from",
-        "line": 13,
+        "line": 14,
         "name": "WildcardSnapshotPort",
         "optional": false,
         "requested": ".wildcard.ports",
@@ -66009,6 +66096,10 @@
       },
       {
         "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "from": "easyuse_anima/bootstrap.py",
         "to": "easyuse_anima/api/routes/aio_profile_mutations.py"
       },
       {
@@ -66813,6 +66904,10 @@
       },
       {
         "from": "easyuse_anima/runtime.py",
+        "to": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "from": "easyuse_anima/runtime.py",
         "to": "easyuse_anima/autocomplete/ports.py"
       },
       {
@@ -67563,6 +67658,12 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/aio/output_settings.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/aio/ports.py"
         ]
       },
       {
@@ -68355,7 +68456,7 @@
     ]
   },
   "inventory": {
-    "module_count": 172,
+    "module_count": 173,
     "modules": [
       {
         "is_package": true,
@@ -68839,6 +68940,18 @@
       },
       {
         "is_package": false,
+        "loc": 14,
+        "module": "easyuse_anima.aio.ports",
+        "normalized_git_blob_sha1": "2f6a0582ff6bd33ea383428feb52d4fb3095be23",
+        "path": "easyuse_anima/aio/ports.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
         "loc": 188,
         "module": "easyuse_anima.aio.postprocess",
         "normalized_git_blob_sha1": "7a9b7adb5aa184ae55ee6323e62ce18d937551c7",
@@ -69259,9 +69372,9 @@
       },
       {
         "is_package": false,
-        "loc": 286,
+        "loc": 288,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "b4994d7c3a0b05817005789acf0c167651f192dc",
+        "normalized_git_blob_sha1": "9a6d328e87f497320d5a1fb5766ee4575ef57d78",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 1,
@@ -69991,9 +70104,9 @@
       },
       {
         "is_package": false,
-        "loc": 85,
+        "loc": 87,
         "module": "easyuse_anima.runtime",
-        "normalized_git_blob_sha1": "feacbf426d89f090a530a4fc0ee76342c25744a6",
+        "normalized_git_blob_sha1": "51d8179d45d446bb2b8a8de9e1ceb891e35c35da",
         "path": "easyuse_anima/runtime.py",
         "top_level": {
           "class_count": 4,
@@ -84623,6 +84736,39 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/aio/postprocess.py"
       },
       {
@@ -90919,6 +91065,7 @@
       "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
+      "easyuse_anima/aio/ports.py",
       "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
@@ -91093,6 +91240,7 @@
       "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
+      "easyuse_anima/aio/ports.py",
       "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
@@ -92442,7 +92590,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 71,
+        "line": 72,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92451,7 +92599,7 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 72,
+        "line": 73,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92910,7 +93058,7 @@
         "column": 1,
         "context": "decorator:RuntimeConfig",
         "kind": "import_time_call",
-        "line": 16,
+        "line": 17,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -92919,7 +93067,7 @@
         "column": 1,
         "context": "decorator:RuntimeServices",
         "kind": "import_time_call",
-        "line": 37,
+        "line": 38,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -93382,7 +93530,7 @@
       },
       {
         "kind": "list",
-        "line": 286,
+        "line": 288,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -93681,7 +93829,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 72,
+        "line": 73,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -12,6 +12,7 @@ from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
 from easyuse_anima.infrastructure.comfy.wiring import resolve_comfy_host_helper
 from easyuse_anima.runtime import RuntimeConfig, RuntimeServices
 from tests.comfy_host_fakes import (
+    FakeAIOFirstPassCache,
     FakeAutocompleteService,
     FakeClock,
     FakeComfyHostProvider,
@@ -256,6 +257,7 @@ class ComfyHostWiringTests(unittest.TestCase):
             translation=FakeTranslationService(),
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
+            aio_first_pass_cache=FakeAIOFirstPassCache(),
         )
 
         self.assertEqual(
@@ -309,6 +311,7 @@ class ComfyHostWiringTests(unittest.TestCase):
             translation=FakeTranslationService(),
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
+            aio_first_pass_cache=FakeAIOFirstPassCache(),
         )
 
         require = resolve_comfy_host_helper(

--- a/tests/test_python_aio_first_pass_cache_contract.py
+++ b/tests/test_python_aio_first_pass_cache_contract.py
@@ -208,13 +208,14 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
                 "owners",
                 "production_callers",
                 "production_changes",
+                "runtime_port",
                 "schema_version",
                 "scope",
             },
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 1)
+        self.assertEqual(self.fixture["production_changes"], 4)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-08a", "E-08b", "E-08c", "E-08d"],
@@ -225,7 +226,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "queued", "queued"],
+            ["complete", "complete", "complete", "queued"],
         )
         self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
@@ -472,6 +473,63 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
                 ),
                 set(),
             )
+
+    def test_runtime_port_composes_the_exact_default_owner(self):
+        runtime_port = self.fixture["runtime_port"]
+        interface = runtime_port["interface"]
+        interface_methods = {
+            statement.name
+            for statement in _top_level_class(
+                interface["module"],
+                interface["class"],
+            ).body
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertEqual(interface_methods, set(interface["methods"]))
+        all_value = _assignment_value(interface["module"], "__all__")
+        self.assertIsInstance(all_value, ast.Tuple)
+        self.assertEqual(all_value.elts, [])
+
+        runtime = runtime_port["runtime"]
+        runtime_field = next(
+            statement
+            for statement in _top_level_class(
+                runtime["module"], "RuntimeServices"
+            ).body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == runtime["field"]
+        )
+        self.assertIsInstance(runtime_field.annotation, ast.Name)
+        self.assertEqual(runtime_field.annotation.id, interface["class"])
+
+        bootstrap = runtime_port["bootstrap"]
+        self.assertEqual(
+            set(bootstrap["uses"])
+            - _references(
+                _top_level_function(
+                    bootstrap["module"],
+                    bootstrap["function"],
+                )
+            ),
+            set(),
+        )
+        self.assertEqual(
+            runtime_port["owner"],
+            "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
+        )
+
+        forbidden_modules = {"runtime", "bootstrap", "nodes"}
+        for module in self.fixture["import_direction"]["feature_modules"]:
+            with self.subTest(module=module):
+                self.assertEqual(
+                    {
+                        imported_module
+                        for imported_module in _imported_modules(module)
+                        if imported_module.split(".")[-1] in forbidden_modules
+                    },
+                    set(),
+                )
 
     def test_root_private_identities_remain_direct_canonical_aliases(self):
         surface = next(

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 172)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 172)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 172)
+        self.assertEqual(report["inventory"]["module_count"], 173)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 173)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 173)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -756,6 +756,7 @@ ignored/
                 "easyuse_anima/aio/negpip.py",
                 "easyuse_anima/aio/output.py",
                 "easyuse_anima/aio/output_settings.py",
+                "easyuse_anima/aio/ports.py",
                 "easyuse_anima/aio/postprocess.py",
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
@@ -850,6 +851,7 @@ ignored/
                 "easyuse_anima/aio/model_preparation.py",
                 "easyuse_anima/aio/negpip.py",
                 "easyuse_anima/aio/output.py",
+                "easyuse_anima/aio/ports.py",
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -13,6 +13,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from easyuse_anima import bootstrap, runtime as runtime_module
+from easyuse_anima.aio import first_pass_cache as aio_first_pass_cache
 from easyuse_anima.autocomplete import dataset as autocomplete_dataset
 from easyuse_anima.autocomplete import index as autocomplete_index
 from easyuse_anima.autocomplete import service as autocomplete_service
@@ -71,6 +72,14 @@ class FakeAutocompleteService:
 class FakeWildcardSnapshots:
     def snapshot_for_roots(self, roots, *, scan_sources, build_snapshot):
         raise AssertionError((roots, scan_sources, build_snapshot))
+
+
+class FakeAIOFirstPassCache:
+    def get(self, cache_key):
+        raise AssertionError(cache_key)
+
+    def put(self, cache_key, latent, image):
+        raise AssertionError((cache_key, latent, image))
 
 
 class RuntimeBaseContractTests(unittest.TestCase):
@@ -171,6 +180,7 @@ class RuntimeServicesTests(unittest.TestCase):
             translation=PromptTranslationService(),
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
+            aio_first_pass_cache=FakeAIOFirstPassCache(),
         )
 
     def test_runtime_value_is_frozen(self):
@@ -275,6 +285,10 @@ class RuntimeServicesTests(unittest.TestCase):
         self.assertIs(
             first.wildcard_snapshots,
             wildcard_snapshot._DEFAULT_WILDCARD_SNAPSHOTS,
+        )
+        self.assertIs(
+            first.aio_first_pass_cache,
+            aio_first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE,
         )
         with patch.object(bootstrap.time, "monotonic", return_value=12.5):
             self.assertEqual(first.clock.monotonic(), 12.5)


### PR DESCRIPTION
## 목적과 경계

Issue #187의 E-08c Move입니다. AiO first-pass cache의 factory/behavior/caller 경로는 바꾸지 않고, exact default owner만 private narrow RuntimeServices capability로 조합합니다.

- Base: `ac527cd5d1621a6f1fda694670be6e80f996579c`
- Head: `48f1e5f468ba1b6aac462d584b2d89a7ba3cef1a`
- Production: `easyuse_anima/aio/ports.py`, `easyuse_anima/runtime.py`, `easyuse_anima/bootstrap.py`

## 변경

- private `AIOFirstPassCachePort`에 `get`/`put`만 정의
- `RuntimeServices.aio_first_pass_cache`를 required field로 추가
- bootstrap이 exact `_DEFAULT_AIO_FIRST_PASS_CACHE`를 최초 runtime에 한 번 조합하고 repeated initialize에서는 같은 runtime을 재사용
- E-08 fixture, analyzer/package closure, runtime/bootstrap/fake-host 직접 증거 갱신
- E-08c 완료와 다음 production-free E-08d audit만 문서화

## 보존 계약

- canonical key/get/put → `FirstPassRuntime` → stage 경로와 cache behavior
- cache key/TTL/LRU/clone/concurrency/metrics 정책
- root aliases, handler/public exports, import direction
- bootstrap initialize signature/order/retry 및 repeated initialize identity
- package/no-host import

## 검증

Focused:
- Runtime base 5, RuntimeServices 8, bootstrap 5, Comfy wiring 10, host ledger 7
- E-08 Contract 9
- cache 33, benchmark 8, stage 6, legacy generation 31
- package skeleton 1, compatibility surface 19
- import boundary 10 + 6, backend analyzer 18
- changed-file Python syntax, fatal Ruff, JSON syntax, `git diff --check`

Official full (exact final SHA, 1회):
- Python 1,396
- frontend 120
- Pyright baseline ratchet 통과
- import boundary 11 groups / 0 violations
- 전체 통과

Package:
- `comfy node validate` 통과
- actual `comfy node pack`: 315 entries, CRC 오류 없음, duplicates 0
- `easyuse_anima/aio/ports.py`, `runtime.py`, `bootstrap.py` 각 1회 포함

Live:
- host-visible/runtime behavior 변화가 없어 기존 isolated-live 증거 재사용

## 위험과 rollback

rollback 단위는 이 PR 하나입니다. E-09 lifecycle/shutdown, D-14, release, Registry는 포함하지 않습니다.

## 다음

merge 후 별도 production-free E-08d completion audit Contract만 진행합니다.