### PR TITLE
E-09a: runtime shutdown 및 cleanup Contract 고정

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-08 are complete; the next bounded unit is a separate
-  E-09 runtime shutdown and cleanup Contract.
+  owns Phase E. E-01 through E-08 are complete; E-09a fixes the runtime shutdown
+  Contract and the next bounded implementation is E-09b only.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-08d: E-08c / PR #554 at
-  `5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b`.
+- E-09a Contract base: E-08d / PR #555 at
+  `4ad6bc947ba59db2df3cf5212ab07789757d7b96`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -40,15 +40,17 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md).
 - E-08 AiO first-pass cache ownership Contract and bounded Move queue:
   [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md).
-- First READY task after E-08d: a separate #187 E-09 runtime shutdown and cleanup
-  Contract only.
+- E-09 runtime shutdown and cleanup Contract and bounded queue:
+  [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md).
+- First READY task after E-09a merges: one cohesive #187 E-09b LIFECYCLE
+  implementation only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-08d authorizes only the separate E-09 Contract. It does not authorize E-09
-  implementation, later Phase E work, root removal, release, or Registry.
+- E-09a authorizes only E-09b after merge. E-10, root removal, release, and Registry
+  remain blocked until the E-09c completion audit.
 
 ## Current code boundary
 
@@ -101,6 +103,9 @@ aliases or absorbing feature behavior.
 - [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md):
   AiO first-pass cache state ownership, direct compatibility surfaces, cleanup
   disposition, caller boundary, and bounded Move queue.
+- [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md):
+  bootstrap terminal lifecycle, reverse cleanup order, partial-initialization
+  rollback, retained no-op resources, and the bounded E-09a/b/c queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,12 +2,12 @@
 
 ## Status and authority
 
-- Status: D-08 and E-01 through E-08 are completed;
+- Status: D-08 and E-01 through E-08 are completed; E-09a Contract is fixed;
   the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-08d:
-  `dev@5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b` after E-08c / PR #554.
-- Document baseline: completed E-08d AiO first-pass cache ownership audit.
+- E-09a Contract base:
+  `dev@4ad6bc947ba59db2df3cf5212ab07789757d7b96` after E-08d / PR #555.
+- Document baseline: E-09 runtime shutdown and cleanup Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -17,7 +17,8 @@
   E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
   ownership Contract, the E-08b owner Move, the E-08c narrow composition Move, and
-  the E-08d completion audit Contract. The next bounded phase is E-09 only.
+  the E-08d completion audit Contract, and the E-09a lifecycle Contract. The next
+  bounded implementation is E-09b only.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -437,7 +438,38 @@ behavior. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
 RuntimeServices/bootstrap composition, and E-08d completion audit. E-08d reconciles
 the single E-01 entry, feature cleanup, import direction, seven root identities, and
 the exact narrow runtime binding, and records zero ambiguous AiO cache state without
-production changes. E-08 is complete. The next READY unit after E-08d merges is a
-separate E-09 runtime shutdown and cleanup Contract. Do not start E-09 implementation,
-D-14 retirement, release, or Registry work inside E-08d.
+production changes. E-08 is complete. E-09a fixes one bootstrap-owned terminal
+lifecycle, reverse cleanup order, partial-initialization rollback, and explicit
+file-I/O/route/provider/warning no-op dispositions. The next READY unit after E-09a
+merges is the single cohesive E-09b LIFECYCLE implementation, followed by the
+production-free E-09c audit. Do not start E-10, D-14 retirement, release, or Registry
+work before E-09 completes.
 ```
+
+## 7. E-09 runtime shutdown and cleanup queue
+
+```text
+E-09a  Contract   owner/disposition/order/rollback gate        complete
+E-09b  LIFECYCLE  one cohesive terminal shutdown implementation next
+E-09c  Contract   zero-ambiguity completion audit              blocked on E-09b
+```
+
+E-09a is production-free. It selects bootstrap as the one serialized lifecycle owner,
+retains weak per-loop file-I/O limiter self-expiry and installed routes as explicit
+no-ops, removes only the callerless Artist Mix warning set in E-09b, and retains the
+Conditioning warning set for process lifetime. Cleanup order and rollback are owned by
+[`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md).
+
+E-09b is one rollback boundary rather than several Move PRs because terminal state,
+RuntimeServices close, executor admission, feature cleanup order, global detach, and
+unexpected-startup rollback share one lifecycle/concurrency invariant. E-09c changes
+no production and must reconcile `ambiguous_state_owners=[]` before the next phase.
+E-10 remains blocked, as do D-14, release, and Registry work.
+
+### E-09a validation
+
+Run changed-file JSON/Python syntax, the new lifecycle Contract, E-01/E-04/E-05/E-06/
+E-08 direct contracts, package/no-host import, current import boundary, analyzer, and
+`git diff --check`. Run official full once on the exact final candidate. Production,
+import closure, archive, metadata, and host-visible behavior do not change, so reuse
+E-08c package/live evidence unless a focused gate proves material drift.

