### PR TITLE
E-09b: terminal runtime lifecycle 및 cleanup 구현

### DIFF
--- a/easyuse_anima/api/routes/translation.py
+++ b/easyuse_anima/api/routes/translation.py
@@ -9,7 +9,6 @@ def build_translation_runtime(
     busy_error_type,
     cancelled_error_type,
     timeout_error_type,
-    register_shutdown,
     translate_prompt_markers,
     resolve_prompt_translation_settings,
     get_worker,
@@ -24,7 +23,6 @@ def build_translation_runtime(
         cancelled_error_type=cancelled_error_type,
         timeout_error_type=timeout_error_type,
     )
-    register_shutdown(worker.shutdown)
 
     def _translate_prompt_sync(text: str) -> str:
         return translate_prompt_markers(

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -55,17 +55,25 @@ from .autocomplete.dataset import _DEFAULT_AUTOCOMPLETE_SNAPSHOTS
 from .autocomplete.index import _DEFAULT_AUTOCOMPLETE_INDEX_STORE
 from .autocomplete.service import _AutocompleteService
 from .infrastructure.comfy.provider import DefaultComfyHostProvider
-from .runtime import RuntimeConfig, RuntimeServices, install_runtime
+from .runtime import (
+    RuntimeConfig,
+    RuntimeServices,
+    _RuntimeCleanupPlan,
+    _detach_runtime,
+    install_runtime,
+)
 from .seed.service import InMemorySeedReservationService
 from .translation.contracts import (
     TranslationBusyError,
     TranslationCancelledError,
     TranslationTimeoutError,
 )
+from .translation.ports import PromptTranslationPort
 from .translation.service import (
     BoundedTranslationCache,
     PromptTranslationService,
     _install_default_translation_service,
+    _restore_default_translation_service,
 )
 from .wildcard.snapshot import _DEFAULT_WILDCARD_SNAPSHOTS
 
@@ -73,6 +81,9 @@ _LOGGER = logging.getLogger("ComfyUI-EasyUseAnima")
 _INITIALIZE_LOCK = threading.Lock()
 _WILDCARDS_INITIALIZED = False
 _DEFAULT_RUNTIME: RuntimeServices | None = None
+_TRANSLATION_ROUTE_EXECUTOR: _PromptTranslationRouteExecutor | None = None
+_ATEXIT_REGISTERED = False
+_SHUTDOWN = False
 
 
 class _SystemClock:
@@ -155,12 +166,13 @@ def build_translation_route_runtime(
 ):
     """Compose one translation route executor and its process cleanup."""
 
-    return _build_translation_runtime(
+    global _TRANSLATION_ROUTE_EXECUTOR
+
+    runtime = _build_translation_runtime(
         executor_type=_PromptTranslationRouteExecutor,
         busy_error_type=TranslationBusyError,
         cancelled_error_type=TranslationCancelledError,
         timeout_error_type=TranslationTimeoutError,
-        register_shutdown=atexit.register,
         translate_prompt_markers=translate_prompt_markers,
         resolve_prompt_translation_settings=resolve_prompt_translation_settings,
         get_worker=get_worker,
@@ -168,6 +180,8 @@ def build_translation_route_runtime(
         get_timeout_seconds=get_timeout_seconds,
         error_response=error_response,
     )
+    _TRANSLATION_ROUTE_EXECUTOR = runtime[0]
+    return runtime
 
 
 def build_aio_torch_compile_route_handler(
@@ -243,46 +257,147 @@ def initialize(
 ) -> None:
     """Initialize routes and the default wildcard root without duplicate work."""
 
-    global _DEFAULT_RUNTIME, _WILDCARDS_INITIALIZED
+    global _ATEXIT_REGISTERED, _DEFAULT_RUNTIME, _WILDCARDS_INITIALIZED
     with _INITIALIZE_LOCK:
+        if _SHUTDOWN:
+            raise RuntimeError(
+                "[EasyUseAnima] RuntimeServices has already been shut down."
+            )
+        if not _ATEXIT_REGISTERED:
+            atexit.register(shutdown)
+            _ATEXIT_REGISTERED = True
+
         runtime = _DEFAULT_RUNTIME
-        if runtime is None:
-            clock = _SystemClock()
-            runtime = RuntimeServices(
-                comfy=DefaultComfyHostProvider(load_comfy_nodes),
-                seed_reservations=InMemorySeedReservationService(),
-                config=_load_runtime_config(),
-                clock=clock,
-                translation=PromptTranslationService(
+        created_runtime = runtime is None
+        previous_translation = None
+        previous_translation_holder: list[
+            PromptTranslationPort | None
+        ] | None = None
+        translation_bound = False
+        try:
+            if runtime is None:
+                clock = _SystemClock()
+                translation = PromptTranslationService(
                     cache=BoundedTranslationCache(
                         time_func=clock.monotonic,
                     )
-                ),
-                autocomplete=_AutocompleteService(
+                )
+                autocomplete = _AutocompleteService(
                     snapshots=_DEFAULT_AUTOCOMPLETE_SNAPSHOTS,
                     index_store=_DEFAULT_AUTOCOMPLETE_INDEX_STORE,
-                ),
-                wildcard_snapshots=_DEFAULT_WILDCARD_SNAPSHOTS,
-                aio_first_pass_cache=_DEFAULT_AIO_FIRST_PASS_CACHE,
-            )
+                )
+                previous_translation_holder = [None]
+
+                def restore_translation_facade() -> None:
+                    previous = previous_translation_holder[0]
+                    if previous is not None:
+                        _restore_default_translation_service(
+                            translation,
+                            previous,
+                        )
+
+                cleanup_callbacks = []
+                if _TRANSLATION_ROUTE_EXECUTOR is not None:
+                    cleanup_callbacks.append(
+                        _TRANSLATION_ROUTE_EXECUTOR.shutdown
+                    )
+                cleanup_callbacks.extend(
+                    (
+                        _DEFAULT_AIO_FIRST_PASS_CACHE.clear,
+                        _DEFAULT_WILDCARD_SNAPSHOTS.clear,
+                        _DEFAULT_AUTOCOMPLETE_INDEX_STORE.close,
+                        _DEFAULT_AUTOCOMPLETE_SNAPSHOTS.clear,
+                        restore_translation_facade,
+                        translation.close,
+                    )
+                )
+                runtime = RuntimeServices(
+                    comfy=DefaultComfyHostProvider(load_comfy_nodes),
+                    seed_reservations=InMemorySeedReservationService(),
+                    config=_load_runtime_config(),
+                    clock=clock,
+                    translation=translation,
+                    autocomplete=autocomplete,
+                    wildcard_snapshots=_DEFAULT_WILDCARD_SNAPSHOTS,
+                    aio_first_pass_cache=_DEFAULT_AIO_FIRST_PASS_CACHE,
+                    _cleanup_plan=_RuntimeCleanupPlan(
+                        tuple(cleanup_callbacks)
+                    ),
+                )
             install_runtime(runtime)
-            _install_default_translation_service(runtime.translation)
+            previous_translation = _install_default_translation_service(
+                runtime.translation
+            )
+            translation_bound = True
+            if previous_translation_holder is not None:
+                previous_translation_holder[0] = previous_translation
             _DEFAULT_RUNTIME = runtime
-        else:
-            install_runtime(runtime)
-            _install_default_translation_service(runtime.translation)
-        register_routes()
-        if _WILDCARDS_INITIALIZED:
-            return
-        try:
-            initialize_wildcards()
-        except OSError as exc:
-            _LOGGER.warning(
-                "EasyUse Anima wildcard folder could not be initialized: %s",
-                exc,
-            )
-            return
-        _WILDCARDS_INITIALIZED = True
+            register_routes()
+            if _WILDCARDS_INITIALIZED:
+                return
+            try:
+                initialize_wildcards()
+            except OSError as exc:
+                _LOGGER.warning(
+                    "EasyUse Anima wildcard folder could not be initialized: %s",
+                    exc,
+                )
+                return
+            _WILDCARDS_INITIALIZED = True
+        except BaseException:
+            if (
+                created_runtime
+                and runtime is not None
+                and _DEFAULT_RUNTIME is runtime
+            ):
+                _DEFAULT_RUNTIME = None
+            if created_runtime and runtime is not None:
+                try:
+                    _detach_runtime(runtime)
+                except BaseException:
+                    _LOGGER.exception(
+                        "EasyUse Anima runtime detach failed during startup rollback."
+                    )
+            if (
+                translation_bound
+                and runtime is not None
+                and previous_translation is not None
+            ):
+                try:
+                    _restore_default_translation_service(
+                        runtime.translation,
+                        previous_translation,
+                    )
+                except BaseException:
+                    _LOGGER.exception(
+                        "EasyUse Anima translation facade rollback failed."
+                    )
+            if created_runtime and runtime is not None:
+                try:
+                    runtime.translation.close()
+                except BaseException:
+                    _LOGGER.exception(
+                        "EasyUse Anima translation cleanup failed during startup rollback."
+                    )
+            raise
 
 
-__all__ = ["initialize"]
+def shutdown() -> None:
+    """Terminally close the installed default runtime at most once."""
+
+    global _DEFAULT_RUNTIME, _SHUTDOWN
+
+    with _INITIALIZE_LOCK:
+        if _SHUTDOWN:
+            return
+        _SHUTDOWN = True
+        runtime = _DEFAULT_RUNTIME
+        if runtime is None:
+            return
+        if _DEFAULT_RUNTIME is runtime:
+            _DEFAULT_RUNTIME = None
+        _detach_runtime(runtime)
+        runtime.close()
+
+
+__all__ = ["initialize", "shutdown"]

--- a/easyuse_anima/prompt/artist_mix.py
+++ b/easyuse_anima/prompt/artist_mix.py
@@ -62,7 +62,6 @@ ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD = 0.25
 ARTIST_MIX_CONTROL_KEY = "anima_prompt_artist_mix_control"
 ARTIST_MIX_EXACT_KEY = "anima_prompt_artist_mix_exact"
 ARTIST_MIX_SCHEDULE_KEY = "anima_prompt_artist_mix_schedule"
-_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED: set[str] = set()
 
 ARTIST_TAG_POSITION_CORRECT = "correct"
 ARTIST_TAG_POSITION_FRONT = "front"

--- a/easyuse_anima/runtime.py
+++ b/easyuse_anima/runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
@@ -35,6 +37,36 @@ class RuntimeResource(Protocol):
     def close(self) -> None: ...
 
 
+class _RuntimeCleanupPlan:
+    """Run a fixed cleanup sequence at most once."""
+
+    __slots__ = ("_callbacks", "_closed", "_lock")
+
+    def __init__(
+        self,
+        callbacks: tuple[Callable[[], None], ...] = (),
+    ) -> None:
+        self._callbacks = callbacks
+        self._closed = False
+        self._lock = threading.Lock()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        first_error: BaseException | None = None
+        for callback in self._callbacks:
+            try:
+                callback()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeServices:
     """Process-lifetime services currently ready for composition."""
@@ -47,6 +79,16 @@ class RuntimeServices:
     autocomplete: AutocompletePort
     wildcard_snapshots: WildcardSnapshotPort
     aio_first_pass_cache: AIOFirstPassCachePort
+    _cleanup_plan: _RuntimeCleanupPlan = field(
+        default_factory=_RuntimeCleanupPlan,
+        repr=False,
+        compare=False,
+    )
+
+    def close(self) -> None:
+        """Release process-owned resources according to the composed plan."""
+
+        self._cleanup_plan.close()
 
 
 _RUNTIME_SERVICES: RuntimeServices | None = None
@@ -75,6 +117,17 @@ def get_runtime() -> RuntimeServices:
     if runtime is None:
         raise RuntimeError("[EasyUseAnima] RuntimeServices has not been installed.")
     return runtime
+
+
+def _detach_runtime(expected: RuntimeServices) -> bool:
+    """Detach only the expected process runtime identity."""
+
+    global _RUNTIME_SERVICES
+
+    if _RUNTIME_SERVICES is not expected:
+        return False
+    _RUNTIME_SERVICES = None
+    return True
 
 
 __all__ = (

--- a/easyuse_anima/translation/service.py
+++ b/easyuse_anima/translation/service.py
@@ -310,10 +310,26 @@ _DEFAULT_TRANSLATION_SERVICE: PromptTranslationPort = (
 
 def _install_default_translation_service(
     translation: PromptTranslationPort,
-) -> None:
+) -> PromptTranslationPort:
     global _DEFAULT_TRANSLATION_SERVICE
 
+    previous = _DEFAULT_TRANSLATION_SERVICE
     _DEFAULT_TRANSLATION_SERVICE = translation
+    return previous
+
+
+def _restore_default_translation_service(
+    expected: PromptTranslationPort,
+    replacement: PromptTranslationPort,
+) -> bool:
+    """Restore the facade only while it still names the expected service."""
+
+    global _DEFAULT_TRANSLATION_SERVICE
+
+    if _DEFAULT_TRANSLATION_SERVICE is not expected:
+        return False
+    _DEFAULT_TRANSLATION_SERVICE = replacement
+    return True
 
 
 def strip_prompt_translation_markers(text: str) -> str:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -17898,6 +17898,42 @@
       },
       {
         "alias": null,
+        "bound_name": "_RuntimeCleanupPlan",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".runtime:_RuntimeCleanupPlan",
+        "kind": "static_from",
+        "line": 58,
+        "name": "_RuntimeCleanupPlan",
+        "optional": false,
+        "requested": ".runtime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_detach_runtime",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".runtime:_detach_runtime",
+        "kind": "static_from",
+        "line": 58,
+        "name": "_detach_runtime",
+        "optional": false,
+        "requested": ".runtime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
         "bound_name": "install_runtime",
         "branch_context": [],
         "classification": "internal",
@@ -17923,7 +17959,7 @@
         "conditional": false,
         "imported": ".seed.service:InMemorySeedReservationService",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "InMemorySeedReservationService",
         "optional": false,
         "requested": ".seed.service",
@@ -17941,7 +17977,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationBusyError",
         "kind": "static_from",
-        "line": 60,
+        "line": 66,
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17959,7 +17995,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationCancelledError",
         "kind": "static_from",
-        "line": 60,
+        "line": 66,
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17977,7 +18013,7 @@
         "conditional": false,
         "imported": ".translation.contracts:TranslationTimeoutError",
         "kind": "static_from",
-        "line": 60,
+        "line": 66,
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".translation.contracts",
@@ -17988,6 +18024,24 @@
       },
       {
         "alias": null,
+        "bound_name": "PromptTranslationPort",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.ports:PromptTranslationPort",
+        "kind": "static_from",
+        "line": 71,
+        "name": "PromptTranslationPort",
+        "optional": false,
+        "requested": ".translation.ports",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "alias": null,
         "bound_name": "BoundedTranslationCache",
         "branch_context": [],
         "classification": "internal",
@@ -17995,7 +18049,7 @@
         "conditional": false,
         "imported": ".translation.service:BoundedTranslationCache",
         "kind": "static_from",
-        "line": 65,
+        "line": 72,
         "name": "BoundedTranslationCache",
         "optional": false,
         "requested": ".translation.service",
@@ -18013,7 +18067,7 @@
         "conditional": false,
         "imported": ".translation.service:PromptTranslationService",
         "kind": "static_from",
-        "line": 65,
+        "line": 72,
         "name": "PromptTranslationService",
         "optional": false,
         "requested": ".translation.service",
@@ -18031,8 +18085,26 @@
         "conditional": false,
         "imported": ".translation.service:_install_default_translation_service",
         "kind": "static_from",
-        "line": 65,
+        "line": 72,
         "name": "_install_default_translation_service",
+        "optional": false,
+        "requested": ".translation.service",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_restore_default_translation_service",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.service:_restore_default_translation_service",
+        "kind": "static_from",
+        "line": 72,
+        "name": "_restore_default_translation_service",
         "optional": false,
         "requested": ".translation.service",
         "role": "ordinary",
@@ -18049,7 +18121,7 @@
         "conditional": false,
         "imported": ".wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
         "kind": "static_from",
-        "line": 70,
+        "line": 78,
         "name": "_DEFAULT_WILDCARD_SNAPSHOTS",
         "optional": false,
         "requested": ".wildcard.snapshot",
@@ -18067,7 +18139,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 86,
+        "line": 97,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -18085,7 +18157,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_ROOT",
         "kind": "static_from",
-        "line": 86,
+        "line": 97,
         "name": "PACKAGE_ROOT",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -18103,7 +18175,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 86,
+        "line": 97,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -28935,7 +29007,7 @@
         "conditional": false,
         "imported": ".advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 127,
+        "line": 126,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".advanced",
@@ -28953,7 +29025,7 @@
         "conditional": false,
         "imported": ".advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 133,
+        "line": 132,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".advanced",
@@ -28971,7 +29043,7 @@
         "conditional": false,
         "imported": ".advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 139,
+        "line": 138,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".advanced",
@@ -28989,7 +29061,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 409
+            "line": 408
           }
         ],
         "classification": "external",
@@ -28997,7 +29069,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 410,
+        "line": 409,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29014,7 +29086,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 425
+            "line": 424
           }
         ],
         "classification": "external",
@@ -29022,7 +29094,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 426,
+        "line": 425,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29039,7 +29111,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 445
+            "line": 444
           }
         ],
         "classification": "external",
