### PR TITLE
E-08d: audit AiO first-pass cache ownership

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-07 and E-08a through E-08c are complete; the next
-  bounded unit is the separate production-free E-08d completion audit Contract.
+  owns Phase E. E-01 through E-08 are complete; the next bounded unit is a separate
+  E-09 runtime shutdown and cleanup Contract.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-08c: E-08b / PR #553 at
-  `ac527cd5d1621a6f1fda694670be6e80f996579c`.
+- Reviewed code baseline before E-08d: E-08c / PR #554 at
+  `5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -40,15 +40,15 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md).
 - E-08 AiO first-pass cache ownership Contract and bounded Move queue:
   [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md).
-- First READY task after E-08c: a separate #187 production-free E-08d completion
-  audit Contract only.
+- First READY task after E-08d: a separate #187 E-09 runtime shutdown and cleanup
+  Contract only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-08c authorizes only the separate E-08d completion audit. It does not authorize
-  E-09 or later Phase E work, root removal, release, or Registry.
+- E-08d authorizes only the separate E-09 Contract. It does not authorize E-09
+  implementation, later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
 

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,13 +2,12 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-07, E-08a, E-08b, and the E-08c composition
-  Move are completed;
+- Status: D-08 and E-01 through E-08 are completed;
   the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-08c:
-  `dev@ac527cd5d1621a6f1fda694670be6e80f996579c` after E-08b / PR #553.
-- Document baseline: completed E-08c AiO first-pass cache composition Move.
+- Code-review base before E-08d:
+  `dev@5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b` after E-08c / PR #554.
+- Document baseline: completed E-08d AiO first-pass cache ownership audit.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -18,7 +17,7 @@
   E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
   ownership Contract, the E-08b owner Move, the E-08c narrow composition Move, and
-  the next bounded E-08d completion audit Contract.
+  the E-08d completion audit Contract. The next bounded phase is E-09 only.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -435,7 +434,10 @@ replacement seams. E-08c adds one private `AIOFirstPassCachePort`, installs the 
 default owner as `RuntimeServices.aio_first_pass_cache`, and preserves the existing
 `FirstPassRuntime` caller path, feature import direction, and repeated initialize
 behavior. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
-RuntimeServices/bootstrap composition, and E-08d completion audit. The next READY
-unit is the production-free E-08d Contract only after E-08c merges. Do not start
-E-09 cleanup, D-14 retirement, release, or Registry work inside E-08d.
+RuntimeServices/bootstrap composition, and E-08d completion audit. E-08d reconciles
+the single E-01 entry, feature cleanup, import direction, seven root identities, and
+the exact narrow runtime binding, and records zero ambiguous AiO cache state without
+production changes. E-08 is complete. The next READY unit after E-08d merges is a
+separate E-09 runtime shutdown and cleanup Contract. Do not start E-09 implementation,
+D-14 retirement, release, or Registry work inside E-08d.
 ```

--- a/docs/architecture/python-runtime-e08-aio-cache-contract.md
+++ b/docs/architecture/python-runtime-e08-aio-cache-contract.md
@@ -11,7 +11,9 @@ authorized bounded Move order. E-08b implements the selected owner from
 `dev@2c5aefeae16dd0f1411516f659bfef6659712243` without changing cache
 behavior or runtime composition. E-08c composes that exact owner from
 `dev@ac527cd5d1621a6f1fda694670be6e80f996579c` behind one private narrow
-runtime port without changing the existing First-pass caller path.
+runtime port without changing the existing First-pass caller path. E-08d audits the
+completed sequence from
+`dev@5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b` without production changes.
 
 The executable source is
 `tests/fixtures/python_aio_first_pass_cache_contract.v1.json`, checked by
@@ -133,9 +135,9 @@ receive or import the complete runtime.
 3. **E-08c Move — bootstrap composition — complete:** the exact default owner is
    installed behind one feature-specific narrow RuntimeServices capability without
    changing the existing `FirstPassRuntime` caller path.
-4. **E-08d Contract — completion audit:** reconcile E-01, cleanup, import direction,
-   root identities, runtime composition, and zero ambiguous AiO cache state before
-   E-09.
+4. **E-08d Contract — completion audit — complete:** E-01, cleanup, import direction,
+   root identities, runtime composition, and zero ambiguous AiO cache state are
+   reconciled before E-09.
 
 Each Move is a separate PR and rollback boundary. Do not combine the owner Move,
 runtime composition, completion audit, or E-09 shutdown.
@@ -160,6 +162,16 @@ All E-08 Moves preserve:
 - public node, workflow serialization, API/result, package/no-host, Legacy, and Node
   2.0 behavior.
 