--- a/docs/architecture/python-runtime-e09-lifecycle-contract.md
+++ b/docs/architecture/python-runtime-e09-lifecycle-contract.md
@@ -1,0 +1,160 @@
+# E-09 Runtime Shutdown and Cleanup Contract
+
+## Scope and authority
+
+E-09a is a production-free Contract created from
+`dev@4ad6bc947ba59db2df3cf5212ab07789757d7b96` after the completed E-08d
+AiO ownership audit. The executable source is
+`tests/fixtures/python_runtime_lifecycle_contract.v1.json`, checked by
+`tests/test_python_runtime_lifecycle_contract.py`.
+
+Issue #187 owns the Phase E decision ledger. The current source, direct owner tests,
+and the separate Sol/max PRO review converge on one bounded sequence:
+
+1. E-09a freezes the lifecycle Contract without production changes;
+2. E-09b implements one cohesive `LIFECYCLE` rollback boundary; and
+3. E-09c performs a production-free completion audit before E-10.
+
+Multiple Move PRs and a broader roadmap redesign are rejected. Shutdown ordering,
+partial-initialization rollback, and terminal process state are one shared concurrency
+contract and are easier to review and roll back as one implementation.
+
+## One lifecycle owner
+
+`easyuse_anima.bootstrap` owns the production lifecycle. `initialize()` and the
+canonical `shutdown()` added by E-09b share `_INITIALIZE_LOCK`. Bootstrap registers
+its shutdown with `atexit` exactly once and owns the composed translation route
+executor identity used by the root compatibility facade.
+
+The lifecycle is terminal:
+
+- `initialize(); initialize()` preserves the installed runtime identity, refreshes
+  the current route table on every call, initializes the wildcard directory once,
+  and retains the existing wildcard `OSError` retry behavior;
+- `shutdown(); shutdown()` is safe and performs cleanup at most once; and
+- `initialize()` after shutdown raises before route, wildcard, or host callbacks run.
+
+E-09b exports only `easyuse_anima.bootstrap.shutdown` beside `initialize`. Root
+`__all__`, the package entrypoint, runtime `__all__`, `install_runtime()` identity
+rules, `get_runtime()` error behavior, node/API identities, and all route signatures
+remain unchanged. The root package continues to invoke only `initialize()`; process
+shutdown is delivered through the bootstrap-owned `atexit` registration.
+
+## RuntimeServices close plan
+
+`RuntimeServices.close()` delegates to a private once-only cleanup plan. Bootstrap
+supplies the default plan while existing explicit/fake RuntimeServices construction
+remains compatible. Shutdown first marks the bootstrap terminal and detaches only
+globals that still hold the expected runtime identity. It then executes the plan in
+this fixed reverse-composition order:
+
+1. shut down translation route admission without waiting for a running worker;
+2. clear the AiO first-pass cache;
+3. clear completed wildcard snapshots;
+4. invoke the autocomplete index store's idempotent no-op `close()`;
+5. clear completed autocomplete dataset snapshots;
+6. compare-and-restore the captured translation facade only if it still names the
+   closing runtime service; and
+7. close the runtime translation service cache.
+
+Translation executor shutdown keeps its current semantics: new admission fails,
+pending futures are cancelled, shutdown does not wait, and already-running work may
+settle. AiO clear preserves enabled state and metrics. Wildcard and autocomplete
+snapshot clears do not cancel active builds, Futures, or waiter settlement. The
+autocomplete index locks remain retained. Translation flights self-remove after their
+last user settles.
+
+Seed reservations, Comfy provider, immutable config, and clock own no additional
+close operation and expire with runtime references. The provider registry/client has
+no supported close protocol, so E-09 must not invent one.
+
+## Initialization rollback
+
+Returning `False` from route registration remains nonterminal. A wildcard directory
+`OSError` remains a warning-and-retry state and retains the installed runtime.
+
+An unexpected route or wildcard exception rolls back only resources created or bound
+by that initialization attempt:
+
+- the attempt-created RuntimeServices value;
+- the attempt-installed runtime identity;
+- the attempt-published bootstrap runtime; and
+- the attempt replacement of the translation facade.
+
+Rollback uses expected-identity compare-and-restore operations, continues cleanup
+after a cleanup failure, and preserves the original startup exception. It does not
+attempt to undo directory effects, partially registered routes, pre-created
+translation route executor state, or process-global feature cache owners. E-09 stops
+instead of inventing safe route rollback or concurrent-request draining.
+
+## Explicit retained no-op boundaries
+
+### Route registration
+
+Routes and their marker remain installed. ComfyUI exposes no reviewed safe route
+deregistration contract, while current same-table idempotence, signature mismatch,
+and new-table refresh behavior are already direct-tested. Shutdown therefore performs
+no route removal and does not clear the marker.
+
+### API file-I/O limiters
+
+`easyuse_anima.api.file_io` retains its module-owned `WeakKeyDictionary` of weak
+semaphore references. Weak loop keys and weak values self-expire, and active requests
+retain their limiter until the real `asyncio.to_thread` work settles. Shutdown must
+not clear the registry, cancel work, release slots, or add the limiter to
+RuntimeServices.
+
+### Warning dedupe
+
+The callerless duplicate
+`easyuse_anima.prompt.artist_mix._SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED`
+set is removed in E-09b. The canonical set in
+`easyuse_anima.prompt.conditioning` remains process-lifetime, keeps its existing
+benign duplicate-warning race, and is not cleared or locked by shutdown.
+
+### Provider/client
+
+The translation provider registry remains lazy and process-owned. No supported
+provider/client close or reset operation has been proven. E-09 records that no-op
+instead of adding a generic client lifecycle.
+
+## Bounded implementation queue
+
+1. **E-09a Contract:** freeze owner/disposition, cleanup order, rollback, no-op,
+   compatibility, validation, and stop conditions. Production changes: zero.
+2. **E-09b LIFECYCLE:** implement the complete fixed contract in
+   `easyuse_anima/runtime.py`, `easyuse_anima/bootstrap.py`,
+   `easyuse_anima/api/routes/translation.py`,
+   `easyuse_anima/translation/service.py`,
+   `easyuse_anima/prompt/artist_mix.py`, and `__init__.py`, with only the direct
+   tests/fixtures/baseline required by actual-code gates.
+3. **E-09c Contract:** reconcile E-01, lifecycle, cleanup, import/package safety, and
+   `ambiguous_state_owners=[]` without production changes.
+
+E-10 remains blocked until E-09c merges. D-14 retirement, release, and Registry work
+remain blocked by the active roadmap.
+
+## Validation and evidence reuse
+
+E-09a edit-loop evidence is limited to changed-file JSON/Python syntax, the new
+Contract test, the existing E-01/E-04/E-05/E-06/E-08 contracts, package/no-host
+import, current import boundaries, analyzer, maintained-document links, and
+`git diff --check`.
+
+Run the official full profile once on the exact E-09a final candidate SHA. E-09a
+changes no production, import closure, archive, metadata, or host-visible behavior,
+so reuse E-08c package/live evidence unless a focused promotion gate proves material
+drift.
+
+E-09b runs its direct lifecycle/concurrency/rollback tests, official full once,
+`comfy node validate`, actual pack/archive inspection, and one isolated ComfyUI
+import/reload/shutdown smoke. A Legacy/Node 2.0 canvas matrix is not triggered by a
+backend-only process lifecycle. E-09c reuses unchanged E-09b package/live evidence.
+
+## Stop conditions
+
+Stop E-09b if implementation requires a safe route deregistration or rollback,
+immediate active-request draining, clearing/cancelling/releasing file-I/O limiters,
+provider/client close, hot shutdown-to-reinitialize, root public-surface change, or
+observed ComfyUI hot-unload behavior absent from the fixed Contract. Record the
+smallest new behavior Contract rather than broadening E-09.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -37,20 +37,20 @@ E-01 drift gate until classified.
 | Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
 | --- | --- | --- | --- |
 | `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; bootstrap installs that exact owner behind a narrow private runtime port | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08 complete; E-08d audited |
-| `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
+| `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry and no explicit close; E-09a fixes that as a no-op | retain in E-09b |
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
 | `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
 | `autocomplete-index-root` | immutable user-data index root retained by the canonical index-store owner | isolated-store injection; no mutable raw root | E-05 complete; E-05e audited |
 | `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry shared by direct/factory stores | guard plus per-path `RLock`; no clear | E-03b complete |
-| `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
+| `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; no production shutdown yet | E-09b shared serialized terminal shutdown |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
-| `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior, no package shutdown | E-09 |
+| `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior and no package shutdown yet | E-09b once-registered `atexit` shutdown |
 | `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d complete |