@@ -29047,7 +29119,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 446,
+        "line": 445,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29064,7 +29136,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 520
+            "line": 519
           }
         ],
         "classification": "external",
@@ -29072,7 +29144,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 521,
+        "line": 520,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29089,7 +29161,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1109
+            "line": 1108
           }
         ],
         "classification": "external",
@@ -29097,7 +29169,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1110,
+        "line": 1109,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -30133,6 +30205,40 @@
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
         "bound_name": "dataclass",
         "branch_context": [],
         "classification": "external",
@@ -30140,8 +30246,25 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 5,
+        "line": 7,
         "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "field",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 7,
+        "name": "field",
         "optional": false,
         "requested": "dataclasses",
         "role": "ordinary",
@@ -30157,7 +30280,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -30174,7 +30297,7 @@
         "conditional": false,
         "imported": "typing:Protocol",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "Protocol",
         "optional": false,
         "requested": "typing",
@@ -30191,7 +30314,7 @@
         "conditional": false,
         "imported": ".aio.ports:AIOFirstPassCachePort",
         "kind": "static_from",
-        "line": 9,
+        "line": 11,
         "name": "AIOFirstPassCachePort",
         "optional": false,
         "requested": ".aio.ports",
@@ -30209,7 +30332,7 @@
         "conditional": false,
         "imported": ".autocomplete.ports:AutocompletePort",
         "kind": "static_from",