+## Completion audit result
+
+E-08d records one E-01 entry and one exact default owner, one feature cleanup
+disposition with whole-runtime ordering retained for E-09, zero feature-to-runtime or
+root back-references, all seven direct root identities, the exact private two-method
+port/runtime/bootstrap binding, and `ambiguous_state_owners=[]`. No production file,
+import closure, package metadata, archive content, or host-visible behavior changes.
+E-08 is complete; the next phase is a separate E-09 runtime shutdown and cleanup
+Contract.
+
 ## Validation and evidence reuse
 
 E-08a focused validation covers the executable Contract, E-01 reconciliation, direct
@@ -174,10 +186,15 @@ E-08c additionally covers the private two-method port, required RuntimeServices
 field, exact bootstrap owner identity, repeated initialize reuse, fake-host wiring,
 package/no-host import, archive inclusion, and unchanged canonical stage injection.
 
-Run the official full profile once on the final candidate SHA. E-08c adds a shipped
-private port module, so run validate/pack and verify that the archive includes it.
-Reuse the existing isolated-live evidence unless a promotion gate proves material
-host-visible or startup drift.
+E-08d additionally covers exact E-01 owner reconciliation, cleanup disposition,
+feature import safety, all direct root identity bindings, the narrow runtime binding,
+and zero ambiguous state. Because it changes no production, import closure, metadata,
+archive, or host-visible behavior, the E-08c validate/pack/live evidence remains valid.
+
+Run the official full profile once on the final E-08d candidate SHA. Because E-08d
+changes no production, import closure, archive, metadata, or host-visible behavior,
+reuse the exact E-08c validate/pack/isolated-live evidence unless a promotion gate
+proves material drift.
 
 ## Stop conditions
 
@@ -189,4 +206,4 @@ behavior changes; canonical feature code must import root/runtime/bootstrap; pac
 import starts host I/O; or E-09 shutdown must be implemented to finish E-08.
 
 Direct source, #169, E-01, and concurrency tests select one owner and one bounded
-Move sequence. E-08a through E-08c therefore do not trigger additional PRO review.
+Move sequence. E-08a through E-08d therefore do not trigger additional PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -36,7 +36,7 @@ E-01 drift gate until classified.
 
 | Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
 | --- | --- | --- | --- |
-| `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; bootstrap installs that exact owner behind a narrow private runtime port | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08c complete; E-08d audit next |
+| `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; bootstrap installs that exact owner behind a narrow private runtime port | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08 complete; E-08d audited |
 | `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
 | `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
@@ -187,5 +187,11 @@ the exact `_DEFAULT_AIO_FIRST_PASS_CACHE` identity as
 `RuntimeServices.aio_first_pass_cache`, and leaves the existing canonical key/get/put
 to `FirstPassRuntime` to stage caller path unchanged. Feature code does not import
 the runtime or bootstrap, repeated initialize reuses the same installed runtime, and