-| prompt warning-dedupe entries | two canonical Prompt feature modules, process lifetime | unprotected sets; direct-test clear only | E-09 |
+| prompt warning-dedupe entries | Conditioning canonical process warning set plus callerless Artist Mix duplicate | two unprotected sets today; E-09a selects retain/remove dispositions | E-09b |
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
-| `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
+| `root-route-registration` | injected router registrar called by bootstrap | serialized refresh, idempotent marker, and no deregistration; E-09a fixes that as a no-op | retain in E-09b |
 | `root-translation-route-worker` | bootstrap composes the lazy single-thread executor; root retains its compatibility reference | internal `RLock`; idempotent `atexit` shutdown only | E-04d complete |
-| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete/wildcard capabilities | bootstrap-serialized install; private-global test reset, no whole-runtime close | E-09 |
+| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete/wildcard capabilities | bootstrap-serialized install; private-global test reset and no close yet | E-09b private once-only close plan |
 | `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; idempotent service close clears cache | E-04c complete |
 | `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
 | `wildcard-snapshot-cache` | canonical private default snapshot-store owner, directly injected through the narrow runtime port | one owned `Condition`; completed-cache-only `clear()` preserves active builds | E-06 complete; E-06e audited |
@@ -195,3 +195,20 @@ preserves package/no-host safety, feature import direction, all seven root ident
 and the narrow runtime binding, and records zero ambiguous AiO cache state. E-08 is
 complete. The next bounded unit is a separate E-09 runtime shutdown and cleanup
 Contract.
+
+## E-09 Contract result
+
+The production-free
+[`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md)
+selects bootstrap as the one serialized lifecycle owner and fixes a terminal,
+idempotent shutdown plus bounded unexpected-initialization rollback. The reverse
+cleanup plan closes translation route admission, then AiO, wildcard, autocomplete,
+translation-facade, and translation-service resources using their existing feature
+semantics. It does not clear weak API file-I/O limiters, deregister routes, close an
+unproven provider/client, drain running work, or create a hot reinitialize contract.
+
+The callerless Artist Mix warning set is the only state selected for removal; the
+Conditioning warning set remains process-lifetime. The bounded queue is E-09a
+Contract, one cohesive E-09b LIFECYCLE implementation, and E-09c production-free
+completion audit. E-10 remains blocked until that audit records zero ambiguous
+owners.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -34,6 +34,8 @@ Read only the sections needed by the active task.
      [`../architecture/python-runtime-e06-wildcard-contract.md`](../architecture/python-runtime-e06-wildcard-contract.md)
    - E-08 AiO first-pass cache ownership Contract:
      [`../architecture/python-runtime-e08-aio-cache-contract.md`](../architecture/python-runtime-e08-aio-cache-contract.md)