-        "line": 10,
+        "line": 12,
         "name": "AutocompletePort",
         "optional": false,
         "requested": ".autocomplete.ports",
@@ -30227,7 +30350,7 @@
         "conditional": false,
         "imported": ".infrastructure.comfy.provider:ComfyHostProvider",
         "kind": "static_from",
-        "line": 11,
+        "line": 13,
         "name": "ComfyHostProvider",
         "optional": false,
         "requested": ".infrastructure.comfy.provider",
@@ -30245,7 +30368,7 @@
         "conditional": false,
         "imported": ".seed.reservation:SeedReservationService",
         "kind": "static_from",
-        "line": 12,
+        "line": 14,
         "name": "SeedReservationService",
         "optional": false,
         "requested": ".seed.reservation",
@@ -30263,7 +30386,7 @@
         "conditional": false,
         "imported": ".translation.ports:PromptTranslationPort",
         "kind": "static_from",
-        "line": 13,
+        "line": 15,
         "name": "PromptTranslationPort",
         "optional": false,
         "requested": ".translation.ports",
@@ -30281,7 +30404,7 @@
         "conditional": false,
         "imported": ".wildcard.ports:WildcardSnapshotPort",
         "kind": "static_from",
-        "line": 14,
+        "line": 16,
         "name": "WildcardSnapshotPort",
         "optional": false,
         "requested": ".wildcard.ports",