-no root alias or public export changes. The next bounded unit is the production-free
-E-08d completion audit only.
+no root alias or public export changes.
+
+The production-free E-08d audit reconciles the single E-01 entry with that exact
+owner, records feature cleanup complete while whole-runtime ordering remains E-09,
+preserves package/no-host safety, feature import direction, all seven root identities,
+and the narrow runtime binding, and records zero ambiguous AiO cache state. E-08 is
+complete. The next bounded unit is a separate E-09 runtime shutdown and cleanup
+Contract.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -56,21 +56,21 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-08c: E-08b / PR #553 at
-  `ac527cd5d1621a6f1fda694670be6e80f996579c`.
+- Reviewed code baseline before E-08d: E-08c / PR #554 at
+  `5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-07 and E-08a through E-08c are complete. The next work is only a
-  separate #187 production-free E-08d completion audit Contract. The #323
+- E-01 through E-08 are complete. The next work is only a separate #187 E-09 runtime
+  shutdown and cleanup Contract. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root compatibility aliases or start E-09 through E-10, release, or
-  Registry work from this entrypoint.
+- Do not remove root compatibility aliases or start E-09 implementation, E-10,
+  release, or Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
 
@@ -161,8 +161,8 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-08c composes the exact
-  AiO first-pass cache owner behind a narrow private runtime port and preserves the
-  compatibility boundary; use that evidence only to start the separate E-08d
-  completion audit. Do not infer E-09 cleanup, release
+- D-14 readiness is recorded and authorizes no removal. The production-free E-08d
+  audit reconciles the exact AiO cache owner, cleanup, import/root/runtime binding,
+  and zero ambiguous state; use that evidence only to start the separate E-09
+  Contract. Do not infer E-09 implementation, release
   publication, or Registry actions.

--- a/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
+++ b/tests/fixtures/python_aio_first_pass_cache_contract.v1.json
@@ -72,6 +72,66 @@
       ]
     }
   ],
+  "completion_audit": {
+    "ambiguous_state_owners": [],
+    "classification": "Contract",
+    "cleanup_dispositions": [
+      {
+        "feature_cleanup": "_AIOFirstPassCacheStore clear/disable advances generation and clears entries/order while metrics reset remains independent",
+        "owner": "aio-first-pass-cache",
+        "remaining_phase": "E-09",
+        "status": "feature-cleanup-complete"
+      }
+    ],
+    "e01_reconciliation": [
+      {
+        "completed_phase": "E-08b-complete",
+        "e01_entry": "aio-first-pass-cache",
+        "owner": "aio-first-pass-cache"
+      }
+    ],
+    "import_safety": {
+      "evidence": [
+        "tests/test_python_package_skeleton.py"
+      ],
+      "feature_modules": [
+        "easyuse_anima/aio/ports.py",
+        "easyuse_anima/aio/first_pass_cache.py",
+        "easyuse_anima/aio/generation_first_pass.py",
+        "easyuse_anima/aio/legacy_generation.py"
+      ],
+      "forbidden_imports": [
+        "bootstrap",
+        "easyuse_anima.bootstrap",
+        "easyuse_anima.runtime",
+        "nodes",
+        "runtime"
+      ],
+      "host_io_at_import": false
+    },
+    "next_phase": "E-09 runtime shutdown and cleanup Contract",
+    "production_changes": 0,
+    "root_identity_bindings": [
+      {
+        "canonical_module": "easyuse_anima.aio.first_pass_cache",
+        "root_module": "nodes.py",
+        "symbols": [
+          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+          "_AIO_FIRST_PASS_CACHE",
+          "_AIO_FIRST_PASS_CACHE_ORDER",
+          "_aio_first_pass_cache_key",
+          "_clone_aio_cache_value",
+          "_get_aio_first_pass_cache",
+          "_put_aio_first_pass_cache"
+        ]
+      }
+    ],
+    "runtime_binding": {
+      "bootstrap_owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE",
+      "interface": "easyuse_anima.aio.ports.AIOFirstPassCachePort",
+      "runtime_field": "aio_first_pass_cache"
+    }
+  },
   "decisions": {
     "behavior_authority": "Issue #169 and its direct cache, benchmark, first-pass stage, legacy generation, and live integration evidence remain authoritative; E-08 changes ownership only.",
     "caller_boundary": "The canonical first-pass stage already receives get/put callables through FirstPassRuntime, so E-08 does not redesign stage execution or make feature code import RuntimeServices.",
@@ -123,7 +183,7 @@
       "goal": "Reconcile E-01, cleanup, import direction, root identities, runtime composition, and zero ambiguous AiO cache state before E-09.",
       "id": "E-08d",
       "name": "AiO first-pass cache ownership completion audit",
-      "status": "queued"
+      "status": "complete"
     }
   ],
   "owners": [
@@ -227,5 +287,5 @@
     }
   },
   "schema_version": 1,
-  "scope": "E-08 AiO first-pass cache process-state ownership, cleanup, callers, compatibility seams, and bounded Move order"
+  "scope": "Completed E-08 AiO first-pass cache ownership sequence through the production-free E-08d audit"
 }

--- a/tests/test_python_aio_first_pass_cache_contract.py
+++ b/tests/test_python_aio_first_pass_cache_contract.py
@@ -202,6 +202,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
                 "adapter_boundary",
                 "classification",
                 "compatibility_surfaces",
+                "completion_audit",
                 "decisions",
                 "import_direction",
                 "move_queue",
@@ -226,7 +227,7 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "complete", "queued"],
+            ["complete", "complete", "complete", "complete"],
         )
         self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
@@ -234,6 +235,113 @@ class PythonAIOFirstPassCacheContractTests(unittest.TestCase):
         )
         for evidence in self.fixture["owners"][0]["evidence"]:
             self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_completion_audit_reconciles_cleanup_import_root_and_runtime(self):
+        audit = self.fixture["completion_audit"]
+        owners = {owner["id"]: owner for owner in self.fixture["owners"]}
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+
+        self.assertEqual(audit["classification"], "Contract")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertEqual(audit["ambiguous_state_owners"], [])
+        self.assertEqual(
+            len({owner["current_owner"] for owner in owners.values()}),
+            len(owners),
+        )
+        self.assertEqual(
+            audit["next_phase"],
+            "E-09 runtime shutdown and cleanup Contract",
+        )
+
+        reconciliations = {
+            item["e01_entry"]: item
+            for item in audit["e01_reconciliation"]
+        }
+        self.assertEqual(
+            set(reconciliations),
+            {
+                e01_entry
+                for owner in owners.values()
+                for e01_entry in owner["e01_entries"]
+            },
+        )
+        for e01_entry, reconciliation in reconciliations.items():
+            with self.subTest(e01_entry=e01_entry):
+                owner = owners[reconciliation["owner"]]
+                self.assertIn(e01_entry, owner["e01_entries"])
+                self.assertEqual(
+                    e01_entries[e01_entry]["owner"],
+                    owner["current_owner"],
+                )
+                self.assertEqual(
+                    e01_entries[e01_entry]["target_phase"],
+                    reconciliation["completed_phase"],
+                )
+
+        cleanup = {
+            item["owner"]: item
+            for item in audit["cleanup_dispositions"]
+        }
+        self.assertEqual(set(cleanup), set(owners))
+        self.assertEqual(
+            cleanup["aio-first-pass-cache"]["status"],
+            "feature-cleanup-complete",
+        )
+        self.assertEqual(
+            {item["remaining_phase"] for item in cleanup.values()},
+            {"E-09"},
+        )
+
+        import_safety = audit["import_safety"]
+        self.assertFalse(import_safety["host_io_at_import"])
+        for evidence in import_safety["evidence"]:
+            self.assertTrue((ROOT / evidence).is_file(), evidence)
+        forbidden = set(import_safety["forbidden_imports"])
+        for module in import_safety["feature_modules"]:
+            with self.subTest(module=module):
+                self.assertEqual(
+                    _imported_modules(module) & forbidden,
+                    set(),
+                )
+
+        identity_surfaces = {
+            surface["module"]: set(surface["symbols"])
+            for surface in self.fixture["compatibility_surfaces"]
+            if surface["kind"] == "identity_reexport"
+        }
+        audited_bindings: dict[str, set[str]] = {}
+        for binding in audit["root_identity_bindings"]:
+            root_module = binding["root_module"]
+            expected = {
+                (binding["canonical_module"], symbol)
+                for symbol in binding["symbols"]
+            }
+            with self.subTest(root_module=root_module):
+                self.assertEqual(
+                    expected - _imported_names(root_module),
+                    set(),
+                )
+            audited_bindings.setdefault(root_module, set()).update(
+                binding["symbols"]
+            )
+        self.assertEqual(audited_bindings, identity_surfaces)
+
+        runtime_binding = audit["runtime_binding"]
+        runtime_port = self.fixture["runtime_port"]
+        self.assertEqual(
+            runtime_binding["bootstrap_owner"],
+            runtime_port["owner"],
+        )
+        self.assertEqual(
+            runtime_binding["interface"],
+            "easyuse_anima.aio.ports.AIOFirstPassCachePort",
+        )
+        self.assertEqual(
+            runtime_binding["runtime_field"],
+            runtime_port["runtime"]["field"],
+        )
 
     def test_e01_entry_reconciles_to_one_exact_target_owner(self):
         owner = self.fixture["owners"][0]


### PR DESCRIPTION
## 목적과 경계

Issue #187의 production-free E-08d completion audit Contract입니다.

- Base: `5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b`
- Head: `380e5fc179e9f3271f5b89bdc219e05b40ac12c8`
- Production changes: **0**
- E-09 lifecycle/shutdown 구현, D-14, release, Registry 미포함

## 감사 결과

- E-01의 `aio-first-pass-cache` entry를 exact `_DEFAULT_AIO_FIRST_PASS_CACHE` owner와 재대조
- six mutable states가 한 owner에만 있음을 유지
- feature cleanup complete, whole-runtime reverse close/partial-failure ordering은 E-09 유지
- `ambiguous_state_owners=[]`
- feature import/package no-host safety 유지
- seven direct root identity bindings 유지
- private `AIOFirstPassCachePort` / `RuntimeServices.aio_first_pass_cache` / bootstrap exact owner binding 유지
- E-08a~E-08d queue 완료, 다음은 별도 E-09 Contract만 기록

## 검증

Focused:
- E-08 Contract 10
- E-01 inventory 5
- cache 33, stage 6, legacy generation 31
- Runtime base 5, RuntimeServices 8, bootstrap 5
- package skeleton 1
- import boundary 10 + 6
- backend analyzer 18
- Python/JSON syntax, fatal Ruff, `git diff --check`

Official full (exact final SHA, 1회):
- Python 1,397
- frontend 120
- Pyright baseline ratchet 통과
- import boundary 11 groups / 0 violations
- 전체 통과

Package/live:
- production, import closure, archive, metadata, host-visible behavior 변화가 없으므로 E-08c의 validate/pack/isolated-live 증거 재사용

## 위험과 rollback

rollback 단위는 이 production-free audit PR 하나입니다. Audit 불일치나 production 변경 필요성이 발견되면 E-09를 시작하지 않고 중단합니다.

## 다음

merge 후 별도 E-09 runtime shutdown and cleanup Contract task card만 작성합니다.