+   - E-09 runtime shutdown and cleanup Contract:
+     [`../architecture/python-runtime-e09-lifecycle-contract.md`](../architecture/python-runtime-e09-lifecycle-contract.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -56,21 +58,22 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-08d: E-08c / PR #554 at
-  `5ede3b0e34f8b83c5aaae70bd843e3c58fa9ed1b`.
+- E-09a Contract base: E-08d / PR #555 at
+  `4ad6bc947ba59db2df3cf5212ab07789757d7b96`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-08 are complete. The next work is only a separate #187 E-09 runtime
-  shutdown and cleanup Contract. The #323
+- E-01 through E-08 are complete. E-09a fixes the runtime shutdown and cleanup
+  Contract; after it merges, the next work is only the single cohesive E-09b
+  LIFECYCLE implementation. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root compatibility aliases or start E-09 implementation, E-10,
-  release, or Registry work from this entrypoint.
+- Do not remove root compatibility aliases or start E-10, release, or Registry work
+  before the E-09c completion audit.
 
 ## Completed D-08 composition audit surface
 

--- a/tests/fixtures/python_runtime_lifecycle_contract.v1.json
+++ b/tests/fixtures/python_runtime_lifecycle_contract.v1.json
@@ -1,0 +1,250 @@
+{
+  "base_sha": "4ad6bc947ba59db2df3cf5212ab07789757d7b96",
+  "classification": "Contract",
+  "production_changes": 0,
+  "cleanup_order": [
+    {
+      "action": "shutdown",
+      "disposition": "Close admission, cancel pending futures, do not wait for running work, and allow running work to settle.",
+      "e01_entry": "root-translation-route-worker",
+      "id": "translation-route-executor",
+      "owner": "easyuse_anima.api.routes.translation_execution.PromptTranslationRouteExecutor"
+    },
+    {
+      "action": "clear",
+      "disposition": "Advance generation and clear entries/order while preserving enabled state and metrics.",
+      "e01_entry": "aio-first-pass-cache",
+      "id": "aio-first-pass-cache",
+      "owner": "easyuse_anima.aio.first_pass_cache._DEFAULT_AIO_FIRST_PASS_CACHE"
+    },
+    {
+      "action": "clear",
+      "disposition": "Clear completed snapshots without cancelling active builds or waiter settlement.",
+      "e01_entry": "wildcard-snapshot-cache",
+      "id": "wildcard-snapshot-cache",
+      "owner": "easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS"
+    },
+    {
+      "action": "close",
+      "disposition": "Idempotent no-op; retained normalized-path locks remain process-lifetime.",
+      "e01_entry": "autocomplete-index-locks",
+      "id": "autocomplete-index-store",
+      "owner": "easyuse_anima.autocomplete.index._DEFAULT_AUTOCOMPLETE_INDEX_STORE"
+    },
+    {
+      "action": "clear",
+      "disposition": "Clear completed snapshots without cancelling or removing in-flight Futures.",
+      "e01_entry": "autocomplete-dataset-cache",
+      "id": "autocomplete-snapshot-store",
+      "owner": "easyuse_anima.autocomplete.dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS"
+    },
+    {
+      "action": "compare-and-restore",
+      "disposition": "Restore the captured prior translation facade only when the facade still names the closing runtime service.",
+      "e01_entry": "translation-default-service",
+      "id": "translation-default-facade",
+      "owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE"
+    },
+    {
+      "action": "close",
+      "disposition": "Clear the runtime translation cache after the facade is detached; active flights self-remove on settlement.",
+      "e01_entry": "translation-default-service",
+      "id": "translation-service-cache",
+      "owner": "easyuse_anima.runtime.RuntimeServices.translation"
+    }
+  ],
+  "current_state": {
+    "bootstrap_exports": [
+      "initialize"
+    ],
+    "bootstrap_has_shutdown": false,
+    "package_entry_calls": "easyuse_anima.bootstrap.initialize",
+    "runtime_services_has_close": false,
+    "translation_worker_registers_own_atexit": true
+  },
+  "e01_pending_dispositions": [
+    {
+      "decision": "retain-module-owner-self-expiring",
+      "id": "api-file-io-limiters"
+    },
+    {
+      "decision": "bootstrap-terminal-lifecycle",
+      "id": "bootstrap-initialize-state"
+    },
+    {
+      "decision": "retain-root-import-initialize-with-bootstrap-atexit-shutdown",
+      "id": "package-bootstrap-effect"
+    },
+    {
+      "decision": "remove-callerless-duplicate",
+      "id": "prompt-artist-mix-warning-dedupe"
+    },
+    {
+      "decision": "retain-process-lifetime-no-op",
+      "id": "prompt-conditioning-warning-dedupe"
+    },
+    {
+      "decision": "retain-installed-routes-no-deregistration",
+      "id": "root-route-registration"
+    },
+    {
+      "decision": "runtime-services-private-once-only-close-plan",
+      "id": "runtime-services"
+    }
+  ],
+  "evidence": [
+    "__init__.py",
+    "easyuse_anima/runtime.py",
+    "easyuse_anima/bootstrap.py",
+    "easyuse_anima/api/file_io.py",
+    "easyuse_anima/api/router.py",
+    "easyuse_anima/api/routes/translation.py",
+    "easyuse_anima/api/routes/translation_execution.py",
+    "easyuse_anima/translation/service.py",
+    "easyuse_anima/autocomplete/dataset.py",
+    "easyuse_anima/autocomplete/index.py",
+    "easyuse_anima/wildcard/snapshot.py",
+    "easyuse_anima/aio/first_pass_cache.py",
+    "easyuse_anima/prompt/artist_mix.py",
+    "easyuse_anima/prompt/conditioning.py",
+    "tests/test_runtime_services.py",
+    "tests/test_python_bootstrap.py",
+    "tests/test_api_contract.py",
+    "tests/test_prompt_translation_api.py",
+    "tests/test_prompt_corrector.py",
+    "tests/test_python_package_skeleton.py"
+  ],
+  "implementation_boundary": {
+    "allowed_production": [
+      "easyuse_anima/runtime.py",
+      "easyuse_anima/bootstrap.py",
+      "easyuse_anima/api/routes/translation.py",
+      "easyuse_anima/translation/service.py",
+      "easyuse_anima/prompt/artist_mix.py",
+      "__init__.py"
+    ],
+    "forbidden": [
+      "active-request-drain",
+      "file-io-limiter-clear-cancel-release",
+      "hot-shutdown-reinitialize",
+      "provider-client-close",
+      "root-public-export-change",
+      "route-deregistration",
+      "route-side-effect-rollback"
+    ]
+  },
+  "lifecycle_owner": {
+    "atexit_registration": "bootstrap-owned-once",
+    "expected_identity_detach": [
+      "easyuse_anima.bootstrap._DEFAULT_RUNTIME",
+      "easyuse_anima.runtime._RUNTIME_SERVICES"
+    ],
+    "initialize_after_shutdown": "raise-before-callbacks",
+    "module": "easyuse_anima/bootstrap.py",
+    "package_shutdown": "atexit-only",
+    "runtime_close": "RuntimeServices.close delegates to a private once-only cleanup plan",
+    "serialization": "initialize and shutdown share _INITIALIZE_LOCK",
+    "shutdown_idempotence": "shutdown/shutdown is safe",
+    "shutdown_state": "terminal"
+  },
+  "preserved_initialize": {
+    "initialize_initialize": "same runtime identity and route refresh on every call",
+    "route_false": "nonterminal and retryable",
+    "unexpected_exception": "rollback only attempt-created or attempt-bound resources and preserve the startup exception",
+    "wildcard_oserror": "warn, retain runtime, and retry wildcard initialization later",
+    "wildcard_success": "initialize once"
+  },
+  "public_surface": {
+    "bootstrap_all_after_e09b": [
+      "initialize",
+      "shutdown"
+    ],
+    "root_all_unchanged": [
+      "NODE_CLASS_MAPPINGS",
+      "NODE_DISPLAY_NAME_MAPPINGS",
+      "WEB_DIRECTORY"
+    ],
+    "runtime_all_unchanged": [
+      "Clock",
+      "RuntimeConfig",
+      "RuntimeResource",
+      "RuntimeServices",
+      "get_runtime",
+      "install_runtime"
+    ]
+  },
+  "retained_noops": [
+    {
+      "id": "api-file-io-limiters",
+      "reason": "Weak loop keys and weak semaphore values self-expire; active calls retain their limiter until real work settles."
+    },
+    {
+      "id": "prompt-conditioning-warning-dedupe",
+      "reason": "The canonical warning-once set is process-lifetime and accepts the existing benign duplicate-warning race."
+    },
+    {
+      "id": "root-route-registration",
+      "reason": "ComfyUI exposes no proven safe deregistration contract; route markers and definitions stay installed."
+    },
+    {
+      "id": "translation-provider-registry",
+      "reason": "The optional provider/client contract exposes no supported close operation."
+    }
+  ],
+  "rollback_contract": {
+    "continue_cleanup": true,
+    "non_rollback": [
+      "directories",
+      "global-feature-cache-owners",
+      "pre-created-translation-route-executor",
+      "registered-route-side-effects"
+    ],
+    "preserve_startup_exception": true,
+    "rollback_only": [
+      "attempt-created-runtime-services",
+      "attempt-installed-runtime-identity",
+      "attempt-published-bootstrap-runtime",
+      "attempt-replaced-translation-facade"
+    ],
+    "triggers": [
+      "unexpected-register-routes-exception",
+      "unexpected-wildcard-initializer-exception"
+    ]
+  },
+  "schema_version": 1,
+  "scope": "E-09 runtime shutdown and cleanup lifecycle Contract",
+  "sequence": [
+    {
+      "classification": "Contract",
+      "goal": "Freeze lifecycle ownership, cleanup dispositions and order, rollback, no-op boundaries, compatibility, and promotion gates.",
+      "id": "E-09a",
+      "status": "complete"
+    },
+    {
+      "classification": "LIFECYCLE",
+      "goal": "Implement the fixed terminal/idempotent bootstrap and RuntimeServices cleanup contract in one cohesive rollback boundary.",
+      "id": "E-09b",
+      "status": "ready"
+    },
+    {
+      "classification": "Contract",
+      "goal": "Reconcile the implemented lifecycle with E-01 and record zero ambiguous owners before E-10.",
+      "id": "E-09c",
+      "status": "blocked-on-E-09b"
+    }
+  ],
+  "warning_dedupe": [
+    {
+      "action": "remove",
+      "id": "prompt-artist-mix-warning-dedupe",
+      "module": "easyuse_anima/prompt/artist_mix.py",
+      "reason": "The duplicate set has no production caller."
+    },
+    {
+      "action": "retain-process-lifetime",
+      "id": "prompt-conditioning-warning-dedupe",
+      "module": "easyuse_anima/prompt/conditioning.py",
+      "reason": "The canonical warning helper owns membership and warning dispatch."
+    }
+  ]
+}

--- a/tests/test_python_runtime_lifecycle_contract.py
+++ b/tests/test_python_runtime_lifecycle_contract.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "python_runtime_lifecycle_contract.v1.json"
+)
+E01_FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_runtime_state_ownership.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-runtime-e09-lifecycle-contract.md"
+)
+ROADMAP = ROOT / "docs" / "architecture" / "backend-roadmap-resume-0.6.2.md"
+
+
+@lru_cache(maxsize=None)
+def _tree(module: str) -> ast.Module:
+    path = ROOT / module
+    return ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+
+
+def _top_level_function_names(module: str) -> set[str]:
+    return {
+        statement.name
+        for statement in _tree(module).body
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _class_method_names(module: str, class_name: str) -> set[str]:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == class_name:
+            return {
+                member.name
+                for member in statement.body
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+    raise AssertionError(f"{module} has no class {class_name}")
+
+
+def _assignment_value(module: str, name: str) -> ast.expr:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in statement.targets
+            ):
+                return statement.value
+        elif (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == name
+        ):
+            return statement.value
+    raise AssertionError(f"{module} has no assignment for {name}")
+
+
+def _literal_string_sequence(module: str, name: str) -> list[str]:
+    value = _assignment_value(module, name)
+    if not isinstance(value, (ast.List, ast.Tuple)):
+        raise AssertionError(f"{module}.{name} is not a literal sequence")
+    return [
+        element.value
+        for element in value.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    ]
+
+
+def _name_reference_count(module: str, name: str) -> int:
+    return sum(
+        1
+        for node in ast.walk(_tree(module))
+        if isinstance(node, ast.Name) and node.id == name
+    )
+
+
+class PythonRuntimeLifecycleContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.e01_fixture = json.loads(
+            E01_FIXTURE_PATH.read_text(encoding="utf-8")
+        )
+
+    def test_schema_sequence_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "base_sha",
+                "classification",
+                "cleanup_order",
+                "current_state",
+                "e01_pending_dispositions",
+                "evidence",
+                "implementation_boundary",
+                "lifecycle_owner",
+                "preserved_initialize",
+                "production_changes",
+                "public_surface",
+                "retained_noops",
+                "rollback_contract",
+                "schema_version",
+                "scope",
+                "sequence",
+                "warning_dedupe",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(self.fixture["classification"], "Contract")
+        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(
+            [item["id"] for item in self.fixture["sequence"]],
+            ["E-09a", "E-09b", "E-09c"],
+        )
+        self.assertEqual(
+            [item["classification"] for item in self.fixture["sequence"]],
+            ["Contract", "LIFECYCLE", "Contract"],
+        )
+        self.assertEqual(
+            [item["status"] for item in self.fixture["sequence"]],
+            ["complete", "ready", "blocked-on-E-09b"],
+        )
+        for evidence in self.fixture["evidence"]:
+            self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_e01_pending_entries_have_exact_dispositions(self):
+        expected = [
+            "api-file-io-limiters",
+            "bootstrap-initialize-state",
+            "package-bootstrap-effect",
+            "prompt-artist-mix-warning-dedupe",
+            "prompt-conditioning-warning-dedupe",
+            "root-route-registration",
+            "runtime-services",
+        ]
+        pending = [
+            entry["id"]
+            for entry in self.e01_fixture["entries"]
+            if entry["target_phase"] == "E-09"
+        ]
+        dispositions = [
+            item["id"]
+            for item in self.fixture["e01_pending_dispositions"]
+        ]
+        self.assertEqual(pending, expected)
+        self.assertEqual(dispositions, expected)
+        self.assertEqual(len(set(dispositions)), len(dispositions))
+
+    def test_cleanup_order_reconciles_completed_feature_owners(self):
+        expected_order = [
+            "translation-route-executor",
+            "aio-first-pass-cache",
+            "wildcard-snapshot-cache",
+            "autocomplete-index-store",
+            "autocomplete-snapshot-store",
+            "translation-default-facade",
+            "translation-service-cache",
+        ]
+        cleanup = self.fixture["cleanup_order"]
+        self.assertEqual([item["id"] for item in cleanup], expected_order)
+
+        entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        expected_e01 = {
+            "root-translation-route-worker",
+            "aio-first-pass-cache",
+            "wildcard-snapshot-cache",
+            "autocomplete-index-locks",
+            "autocomplete-dataset-cache",
+            "translation-default-service",
+        }
+        self.assertEqual(
+            {item["e01_entry"] for item in cleanup},
+            expected_e01,
+        )
+        for item in cleanup:
+            self.assertIn(item["e01_entry"], entries)
+            self.assertNotEqual(entries[item["e01_entry"]]["target_phase"], "E-09")
+
+    def test_current_lifecycle_gap_is_explicit_without_production_change(self):
+        current = self.fixture["current_state"]
+        bootstrap_functions = _top_level_function_names(
+            "easyuse_anima/bootstrap.py"
+        )
+        runtime_methods = _class_method_names(
+            "easyuse_anima/runtime.py",
+            "RuntimeServices",
+        )
+        self.assertEqual(
+            "shutdown" in bootstrap_functions,
+            current["bootstrap_has_shutdown"],
+        )
+        self.assertEqual(
+            "close" in runtime_methods,
+            current["runtime_services_has_close"],
+        )
+        self.assertEqual(
+            _literal_string_sequence("easyuse_anima/bootstrap.py", "__all__"),
+            current["bootstrap_exports"],
+        )
+
+        translation_factory = (
+            ROOT / "easyuse_anima" / "api" / "routes" / "translation.py"
+        ).read_text(encoding="utf-8")
+        bootstrap_source = (
+            ROOT / "easyuse_anima" / "bootstrap.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("register_shutdown(worker.shutdown)", translation_factory)
+        self.assertIn("register_shutdown=atexit.register", bootstrap_source)
+        package_source = (ROOT / "__init__.py").read_text(encoding="utf-8")
+        self.assertEqual(
+            current["package_entry_calls"],
+            "easyuse_anima.bootstrap.initialize",
+        )
+        self.assertIn("_initialize(", package_source)
+        self.assertTrue(current["translation_worker_registers_own_atexit"])
+
+    def test_target_lifecycle_is_terminal_serialized_and_compatible(self):
+        lifecycle = self.fixture["lifecycle_owner"]
+        self.assertEqual(lifecycle["module"], "easyuse_anima/bootstrap.py")
+        self.assertEqual(
+            lifecycle["serialization"],
+            "initialize and shutdown share _INITIALIZE_LOCK",
+        )
+        self.assertEqual(lifecycle["shutdown_state"], "terminal")
+        self.assertEqual(
+            lifecycle["initialize_after_shutdown"],
+            "raise-before-callbacks",
+        )
+        self.assertEqual(
+            lifecycle["atexit_registration"],
+            "bootstrap-owned-once",
+        )
+        self.assertEqual(
+            lifecycle["expected_identity_detach"],
+            [
+                "easyuse_anima.bootstrap._DEFAULT_RUNTIME",
+                "easyuse_anima.runtime._RUNTIME_SERVICES",
+            ],
+        )
+        self.assertEqual(
+            self.fixture["public_surface"]["bootstrap_all_after_e09b"],
+            ["initialize", "shutdown"],
+        )
+        self.assertEqual(
+            self.fixture["public_surface"]["root_all_unchanged"],
+            _literal_string_sequence("__init__.py", "__all__"),
+        )
+        self.assertEqual(
+            self.fixture["public_surface"]["runtime_all_unchanged"],
+            _literal_string_sequence("easyuse_anima/runtime.py", "__all__"),
+        )
+        boundary = self.fixture["implementation_boundary"]
+        self.assertEqual(
+            boundary["allowed_production"],
+            [
+                "easyuse_anima/runtime.py",
+                "easyuse_anima/bootstrap.py",
+                "easyuse_anima/api/routes/translation.py",
+                "easyuse_anima/translation/service.py",
+                "easyuse_anima/prompt/artist_mix.py",
+                "__init__.py",
+            ],
+        )
+        self.assertEqual(
+            set(boundary["forbidden"]),
+            {
+                "active-request-drain",
+                "file-io-limiter-clear-cancel-release",
+                "hot-shutdown-reinitialize",
+                "provider-client-close",
+                "root-public-export-change",
+                "route-deregistration",
+                "route-side-effect-rollback",
+            },
+        )
+
+    def test_initialize_retry_and_rollback_contracts_are_bounded(self):
+        preserved = self.fixture["preserved_initialize"]
+        self.assertEqual(
+            preserved["route_false"],
+            "nonterminal and retryable",
+        )
+        self.assertEqual(
+            preserved["wildcard_oserror"],
+            "warn, retain runtime, and retry wildcard initialization later",
+        )
+        self.assertEqual(preserved["wildcard_success"], "initialize once")
+
+        rollback = self.fixture["rollback_contract"]
+        self.assertTrue(rollback["continue_cleanup"])
+        self.assertTrue(rollback["preserve_startup_exception"])
+        self.assertEqual(
+            rollback["triggers"],
+            [
+                "unexpected-register-routes-exception",
+                "unexpected-wildcard-initializer-exception",
+            ],
+        )
+        self.assertEqual(
+            set(rollback["rollback_only"]),
+            {
+                "attempt-created-runtime-services",
+                "attempt-installed-runtime-identity",
+                "attempt-published-bootstrap-runtime",
+                "attempt-replaced-translation-facade",
+            },
+        )
+        self.assertEqual(
+            set(rollback["non_rollback"]),
+            {
+                "directories",
+                "global-feature-cache-owners",
+                "pre-created-translation-route-executor",
+                "registered-route-side-effects",
+            },
+        )
+
+    def test_file_io_routes_and_provider_are_explicit_noops(self):
+        retained = {
+            item["id"]: item for item in self.fixture["retained_noops"]
+        }
+        self.assertEqual(
+            set(retained),
+            {
+                "api-file-io-limiters",
+                "prompt-conditioning-warning-dedupe",
+                "root-route-registration",
+                "translation-provider-registry",
+            },
+        )
+
+        file_io = (
+            ROOT / "easyuse_anima" / "api" / "file_io.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("weakref.WeakKeyDictionary", file_io)
+        self.assertIn("weakref.ref(limiter)", file_io)
+        self.assertIn("asyncio.Semaphore", file_io)
+        self.assertIn("asyncio.to_thread", file_io)
+
+        router = (
+            ROOT / "easyuse_anima" / "api" / "router.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("deregister", router)
+        self.assertNotIn("remove_route", router)
+        self.assertIn("ROUTE_REGISTRATION_MARKER", router)
+
+    def test_warning_dedupe_partition_matches_current_callers(self):
+        name = "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
+        warning_decisions = {
+            item["id"]: item for item in self.fixture["warning_dedupe"]
+        }
+        self.assertEqual(
+            warning_decisions["prompt-artist-mix-warning-dedupe"]["action"],
+            "remove",
+        )
+        self.assertEqual(
+            warning_decisions["prompt-conditioning-warning-dedupe"]["action"],
+            "retain-process-lifetime",
+        )
+        self.assertEqual(
+            _name_reference_count("easyuse_anima/prompt/artist_mix.py", name),
+            1,
+        )
+        self.assertGreaterEqual(
+            _name_reference_count("easyuse_anima/prompt/conditioning.py", name),
+            3,
+        )
+
+    def test_current_feature_cleanup_methods_support_the_plan(self):
+        required = {
+            ("easyuse_anima/api/routes/translation_execution.py", "PromptTranslationRouteExecutor"): "shutdown",
+            ("easyuse_anima/aio/first_pass_cache.py", "_AIOFirstPassCacheStore"): "clear",
+            ("easyuse_anima/wildcard/snapshot.py", "_WildcardSnapshotStore"): "clear",
+            ("easyuse_anima/autocomplete/index.py", "_AutocompleteIndexStore"): "close",
+            ("easyuse_anima/autocomplete/dataset.py", "_AutocompleteSnapshotStore"): "clear",
+            ("easyuse_anima/translation/service.py", "PromptTranslationService"): "close",
+        }
+        for (module, class_name), method in required.items():
+            with self.subTest(module=module, class_name=class_name):
+                self.assertIn(method, _class_method_names(module, class_name))
+
+    def test_contract_document_and_roadmap_queue_are_linked(self):
+        self.assertTrue(CONTRACT_DOC.is_file())
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        roadmap = ROADMAP.read_text(encoding="utf-8")
+        self.assertIn(CONTRACT_DOC.name, architecture_entry)
+        self.assertIn(
+            f"../architecture/{CONTRACT_DOC.name}",
+            development_entry,
+        )
+        for task_id in ("E-09a", "E-09b", "E-09c"):
+            self.assertIn(task_id, roadmap)
+        self.assertIn("E-10 remains blocked", roadmap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187의 E-09a production-free Contract를 고정합니다. bootstrap terminal lifecycle, RuntimeServices once-only close plan, reverse cleanup order, unexpected initialization rollback, retained no-op resource를 executable fixture와 직접 테스트로 기록합니다.

- Base → Head: `4ad6bc947ba59db2df3cf5212ab07789757d7b96` → `ee7d505fba67a31b87a957ba8cf21568f8781fc9`
- Primary class: `CONTRACT`
- Production changes: 0
- Roadmap 변경: `E-09a Contract → E-09b 단일 LIFECYCLE → E-09c completion audit`
- 여러 Move PR이나 broader roadmap redesign은 필요하지 않다는 PRO 결정을 반영했습니다.

## 주요 파일과 보존 계약

- `docs/architecture/python-runtime-e09-lifecycle-contract.md`
- `tests/fixtures/python_runtime_lifecycle_contract.v1.json`
- `tests/test_python_runtime_lifecycle_contract.py`
- current runtime inventory, resume roadmap, architecture/development indexes

보존:

- repeated initialize runtime identity, route refresh, wildcard once/OSError retry
- route signature/marker 및 deregistration no-op
- weak per-loop file-I/O limiter self-expiry
- translation admission/timeout/cancellation 및 기존 feature cleanup
- root/runtime/package/import public surface

## 검증

Focused:

- E-09a Contract 10
- E-01 ownership 5
- E-04 translation 7
- E-05 autocomplete 10
- E-06 wildcard 10
- E-08 AiO 10
- package/no-host import 1
- import boundary 16
- analyzer 18
- changed-file Python/JSON syntax, fatal Ruff, `git diff --check`

Full:

- exact `ee7d505f`에서 official full 정확히 1회
- Python 1,407 / frontend 120 / Pyright ratchet / import boundary 11 groups, 0 violations

Package/live:

- production/import/archive/metadata/host-visible 변경이 없어 retrigger하지 않음
- E-08c validate/pack/isolated-live evidence 재사용

## 위험과 rollback

이 PR의 rollback 경계는 fixture/test/docs 7개뿐입니다. E-09b는 safe route rollback, active-request drain, provider close, file-I/O limiter cleanup, hot shutdown→reinitialize, root-public change가 필요하면 중단합니다.

## Next

병합 후 E-09b one cohesive LIFECYCLE PR만 진행합니다. E-10, D-14, release, Registry는 E-09c 전까지 시작하지 않습니다.

Refs #187