@@ -66188,6 +66311,10 @@
       },
       {
         "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "from": "easyuse_anima/bootstrap.py",
         "to": "easyuse_anima/translation/service.py"
       },
       {
@@ -69252,9 +69379,9 @@
       },
       {
         "is_package": false,
-        "loc": 85,
+        "loc": 83,
         "module": "easyuse_anima.api.routes.translation",
-        "normalized_git_blob_sha1": "7be0a07e0b07bfc7cda7cfdde00465856ba5d59d",
+        "normalized_git_blob_sha1": "cefaba9951e0f528673c90e8eb45e36e7e080ce4",
         "path": "easyuse_anima/api/routes/translation.py",
         "top_level": {
           "class_count": 0,
@@ -69372,14 +69499,14 @@
       },
       {
         "is_package": false,
-        "loc": 288,
+        "loc": 403,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "9a6d328e87f497320d5a1fb5766ee4575ef57d78",
+        "normalized_git_blob_sha1": "a78b1fa2560ccf77823ef15b732c24acd40f0472",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 11,
-          "global_count": 5
+          "function_count": 12,
+          "global_count": 8
         }
       },
       {
@@ -70020,14 +70147,14 @@
       },
       {
         "is_package": false,
-        "loc": 1497,
+        "loc": 1496,
         "module": "easyuse_anima.prompt.artist_mix",
-        "normalized_git_blob_sha1": "d6b4ba5d57c831f6ead9e94b5f595e82f502c275",
+        "normalized_git_blob_sha1": "4b87698d8c7f87066e2533e924ef7f706c2fa86c",
         "path": "easyuse_anima/prompt/artist_mix.py",
         "top_level": {
           "class_count": 0,
           "function_count": 51,
-          "global_count": 36
+          "global_count": 35
         }
       },
       {
@@ -70104,13 +70231,13 @@
       },
       {
         "is_package": false,
-        "loc": 87,
+        "loc": 140,
         "module": "easyuse_anima.runtime",
-        "normalized_git_blob_sha1": "51d8179d45d446bb2b8a8de9e1ceb891e35c35da",
+        "normalized_git_blob_sha1": "4903073ebb65b3a0117170517fc730dee1b76720",
         "path": "easyuse_anima/runtime.py",
         "top_level": {
-          "class_count": 4,
-          "function_count": 2,
+          "class_count": 5,
+          "function_count": 3,
           "global_count": 2
         }
       },
@@ -70320,13 +70447,13 @@
       },
       {
         "is_package": false,
-        "loc": 344,
+        "loc": 360,
         "module": "easyuse_anima.translation.service",
-        "normalized_git_blob_sha1": "3407db664c5d78d5d707c89b69432524ffb8ac43",
+        "normalized_git_blob_sha1": "2782f27cbd0b57dcb7d881dcd363e18c54fbd5a7",
         "path": "easyuse_anima/translation/service.py",
         "top_level": {
           "class_count": 3,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 4
         }
       },
@@ -88312,14 +88439,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 409
+            "line": 408
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 410,
+        "line": 409,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -88331,14 +88458,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 425
+            "line": 424
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 426,
+        "line": 425,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -88350,14 +88477,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 445
+            "line": 444
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 446,
+        "line": 445,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -88369,14 +88496,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 520
+            "line": 519
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 521,
+        "line": 520,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -88388,14 +88515,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1109
+            "line": 1108
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1110,
+        "line": 1109,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -88596,8 +88723,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "dataclasses:dataclass",
-        "kind": "static_from",
+        "imported": "threading",
+        "kind": "static_import",
         "line": 5,
         "optional": false,
         "role": "ordinary",
@@ -88607,7 +88734,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "pathlib:Path",
+        "imported": "collections.abc:Callable",
         "kind": "static_from",
         "line": 6,
         "optional": false,
@@ -88618,9 +88745,42 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Protocol",
+        "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 9,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/runtime.py"
@@ -90820,14 +90980,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 409
+            "line": 408
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 410,
+        "line": 409,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -90839,14 +90999,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 425
+            "line": 424
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 426,
+        "line": 425,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -90858,14 +91018,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 445
+            "line": 444
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 446,
+        "line": 445,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -90877,14 +91037,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 520
+            "line": 519
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 521,
+        "line": 520,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -90896,14 +91056,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1109
+            "line": 1108
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1110,
+        "line": 1109,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -92590,7 +92750,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 72,
+        "line": 80,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92599,7 +92759,7 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 73,
+        "line": 81,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -92982,20 +93142,11 @@
         "scope": "<module>"
       },
       {
-        "callee": "set",
-        "column": 62,
-        "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "kind": "import_time_call",
-        "line": 65,
-        "module": "easyuse_anima/prompt/artist_mix.py",
-        "scope": "<module>"
-      },
-      {
         "callee": "re.compile",
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 104,
+        "line": 103,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -93004,7 +93155,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 106,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -93013,7 +93164,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 111,
+        "line": 110,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -93058,7 +93209,7 @@
         "column": 1,
         "context": "decorator:RuntimeConfig",
         "kind": "import_time_call",
-        "line": 17,
+        "line": 19,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -93067,9 +93218,18 @@
         "column": 1,
         "context": "decorator:RuntimeServices",
         "kind": "import_time_call",
-        "line": 38,
+        "line": 70,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
+      },
+      {
+        "callee": "field",
+        "column": 41,
+        "context": "assign:_cleanup_plan",
+        "kind": "import_time_call",
+        "line": 82,
+        "module": "easyuse_anima/runtime.py",
+        "scope": "RuntimeServices"
       },
       {
         "callee": "dataclass",
@@ -93530,7 +93690,7 @@
       },
       {
         "kind": "list",
-        "line": 288,
+        "line": 403,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -93656,15 +93816,9 @@
       },
       {
         "kind": "dict",
-        "line": 75,
+        "line": 74,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
-      },
-      {
-        "kind": "set",
-        "line": 65,
-        "module": "easyuse_anima/prompt/artist_mix.py",
-        "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
       {
         "kind": "set",
@@ -93829,7 +93983,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 73,
+        "line": 81,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/fixtures/python_runtime_lifecycle_contract.v1.json
+++ b/tests/fixtures/python_runtime_lifecycle_contract.v1.json
@@ -55,12 +55,13 @@
   ],
   "current_state": {
     "bootstrap_exports": [
-      "initialize"
+      "initialize",
+      "shutdown"
     ],
-    "bootstrap_has_shutdown": false,
+    "bootstrap_has_shutdown": true,
     "package_entry_calls": "easyuse_anima.bootstrap.initialize",
-    "runtime_services_has_close": false,
-    "translation_worker_registers_own_atexit": true
+    "runtime_services_has_close": true,
+    "translation_worker_registers_own_atexit": false
   },
   "e01_pending_dispositions": [
     {
@@ -224,13 +225,13 @@
       "classification": "LIFECYCLE",
       "goal": "Implement the fixed terminal/idempotent bootstrap and RuntimeServices cleanup contract in one cohesive rollback boundary.",
       "id": "E-09b",
-      "status": "ready"
+      "status": "complete"
     },
     {
       "classification": "Contract",
       "goal": "Reconcile the implemented lifecycle with E-01 and record zero ambiguous owners before E-10.",
       "id": "E-09c",
-      "status": "blocked-on-E-09b"
+      "status": "ready"
     }
   ],
   "warning_dedupe": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -221,16 +221,16 @@
       "thread_safety": "The guard serializes registry access; per-path RLocks serialize publish operations."
     },
     {
-      "categories": ["bootstrap", "lock", "runtime_reference"],
-      "cleanup": "No production reset or shutdown; tests patch _DEFAULT_RUNTIME and _WILDCARDS_INITIALIZED.",
+      "categories": ["atexit", "bootstrap", "executor", "lock", "runtime_reference"],
+      "cleanup": "shutdown terminally detaches the expected runtime identities and executes the once-only cleanup plan; routes remain installed.",
       "id": "bootstrap-initialize-state",
-      "lifetime": "Process lifetime after first successful package initialization.",
+      "lifetime": "Process lifetime from first initialization attempt through terminal shutdown.",
       "module": "easyuse_anima/bootstrap.py",
-      "owner": "easyuse_anima.bootstrap.initialize",
-      "symbols": ["_DEFAULT_RUNTIME", "_INITIALIZE_LOCK", "_WILDCARDS_INITIALIZED", "initialize"],
+      "owner": "easyuse_anima.bootstrap lifecycle",
+      "symbols": ["_ATEXIT_REGISTERED", "_DEFAULT_RUNTIME", "_INITIALIZE_LOCK", "_SHUTDOWN", "_TRANSLATION_ROUTE_EXECUTOR", "_WILDCARDS_INITIALIZED", "initialize", "shutdown"],
       "target_phase": "E-09",
       "test_evidence": ["tests/test_python_bootstrap.py", "tests/test_runtime_services.py"],
-      "thread_safety": "One Lock serializes default config/clock composition, runtime install, route refresh, and wildcard initialization."
+      "thread_safety": "One Lock serializes composition, install, route refresh, wildcard initialization, terminal state, expected-identity detach, and cleanup."
     },
     {
       "categories": ["path_resolution", "runtime_config"],
@@ -270,15 +270,15 @@
     },
     {
       "categories": ["compatibility_warning", "dedupe_set"],
-      "cleanup": "No production reset; direct tests clear the set.",
+      "cleanup": "The callerless duplicate set was removed by E-09b; canonical warning ownership remains in prompt.conditioning.",
       "id": "prompt-artist-mix-warning-dedupe",
-      "lifetime": "Process lifetime, keyed by external patcher class.",
+      "lifetime": "Removed; no production state remains in this module.",
       "module": "easyuse_anima/prompt/artist_mix.py",
-      "owner": "easyuse_anima.prompt.artist_mix",
-      "symbols": ["_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"],
+      "owner": "removed by E-09b",
+      "symbols": [],
       "target_phase": "E-09",
       "test_evidence": ["tests/test_prompt_corrector.py"],
-      "thread_safety": "Unprotected membership/add; current execution accepts benign duplicate-warning races."
+      "thread_safety": "No remaining state."
     },
     {
       "categories": ["compatibility_warning", "dedupe_set"],
@@ -330,7 +330,7 @@
     },
     {
       "categories": ["autocomplete_port", "capability", "clock", "runtime_config", "runtime_reference", "seed_reservation_service", "translation_port"],
-      "cleanup": "No production uninstall/close; tests patch _RUNTIME_SERVICES.",
+      "cleanup": "RuntimeServices.close delegates once to the bootstrap-composed cleanup plan; expected-identity detach is private and conflict-safe.",
       "id": "runtime-services",
       "lifetime": "One identity-installed RuntimeServices object for the process, including immutable config, a monotonic clock, and narrow translation and autocomplete service ports.",
       "module": "easyuse_anima/runtime.py",
@@ -338,7 +338,7 @@
       "symbols": ["RuntimeServices", "_RUNTIME_SERVICES"],
       "target_phase": "E-09",
       "test_evidence": ["tests/test_autocomplete_service.py", "tests/test_comfy_host_wiring.py", "tests/test_runtime_services.py", "tests/test_seed_reservation_service.py"],
-      "thread_safety": "Bootstrap serializes production install; install_runtime enforces identity without a Lock."
+      "thread_safety": "Bootstrap serializes install and detach; the private cleanup plan locks its once-only transition and continues the fixed callback sequence after failures."
     },
     {
       "categories": ["cache", "lock", "service", "single_flight"],

--- a/tests/fixtures/python_translation_runtime_contract.v1.json
+++ b/tests/fixtures/python_translation_runtime_contract.v1.json
@@ -34,7 +34,7 @@
     "classification": "Contract",
     "cleanup_dispositions": [
       {
-        "feature_cleanup": "PromptTranslationRouteExecutor.shutdown is idempotent and registered once with atexit",
+        "feature_cleanup": "PromptTranslationRouteExecutor.shutdown is idempotent and invoked by the bootstrap-owned terminal cleanup plan",
         "owner": "route-executor",
         "remaining_phase": "E-09",
         "status": "feature-cleanup-complete"
@@ -126,7 +126,7 @@
   "owners": [
     {
       "cleanup": {
-        "current": "private bootstrap composition registers idempotent shutdown once with atexit while root retains the compatibility reference; package shutdown does not own it",
+        "current": "private bootstrap composition owns the executor identity and invokes idempotent shutdown from the one terminal cleanup plan while root retains the compatibility reference",
         "implemented_methods": [
           "shutdown"
         ],

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -793,7 +793,7 @@ class ApiIntegratedRouteCompositionContractTests(unittest.TestCase):
 
         api, _routes = load_api_routes(register=False)
         bootstrap = sys.modules[api._build_profile_route_group.__module__]
-        self.assertEqual(bootstrap.__all__, ["initialize"])
+        self.assertEqual(bootstrap.__all__, ["initialize", "shutdown"])
 
 
 class ApiRequestCorrelationTests(unittest.TestCase):

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -153,11 +153,10 @@ class PromptTranslationApiTests(unittest.TestCase):
         )
         self.assertIs(routes.handlers[ROUTE], api.translate_prompt_handler)
 
-    def test_runtime_builder_constructs_and_registers_one_worker(self):
+    def test_runtime_builder_constructs_one_worker_without_lifecycle_side_effect(self):
         api, _routes, _translation, _translation_service = self.load_routes()
         owner = sys.modules[api._translate_prompt_sync.__module__]
         created = []
-        registered = []
 
         class FakeExecutor:
             def __init__(
@@ -183,7 +182,6 @@ class PromptTranslationApiTests(unittest.TestCase):
             busy_error_type=api.TranslationBusyError,
             cancelled_error_type=api.TranslationCancelledError,
             timeout_error_type=api.TranslationTimeoutError,
-            register_shutdown=registered.append,
             translate_prompt_markers=lambda text, settings: text,
             resolve_prompt_translation_settings=lambda: object(),
             get_worker=lambda: runtime[0],
@@ -192,7 +190,6 @@ class PromptTranslationApiTests(unittest.TestCase):
             error_response=lambda *args: args,
         )
 
-        worker = runtime[0]
         self.assertEqual(
             created,
             [
@@ -203,9 +200,6 @@ class PromptTranslationApiTests(unittest.TestCase):
                 )
             ],
         )
-        self.assertEqual(len(registered), 1)
-        self.assertIs(registered[0].__self__, worker)
-        self.assertIs(registered[0].__func__, FakeExecutor.shutdown)
         self.assertFalse(hasattr(owner, "_PROMPT_TRANSLATION_WORKER"))
 
     def test_runtime_helpers_keep_dynamic_root_dependencies(self):

--- a/tests/test_python_bootstrap.py
+++ b/tests/test_python_bootstrap.py
@@ -5,14 +5,29 @@ import time
 import unittest
 from unittest.mock import Mock, patch
 
-from easyuse_anima import bootstrap
+from easyuse_anima import bootstrap, runtime as runtime_module
+from easyuse_anima.translation import service as translation_service
 
 
 class PythonBootstrapTests(unittest.TestCase):
     def setUp(self):
-        state = patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False)
-        state.start()
-        self.addCleanup(state.stop)
+        patchers = (
+            patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False),
+            patch.object(bootstrap, "_DEFAULT_RUNTIME", None),
+            patch.object(bootstrap, "_TRANSLATION_ROUTE_EXECUTOR", None),
+            patch.object(bootstrap, "_ATEXIT_REGISTERED", False),
+            patch.object(bootstrap, "_SHUTDOWN", False),
+            patch.object(runtime_module, "_RUNTIME_SERVICES", None),
+            patch.object(bootstrap.atexit, "register"),
+            patch.object(
+                translation_service,
+                "_DEFAULT_TRANSLATION_SERVICE",
+                translation_service.PromptTranslationService(),
+            ),
+        )
+        for state in patchers:
+            state.start()
+            self.addCleanup(state.stop)
 
     def test_repeated_initialize_keeps_routes_refreshable_and_wildcards_once(self):
         register_routes = Mock(return_value=True)
@@ -51,6 +66,24 @@ class PythonBootstrapTests(unittest.TestCase):
             "EasyUse Anima wildcard folder could not be initialized: %s",
             error,
         )
+
+    def test_route_false_is_nonterminal_and_refreshes_on_the_next_initialize(self):
+        register_routes = Mock(side_effect=(False, True))
+        initialize_wildcards = Mock(return_value=object())
+
+        bootstrap.initialize(
+            register_routes=register_routes,
+            initialize_wildcards=initialize_wildcards,
+        )
+        first = runtime_module.get_runtime()
+        bootstrap.initialize(
+            register_routes=register_routes,
+            initialize_wildcards=initialize_wildcards,
+        )
+
+        self.assertIs(runtime_module.get_runtime(), first)
+        self.assertEqual(register_routes.call_count, 2)
+        initialize_wildcards.assert_called_once_with()
 
     def test_route_failure_preserves_order_and_retries_all_startup_work(self):
         register_routes = Mock(side_effect=(RuntimeError("routes"), True))
@@ -113,6 +146,249 @@ class PythonBootstrapTests(unittest.TestCase):
         self.assertTrue(all(not thread.is_alive() for thread in threads))
         self.assertEqual(register_routes.call_count, len(threads))
         self.assertEqual(len(wildcard_calls), 1)
+
+    def test_initialize_registers_bootstrap_shutdown_once(self):
+        register_routes = Mock(return_value=True)
+        initialize_wildcards = Mock(return_value=object())
+
+        bootstrap.initialize(
+            register_routes=register_routes,
+            initialize_wildcards=initialize_wildcards,
+        )
+        bootstrap.initialize(
+            register_routes=register_routes,
+            initialize_wildcards=initialize_wildcards,
+        )
+
+        bootstrap.atexit.register.assert_called_once_with(bootstrap.shutdown)
+
+    def test_shutdown_is_idempotent_terminal_and_detaches_expected_runtime(self):
+        register_routes = Mock(return_value=True)
+        initialize_wildcards = Mock(return_value=object())
+        previous_translation = translation_service._DEFAULT_TRANSLATION_SERVICE
+        bootstrap.initialize(
+            register_routes=register_routes,
+            initialize_wildcards=initialize_wildcards,
+        )
+        runtime = runtime_module.get_runtime()
+
+        bootstrap.shutdown()
+        bootstrap.shutdown()
+
+        self.assertIsNone(bootstrap._DEFAULT_RUNTIME)
+        self.assertIs(
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+            previous_translation,
+        )
+        with self.assertRaisesRegex(RuntimeError, "has not been installed"):
+            runtime_module.get_runtime()
+        runtime.close()
+
+        register_routes.reset_mock()
+        initialize_wildcards.reset_mock()
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "RuntimeServices has already been shut down",
+        ):
+            bootstrap.initialize(
+                register_routes=register_routes,
+                initialize_wildcards=initialize_wildcards,
+            )
+        register_routes.assert_not_called()
+        initialize_wildcards.assert_not_called()
+
+    def test_shutdown_runs_the_composed_cleanup_order(self):
+        calls = []
+
+        class Resource:
+            def __init__(self, name):
+                self.name = name
+
+            def shutdown(self):
+                calls.append(self.name)
+
+            def clear(self):
+                calls.append(self.name)
+
+            def close(self):
+                calls.append(self.name)
+
+        worker = Resource("translation-route-executor")
+        aio_cache = Resource("aio-first-pass-cache")
+        wildcard_cache = Resource("wildcard-snapshot-cache")
+        autocomplete_index = Resource("autocomplete-index-store")
+        autocomplete_snapshots = Resource("autocomplete-snapshot-store")
+        translation = Resource("translation-service-cache")
+        restore = translation_service._restore_default_translation_service
+
+        def restore_facade(expected, replacement):
+            calls.append("translation-default-facade")
+            return restore(expected, replacement)
+
+        with (
+            patch.object(bootstrap, "_TRANSLATION_ROUTE_EXECUTOR", worker),
+            patch.object(bootstrap, "_DEFAULT_AIO_FIRST_PASS_CACHE", aio_cache),
+            patch.object(
+                bootstrap,
+                "_DEFAULT_WILDCARD_SNAPSHOTS",
+                wildcard_cache,
+            ),
+            patch.object(
+                bootstrap,
+                "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+                autocomplete_index,
+            ),
+            patch.object(
+                bootstrap,
+                "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
+                autocomplete_snapshots,
+            ),
+            patch.object(
+                bootstrap,
+                "PromptTranslationService",
+                return_value=translation,
+            ),
+            patch.object(
+                bootstrap,
+                "_restore_default_translation_service",
+                side_effect=restore_facade,
+            ),
+        ):
+            bootstrap.initialize(
+                register_routes=Mock(return_value=True),
+                initialize_wildcards=Mock(return_value=object()),
+            )
+            bootstrap.shutdown()
+
+        self.assertEqual(
+            calls,
+            [
+                "translation-route-executor",
+                "aio-first-pass-cache",
+                "wildcard-snapshot-cache",
+                "autocomplete-index-store",
+                "autocomplete-snapshot-store",
+                "translation-default-facade",
+                "translation-service-cache",
+            ],
+        )
+
+    def test_route_exception_rolls_back_only_attempt_created_runtime(self):
+        calls = []
+
+        class Translation:
+            def close(self):
+                calls.append("translation-close")
+
+        previous_translation = translation_service._DEFAULT_TRANSLATION_SERVICE
+        with patch.object(
+            bootstrap,
+            "PromptTranslationService",
+            return_value=Translation(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "routes"):
+                bootstrap.initialize(
+                    register_routes=Mock(side_effect=RuntimeError("routes")),
+                    initialize_wildcards=Mock(return_value=object()),
+                )
+
+        self.assertEqual(calls, ["translation-close"])
+        self.assertIsNone(bootstrap._DEFAULT_RUNTIME)
+        self.assertIs(
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+            previous_translation,
+        )
+        with self.assertRaisesRegex(RuntimeError, "has not been installed"):
+            runtime_module.get_runtime()
+
+    def test_repeated_initialize_failure_restores_only_attempt_bound_facade(self):
+        bootstrap.initialize(
+            register_routes=Mock(return_value=True),
+            initialize_wildcards=Mock(return_value=object()),
+        )
+        runtime = runtime_module.get_runtime()
+        foreign_translation = translation_service.PromptTranslationService()
+        translation_service._DEFAULT_TRANSLATION_SERVICE = foreign_translation
+
+        with (
+            patch.object(runtime.translation, "close") as close,
+            self.assertRaisesRegex(RuntimeError, "routes"),
+        ):
+            bootstrap.initialize(
+                register_routes=Mock(side_effect=RuntimeError("routes")),
+                initialize_wildcards=Mock(return_value=object()),
+            )
+
+        self.assertIs(runtime_module.get_runtime(), runtime)
+        self.assertIs(bootstrap._DEFAULT_RUNTIME, runtime)
+        self.assertIs(
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+            foreign_translation,
+        )
+        close.assert_not_called()
+
+    def test_startup_exception_survives_rollback_cleanup_failure(self):
+        startup_error = ValueError("wildcards")
+
+        class Translation:
+            def close(self):
+                raise RuntimeError("cleanup")
+
+        with (
+            patch.object(
+                bootstrap,
+                "PromptTranslationService",
+                return_value=Translation(),
+            ),
+            patch.object(bootstrap._LOGGER, "exception") as cleanup_log,
+        ):
+            with self.assertRaisesRegex(ValueError, "wildcards") as raised:
+                bootstrap.initialize(
+                    register_routes=Mock(return_value=True),
+                    initialize_wildcards=Mock(side_effect=startup_error),
+                )
+
+        self.assertIs(raised.exception, startup_error)
+        cleanup_log.assert_called_once_with(
+            "EasyUse Anima translation cleanup failed during startup rollback."
+        )
+
+    def test_shutdown_waits_for_in_progress_initialize(self):
+        entered = threading.Event()
+        release = threading.Event()
+        errors = []
+
+        def register_routes():
+            entered.set()
+            release.wait(timeout=1)
+            return True
+
+        def run_initialize():
+            try:
+                bootstrap.initialize(
+                    register_routes=register_routes,
+                    initialize_wildcards=Mock(return_value=object()),
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        initialize_thread = threading.Thread(target=run_initialize)
+        shutdown_thread = threading.Thread(target=bootstrap.shutdown)
+        initialize_thread.start()
+        self.assertTrue(entered.wait(timeout=1))
+        shutdown_thread.start()
+        time.sleep(0.01)
+
+        self.assertTrue(shutdown_thread.is_alive())
+        self.assertFalse(bootstrap._SHUTDOWN)
+        release.set()
+        initialize_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
+
+        self.assertEqual(errors, [])
+        self.assertFalse(initialize_thread.is_alive())
+        self.assertFalse(shutdown_thread.is_alive())
+        self.assertTrue(bootstrap._SHUTDOWN)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -209,7 +209,10 @@ print(json.dumps({{
         payload = json.loads(result.stdout)
         self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
         expected_all = [[] for _ in PACKAGE_MODULES]
-        expected_all[PACKAGE_MODULES.index("easyuse_anima.bootstrap")] = ["initialize"]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.bootstrap")] = [
+            "initialize",
+            "shutdown",
+        ]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.api.errors")] = [
             "ApiContractError"
         ]

--- a/tests/test_python_runtime_lifecycle_contract.py
+++ b/tests/test_python_runtime_lifecycle_contract.py
@@ -134,7 +134,7 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [item["status"] for item in self.fixture["sequence"]],
-            ["complete", "ready", "blocked-on-E-09b"],
+            ["complete", "complete", "ready"],
         )
         for evidence in self.fixture["evidence"]:
             self.assertTrue((ROOT / evidence).is_file(), evidence)
@@ -194,7 +194,7 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
             self.assertIn(item["e01_entry"], entries)
             self.assertNotEqual(entries[item["e01_entry"]]["target_phase"], "E-09")
 
-    def test_current_lifecycle_gap_is_explicit_without_production_change(self):
+    def test_current_lifecycle_matches_the_implemented_contract(self):
         current = self.fixture["current_state"]
         bootstrap_functions = _top_level_function_names(
             "easyuse_anima/bootstrap.py"
@@ -222,15 +222,15 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         bootstrap_source = (
             ROOT / "easyuse_anima" / "bootstrap.py"
         ).read_text(encoding="utf-8")
-        self.assertIn("register_shutdown(worker.shutdown)", translation_factory)
-        self.assertIn("register_shutdown=atexit.register", bootstrap_source)
+        self.assertNotIn("register_shutdown", translation_factory)
+        self.assertIn("atexit.register(shutdown)", bootstrap_source)
         package_source = (ROOT / "__init__.py").read_text(encoding="utf-8")
         self.assertEqual(
             current["package_entry_calls"],
             "easyuse_anima.bootstrap.initialize",
         )
         self.assertIn("_initialize(", package_source)
-        self.assertTrue(current["translation_worker_registers_own_atexit"])
+        self.assertFalse(current["translation_worker_registers_own_atexit"])
 
     def test_target_lifecycle_is_terminal_serialized_and_compatible(self):
         lifecycle = self.fixture["lifecycle_owner"]
@@ -377,7 +377,7 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         )
         self.assertEqual(
             _name_reference_count("easyuse_anima/prompt/artist_mix.py", name),
-            1,
+            0,
         )
         self.assertGreaterEqual(
             _name_reference_count("easyuse_anima/prompt/conditioning.py", name),

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -243,7 +243,10 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
                 "easyuse_anima/autocomplete/index.py",
                 "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
             ),
+            ("easyuse_anima/bootstrap.py", "_ATEXIT_REGISTERED"),
             ("easyuse_anima/bootstrap.py", "_DEFAULT_RUNTIME"),
+            ("easyuse_anima/bootstrap.py", "_SHUTDOWN"),
+            ("easyuse_anima/bootstrap.py", "_TRANSLATION_ROUTE_EXECUTOR"),
             ("easyuse_anima/bootstrap.py", "_WILDCARDS_INITIALIZED"),
             (
                 "easyuse_anima/infrastructure/filesystem/atomic_json.py",
@@ -256,10 +259,6 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
             (
                 "easyuse_anima/profiles/mutation.py",
                 "PROFILE_MUTATION_COORDINATOR",
-            ),
-            (
-                "easyuse_anima/prompt/artist_mix.py",
-                "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
             ),
             (
                 "easyuse_anima/prompt/conditioning.py",

--- a/tests/test_python_translation_runtime_contract.py
+++ b/tests/test_python_translation_runtime_contract.py
@@ -343,7 +343,7 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
                 "TranslationBusyError",
                 "TranslationCancelledError",
                 "TranslationTimeoutError",
-                "atexit",
+                "_TRANSLATION_ROUTE_EXECUTOR",
             }
             <= bootstrap_runtime_references
         )
@@ -411,10 +411,10 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
                 "get_worker",
                 "get_translate_prompt_sync",
                 "get_timeout_seconds",
-                "register_shutdown",
             }
             <= root_references
         )
+        self.assertNotIn("register_shutdown", root_references)
 
     def test_optional_client_stays_lazy_and_no_generic_runtime_port_exists(self):
         optional_import = self.fixture["completion_audit"]["optional_import"]

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -161,13 +161,28 @@ class RuntimeServicesTests(unittest.TestCase):
         self.runtime_state.start()
         self.default_runtime_state = patch.object(bootstrap, "_DEFAULT_RUNTIME", None)
         self.default_runtime_state.start()
+        self.shutdown_state = patch.object(bootstrap, "_SHUTDOWN", False)
+        self.shutdown_state.start()
+        self.atexit_state = patch.object(bootstrap, "_ATEXIT_REGISTERED", False)
+        self.atexit_state.start()
+        self.wildcard_state = patch.object(
+            bootstrap,
+            "_WILDCARDS_INITIALIZED",
+            False,
+        )
+        self.wildcard_state.start()
 
     def tearDown(self):
+        self.wildcard_state.stop()
+        self.atexit_state.stop()
+        self.shutdown_state.stop()
         self.default_runtime_state.stop()
         self.runtime_state.stop()
 
     @staticmethod
-    def make_runtime() -> RuntimeServices:
+    def make_runtime(
+        cleanup_plan=None,
+    ) -> RuntimeServices:
         return RuntimeServices(
             comfy=FakeComfyHostProvider(),
             seed_reservations=InMemorySeedReservationService(),
@@ -181,6 +196,11 @@ class RuntimeServicesTests(unittest.TestCase):
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
             aio_first_pass_cache=FakeAIOFirstPassCache(),
+            _cleanup_plan=(
+                cleanup_plan
+                if cleanup_plan is not None
+                else runtime_module._RuntimeCleanupPlan()
+            ),
         )
 
     def test_runtime_value_is_frozen(self):
@@ -197,6 +217,77 @@ class RuntimeServicesTests(unittest.TestCase):
             r"^\[EasyUseAnima\] RuntimeServices has not been installed\.$",
         ):
             get_runtime()
+
+    def test_close_runs_cleanup_once_in_order_and_continues_after_failure(self):
+        calls = []
+        failure = RuntimeError("cleanup")
+
+        def fail():
+            calls.append("first")
+            raise failure
+
+        runtime = self.make_runtime(
+            runtime_module._RuntimeCleanupPlan(
+                (
+                    fail,
+                    lambda: calls.append("second"),
+                    lambda: calls.append("third"),
+                )
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "cleanup") as raised:
+            runtime.close()
+        runtime.close()
+
+        self.assertIs(raised.exception, failure)
+        self.assertEqual(calls, ["first", "second", "third"])
+
+    def test_detach_runtime_compares_expected_identity(self):
+        first = self.make_runtime()
+        other = self.make_runtime()
+        install_runtime(first)
+
+        self.assertFalse(runtime_module._detach_runtime(other))
+        self.assertIs(get_runtime(), first)
+        self.assertTrue(runtime_module._detach_runtime(first))
+        with self.assertRaisesRegex(RuntimeError, "has not been installed"):
+            get_runtime()
+
+    def test_translation_facade_restore_is_expected_identity_only(self):
+        original = PromptTranslationService()
+        replacement = PromptTranslationService()
+        foreign = PromptTranslationService()
+
+        with patch.object(
+            translation_service,
+            "_DEFAULT_TRANSLATION_SERVICE",
+            original,
+        ):
+            previous = translation_service._install_default_translation_service(
+                replacement
+            )
+            self.assertIs(previous, original)
+            self.assertFalse(
+                translation_service._restore_default_translation_service(
+                    foreign,
+                    original,
+                )
+            )
+            self.assertIs(
+                translation_service._DEFAULT_TRANSLATION_SERVICE,
+                replacement,
+            )
+            self.assertTrue(
+                translation_service._restore_default_translation_service(
+                    replacement,
+                    original,
+                )
+            )
+            self.assertIs(
+                translation_service._DEFAULT_TRANSLATION_SERVICE,
+                original,
+            )
 
     def test_first_install_is_returned_and_available(self):
         runtime = self.make_runtime()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187의 E-09a Contract에 따라 E-09b LIFECYCLE만 구현합니다. Bootstrap이 하나의 serialized/terminal lifecycle과 atexit registration을 소유하고, `RuntimeServices.close()`가 고정된 once-only cleanup plan을 수행합니다.

- Base: `6152aad78046c0d845117aac2a4a03c80f30ddb3`
- Head: `10e9695c99c439fd68ad4dc1c599b69973385052`
- Production 변경: 허용된 5개 canonical owner 파일만 변경 (`__init__.py`는 보존)

## 주요 변경과 보존 계약

- `initialize`/`shutdown`이 `_INITIALIZE_LOCK`을 공유하며 bootstrap shutdown을 atexit에 한 번만 등록합니다.
- shutdown은 terminal/idempotent이고 expected runtime identity만 detach한 뒤 translation route executor → AiO → wildcard → autocomplete index/snapshot → translation facade → translation cache 순으로 정리합니다.
- unexpected route/wildcard 오류는 이번 시도에서 만든 runtime 및 facade binding만 rollback하고 원래 startup 예외를 보존합니다.
- translation route worker의 개별 atexit 등록을 제거하고 bootstrap cleanup plan 소유로 이동했습니다.
- callerless `artist_mix` duplicate warning set만 제거했습니다.
- route deregistration, file-I/O limiter teardown, provider/client close, active-request drain, hot shutdown→reinitialize는 추가하지 않았습니다.
- route/API/node identity, root `__all__`, repeated route refresh, wildcard once/OSError retry, dynamic facade seam은 보존합니다.

## 검증

- changed-file AST/fatal Ruff 및 `git diff --check`: 통과
- lifecycle/bootstrap/runtime/rollback direct tests: `PythonBootstrapTests` 13, `RuntimeServicesTests` 11, lifecycle contract 10
- translation/API/file-I/O/prompt 및 AiO/wildcard/autocomplete runtime contracts: 통과
- package-skeleton direct import, runtime ownership, import-boundary, analyzer: 통과
- 최종 Head SHA official full 정확히 1회 통과: Python 1,418 tests, frontend 120 files, Pyright baseline, 11 import-boundary groups
- `comfy node validate`: 통과
- actual pack: 315 entries, CRC 정상, required runtime closure 7/7, SHA256 `d5a804cdef20cf8862975252f60c750ef92985ed79608ca5fa00f4a655ca6516`
- isolated ComfyUI loader: packed archive import/reload 성공, 18 nodes, 동일 runtime identity, shutdown/shutdown 및 shutdown 후 callback 0회 확인
- backend-only lifecycle이므로 Legacy/Node 2.0 canvas matrix는 미실행

## 남은 위험과 rollback

- shutdown은 process-terminal 계약이며 hot reinitialize를 지원하지 않습니다.
- translation executor는 admission을 닫고 pending을 취소하지만 running work를 기다리지 않습니다.
- ComfyUI의 안전한 route deregistration/rollback 계약이 없어 기존 route marker와 side effects는 유지합니다.
- rollback은 이 squash commit의 revert로 가능합니다.

## Next

별도 E-09c production-free completion audit만 진행합니다. E-09c 전에는 E-10, D-14, release, Registry를 시작하지 않습니다.

Refs #187