### PR TITLE
E-09c: runtime lifecycle completion audit

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-08 are complete; E-09a fixes the runtime shutdown
-  Contract and the next bounded implementation is E-09b only.
+  owns Phase E. E-01 through E-09 are complete; E-10 is the next READY task and
+  requires its own bounded task card.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- E-09a Contract base: E-08d / PR #555 at
-  `4ad6bc947ba59db2df3cf5212ab07789757d7b96`.
+- E-09c completion-audit base: E-09b / PR #557 at
+  `05fc20eb366be8376a6d3a47a79d2b5d00654a08`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -42,15 +42,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md).
 - E-09 runtime shutdown and cleanup Contract and bounded queue:
   [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md).
-- First READY task after E-09a merges: one cohesive #187 E-09b LIFECYCLE
-  implementation only.
+- E-09 is complete with `ambiguous_state_owners=[]`; E-10 is the next READY task.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-09a authorizes only E-09b after merge. E-10, root removal, release, and Registry
-  remain blocked until the E-09c completion audit.
+- Root removal, release, and Registry remain governed by the active roadmap; E-09
+  completion authorizes only a separately carded E-10 next step.
 
 ## Current code boundary
 

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,12 +2,12 @@
 
 ## Status and authority
 
-- Status: D-08 and E-01 through E-08 are completed; E-09a Contract is fixed;
+- Status: D-08 and E-01 through E-09 are completed; E-10 is the next READY task;
   the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- E-09a Contract base:
-  `dev@4ad6bc947ba59db2df3cf5212ab07789757d7b96` after E-08d / PR #555.
-- Document baseline: E-09 runtime shutdown and cleanup Contract.
+- E-09c completion-audit base:
+  `dev@05fc20eb366be8376a6d3a47a79d2b5d00654a08` after E-09b / PR #557.
+- Document baseline: completed E-09 runtime shutdown and cleanup lifecycle.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -17,8 +17,9 @@
   E-06d narrow RuntimeServices/bootstrap composition Move, the E-06e completion
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
   ownership Contract, the E-08b owner Move, the E-08c narrow composition Move, and
-  the E-08d completion audit Contract, and the E-09a lifecycle Contract. The next
-  bounded implementation is E-09b only.
+  the E-08d completion audit Contract, the E-09a lifecycle Contract, the E-09b
+  cohesive LIFECYCLE implementation, and the E-09c completion audit Contract. The
+  next bounded task is E-10 only.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -438,20 +439,20 @@ behavior. The queue remains E-08a Contract, E-08b owner Move, E-08c narrow
 RuntimeServices/bootstrap composition, and E-08d completion audit. E-08d reconciles
 the single E-01 entry, feature cleanup, import direction, seven root identities, and
 the exact narrow runtime binding, and records zero ambiguous AiO cache state without
-production changes. E-08 is complete. E-09a fixes one bootstrap-owned terminal
+production changes. E-08 is complete. E-09a fixed one bootstrap-owned terminal
 lifecycle, reverse cleanup order, partial-initialization rollback, and explicit
-file-I/O/route/provider/warning no-op dispositions. The next READY unit after E-09a
-merges is the single cohesive E-09b LIFECYCLE implementation, followed by the
-production-free E-09c audit. Do not start E-10, D-14 retirement, release, or Registry
-work before E-09 completes.
+file-I/O/route/provider/warning no-op dispositions. E-09b implemented the cohesive
+lifecycle and E-09c reconciled E-01 with zero ambiguous owners without production
+changes. E-09 is complete and E-10 is the next READY task. D-14 retirement, release,
+and Registry work remain blocked by their existing roadmap gates.
 ```
 
 ## 7. E-09 runtime shutdown and cleanup queue
 
 ```text
 E-09a  Contract   owner/disposition/order/rollback gate        complete
-E-09b  LIFECYCLE  one cohesive terminal shutdown implementation next
-E-09c  Contract   zero-ambiguity completion audit              blocked on E-09b
+E-09b  LIFECYCLE  one cohesive terminal shutdown implementation complete
+E-09c  Contract   zero-ambiguity completion audit              complete
 ```
 
 E-09a is production-free. It selects bootstrap as the one serialized lifecycle owner,
@@ -463,8 +464,10 @@ Conditioning warning set for process lifetime. Cleanup order and rollback are ow
 E-09b is one rollback boundary rather than several Move PRs because terminal state,
 RuntimeServices close, executor admission, feature cleanup order, global detach, and
 unexpected-startup rollback share one lifecycle/concurrency invariant. E-09c changes
-no production and must reconcile `ambiguous_state_owners=[]` before the next phase.
-E-10 remains blocked, as do D-14, release, and Registry work.
+no production and reconciles `ambiguous_state_owners=[]`, the seven completed E-01
+lifecycle dispositions, package/import safety, and the E-09b promotion evidence.
+E-09 is complete. E-10 is the next READY task; D-14, release, and Registry work
+remain governed by their existing blockers.
 
 ### E-09a validation
 
@@ -473,3 +476,12 @@ E-08 direct contracts, package/no-host import, current import boundary, analyzer
 `git diff --check`. Run official full once on the exact final candidate. Production,
 import closure, archive, metadata, and host-visible behavior do not change, so reuse
 E-08c package/live evidence unless a focused gate proves material drift.
+
+### E-09c validation
+
+Run changed-file JSON/Python syntax, the E-09 lifecycle and E-01 ownership Contracts,
+the E-04/E-05/E-06/E-08 direct Contracts, package/no-host import, current import
+boundaries, analyzer, maintained-document links, and `git diff --check`. Run official
+full once on the exact final candidate. Because E-09c changes no production, import
+closure, archive, metadata, or host-visible behavior, reuse E-09b validate/pack/live
+evidence.

--- a/docs/architecture/python-runtime-e09-lifecycle-contract.md
+++ b/docs/architecture/python-runtime-e09-lifecycle-contract.md
@@ -11,9 +11,9 @@ AiO ownership audit. The executable source is
 Issue #187 owns the Phase E decision ledger. The current source, direct owner tests,
 and the separate Sol/max PRO review converge on one bounded sequence:
 
-1. E-09a freezes the lifecycle Contract without production changes;
-2. E-09b implements one cohesive `LIFECYCLE` rollback boundary; and
-3. E-09c performs a production-free completion audit before E-10.
+1. E-09a froze the lifecycle Contract without production changes;
+2. E-09b implemented one cohesive `LIFECYCLE` rollback boundary; and
+3. E-09c completed the production-free reconciliation before E-10.
 
 Multiple Move PRs and a broader roadmap redesign are rejected. Shutdown ordering,
 partial-initialization rollback, and terminal process state are one shared concurrency
@@ -120,19 +120,32 @@ instead of adding a generic client lifecycle.
 
 ## Bounded implementation queue
 
-1. **E-09a Contract:** freeze owner/disposition, cleanup order, rollback, no-op,
-   compatibility, validation, and stop conditions. Production changes: zero.
-2. **E-09b LIFECYCLE:** implement the complete fixed contract in
+1. **E-09a Contract — complete:** freeze owner/disposition, cleanup order, rollback,
+   no-op, compatibility, validation, and stop conditions. Production changes: zero.
+2. **E-09b LIFECYCLE — complete:** implement the complete fixed contract in
    `easyuse_anima/runtime.py`, `easyuse_anima/bootstrap.py`,
    `easyuse_anima/api/routes/translation.py`,
    `easyuse_anima/translation/service.py`,
    `easyuse_anima/prompt/artist_mix.py`, and `__init__.py`, with only the direct
    tests/fixtures/baseline required by actual-code gates.
-3. **E-09c Contract:** reconcile E-01, lifecycle, cleanup, import/package safety, and
-   `ambiguous_state_owners=[]` without production changes.
+3. **E-09c Contract — complete:** reconcile E-01, lifecycle, cleanup,
+   import/package safety, and `ambiguous_state_owners=[]` without production
+   changes.
 
-E-10 remains blocked until E-09c merges. D-14 retirement, release, and Registry work
-remain blocked by the active roadmap.
+E-09 is complete. E-10 is the next READY task and must begin from its own bounded
+task card. D-14 retirement, release, and Registry work remain blocked by the active
+roadmap.
+
+## E-09c completion audit
+
+The E-09c executable audit starts from the merged E-09b result at
+`05fc20eb366be8376a6d3a47a79d2b5d00654a08`. It reconciles the seven formerly pending
+E-01 lifecycle entries as `E-09-complete`, rechecks the seven-step cleanup order and
+four retained no-op owners, and records `ambiguous_state_owners=[]`.
+
+The audit changes no production file. Package, root, runtime, route, API, and import
+surfaces remain the E-09b surfaces. Therefore the E-09b validate/pack/archive and
+isolated ComfyUI import/reload/shutdown evidence remains valid for E-09c.
 
 ## Validation and evidence reuse
 

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -37,21 +37,21 @@ E-01 drift gate until classified.
 | Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
 | --- | --- | --- | --- |
 | `aio-first-pass-cache` | one private default AiO cache store owns entries/order/enabled/generation/metrics/`RLock`; bootstrap installs that exact owner behind a narrow private runtime port | owner clear/disable invalidate entries and generation while preserving metrics; metric reset is separate | E-08 complete; E-08d audited |
-| `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry and no explicit close; E-09a fixes that as a no-op | retain in E-09b |
+| `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry and no explicit close; E-09 retains this as a lifecycle no-op | E-09 complete; E-09c audited |
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
 | `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
 | `autocomplete-index-root` | immutable user-data index root retained by the canonical index-store owner | isolated-store injection; no mutable raw root | E-05 complete; E-05e audited |
 | `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry shared by direct/factory stores | guard plus per-path `RLock`; no clear | E-03b complete |
-| `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; no production shutdown yet | E-09b shared serialized terminal shutdown |
+| `bootstrap-initialize-state` | bootstrap default runtime, wildcard completion, executor, atexit, and terminal state | shared initialize/shutdown `Lock`; expected-identity detach and once-only cleanup | E-09 complete; E-09c audited |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
-| `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior and no package shutdown yet | E-09b once-registered `atexit` shutdown |
+| `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior plus once-registered terminal `atexit` shutdown | E-09 complete; E-09c audited |
 | `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d complete |
-| prompt warning-dedupe entries | Conditioning canonical process warning set plus callerless Artist Mix duplicate | two unprotected sets today; E-09a selects retain/remove dispositions | E-09b |
+| prompt warning-dedupe entries | Conditioning owns the canonical process warning set; the callerless Artist Mix duplicate is removed | canonical set remains process-lifetime with its accepted benign race | E-09 complete; E-09c audited |
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
-| `root-route-registration` | injected router registrar called by bootstrap | serialized refresh, idempotent marker, and no deregistration; E-09a fixes that as a no-op | retain in E-09b |
-| `root-translation-route-worker` | bootstrap composes the lazy single-thread executor; root retains its compatibility reference | internal `RLock`; idempotent `atexit` shutdown only | E-04d complete |
-| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete/wildcard capabilities | bootstrap-serialized install; private-global test reset and no close yet | E-09b private once-only close plan |
-| `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; idempotent service close clears cache | E-04c complete |
+| `root-route-registration` | injected router registrar called by bootstrap | serialized refresh, idempotent marker, and retained routes with no deregistration | E-09 complete; E-09c audited |
+| `root-translation-route-worker` | bootstrap composes the lazy single-thread executor; root retains its compatibility reference | internal `RLock`; bootstrap cleanup plan closes admission first without waiting | E-04d owner; E-09 lifecycle audited |
+| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete/wildcard capabilities | bootstrap-serialized install/detach; private once-only reverse cleanup plan | E-09 complete; E-09c audited |
+| `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; compare-and-restore facade then idempotent service close | E-04c owner; E-09 lifecycle audited |
 | `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
 | `wildcard-snapshot-cache` | canonical private default snapshot-store owner, directly injected through the narrow runtime port | one owned `Condition`; completed-cache-only `clear()` preserves active builds | E-06 complete; E-06e audited |
 
@@ -196,9 +196,9 @@ and the narrow runtime binding, and records zero ambiguous AiO cache state. E-08
 complete. The next bounded unit is a separate E-09 runtime shutdown and cleanup
 Contract.
 
-## E-09 Contract result
+## E-09 completion result
 
-The production-free
+The production-free E-09a
 [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md)
 selects bootstrap as the one serialized lifecycle owner and fixes a terminal,
 idempotent shutdown plus bounded unexpected-initialization rollback. The reverse
@@ -207,8 +207,9 @@ translation-facade, and translation-service resources using their existing featu
 semantics. It does not clear weak API file-I/O limiters, deregister routes, close an
 unproven provider/client, drain running work, or create a hot reinitialize contract.
 
-The callerless Artist Mix warning set is the only state selected for removal; the
-Conditioning warning set remains process-lifetime. The bounded queue is E-09a
-Contract, one cohesive E-09b LIFECYCLE implementation, and E-09c production-free
-completion audit. E-10 remains blocked until that audit records zero ambiguous
-owners.
+E-09b implements that one cohesive lifecycle, and the production-free E-09c audit
+reconciles the seven E-01 lifecycle targets as `E-09-complete`. The callerless Artist
+Mix warning set is removed, the Conditioning set remains process-lifetime, all six
+feature cleanup owners retain their existing semantics, package/import surfaces are
+unchanged, and `ambiguous_state_owners=[]`. E-09 is complete; E-10 is the next READY
+task and requires its own bounded task card.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -58,22 +58,21 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- E-09a Contract base: E-08d / PR #555 at
-  `4ad6bc947ba59db2df3cf5212ab07789757d7b96`.
+- E-09c completion-audit base: E-09b / PR #557 at
+  `05fc20eb366be8376a6d3a47a79d2b5d00654a08`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-08 are complete. E-09a fixes the runtime shutdown and cleanup
-  Contract; after it merges, the next work is only the single cohesive E-09b
-  LIFECYCLE implementation. The #323
+- E-01 through E-09 are complete with `ambiguous_state_owners=[]`. E-10 is the next
+  READY task and requires its own bounded task card. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root compatibility aliases or start E-10, release, or Registry work
-  before the E-09c completion audit.
+- Do not remove root compatibility aliases or start release/Registry work outside
+  the active roadmap gates.
 
 ## Completed D-08 composition audit surface
 

--- a/tests/fixtures/python_runtime_lifecycle_contract.v1.json
+++ b/tests/fixtures/python_runtime_lifecycle_contract.v1.json
@@ -1,7 +1,7 @@
 {
   "base_sha": "4ad6bc947ba59db2df3cf5212ab07789757d7b96",
   "classification": "Contract",
-  "production_changes": 0,
+  "production_changes": 5,
   "cleanup_order": [
     {
       "action": "shutdown",
@@ -53,6 +53,74 @@
       "owner": "easyuse_anima.runtime.RuntimeServices.translation"
     }
   ],
+  "completion_audit": {
+    "ambiguous_state_owners": [],
+    "base_sha": "05fc20eb366be8376a6d3a47a79d2b5d00654a08",
+    "classification": "Contract",
+    "e01_reconciliation": [
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "retain-module-owner-self-expiring",
+        "e01_entry": "api-file-io-limiters"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "bootstrap-terminal-lifecycle",
+        "e01_entry": "bootstrap-initialize-state"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "retain-root-import-initialize-with-bootstrap-atexit-shutdown",
+        "e01_entry": "package-bootstrap-effect"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "remove-callerless-duplicate",
+        "e01_entry": "prompt-artist-mix-warning-dedupe"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "retain-process-lifetime-no-op",
+        "e01_entry": "prompt-conditioning-warning-dedupe"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "retain-installed-routes-no-deregistration",
+        "e01_entry": "root-route-registration"
+      },
+      {
+        "completed_phase": "E-09-complete",
+        "decision": "runtime-services-private-once-only-close-plan",
+        "e01_entry": "runtime-services"
+      }
+    ],
+    "next_phase": "E-10 task card only",
+    "production_changes": 0,
+    "reused_evidence": {
+      "archive_sha256": "d5a804cdef20cf8862975252f60c750ef92985ed79608ca5fa00f4a655ca6516",
+      "source": "E-09b final candidate 10e9695c99c439fd68ad4dc1c599b69973385052",
+      "surfaces": [
+        "comfy-node-validate",
+        "packed-archive-closure",
+        "isolated-comfyui-import-reload-shutdown"
+      ]
+    },
+    "verified_cleanup_order": [
+      "translation-route-executor",
+      "aio-first-pass-cache",
+      "wildcard-snapshot-cache",
+      "autocomplete-index-store",
+      "autocomplete-snapshot-store",
+      "translation-default-facade",
+      "translation-service-cache"
+    ],
+    "verified_noops": [
+      "api-file-io-limiters",
+      "prompt-conditioning-warning-dedupe",
+      "root-route-registration",
+      "translation-provider-registry"
+    ]
+  },
   "current_state": {
     "bootstrap_exports": [
       "initialize",
@@ -63,7 +131,7 @@
     "runtime_services_has_close": true,
     "translation_worker_registers_own_atexit": false
   },
-  "e01_pending_dispositions": [
+  "e01_dispositions": [
     {
       "decision": "retain-module-owner-self-expiring",
       "id": "api-file-io-limiters"
@@ -213,7 +281,7 @@
     ]
   },
   "schema_version": 1,
-  "scope": "E-09 runtime shutdown and cleanup lifecycle Contract",
+  "scope": "Completed E-09 runtime shutdown and cleanup lifecycle sequence through the production-free E-09c audit",
   "sequence": [
     {
       "classification": "Contract",
@@ -231,7 +299,7 @@
       "classification": "Contract",
       "goal": "Reconcile the implemented lifecycle with E-01 and record zero ambiguous owners before E-10.",
       "id": "E-09c",
-      "status": "ready"
+      "status": "complete"
     }
   ],
   "warning_dedupe": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -168,7 +168,7 @@
       "module": "easyuse_anima/api/file_io.py",
       "owner": "easyuse_anima.api.file_io",
       "symbols": ["_FILE_IO_LIMITERS", "_FILE_IO_LIMITERS_LOCK"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_api_contract.py"],
       "thread_safety": "A module Lock serializes weak-registry lookup and semaphore creation."
     },
@@ -228,7 +228,7 @@
       "module": "easyuse_anima/bootstrap.py",
       "owner": "easyuse_anima.bootstrap lifecycle",
       "symbols": ["_ATEXIT_REGISTERED", "_DEFAULT_RUNTIME", "_INITIALIZE_LOCK", "_SHUTDOWN", "_TRANSLATION_ROUTE_EXECUTOR", "_WILDCARDS_INITIALIZED", "initialize", "shutdown"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_python_bootstrap.py", "tests/test_runtime_services.py"],
       "thread_safety": "One Lock serializes composition, install, route refresh, wildcard initialization, terminal state, expected-identity detach, and cleanup."
     },
@@ -246,13 +246,13 @@
     },
     {
       "categories": ["directory_initialization", "import_effect", "route_registration"],
-      "cleanup": "No package shutdown or route deregistration; bootstrap retries failed initialization.",
+      "cleanup": "Bootstrap registers its terminal shutdown with atexit once; shutdown detaches the expected runtime and leaves routes installed.",
       "id": "package-bootstrap-effect",
       "lifetime": "Executed once per root package import; bootstrap state survives for the process.",
       "module": "__init__.py",
       "owner": "easyuse_anima.bootstrap.initialize",
       "symbols": ["_initialize"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_python_bootstrap.py", "tests/test_python_package_skeleton.py", "tests/test_runtime_services.py"],
       "thread_safety": "Bootstrap serializes the production call with _INITIALIZE_LOCK."
     },
@@ -276,7 +276,7 @@
       "module": "easyuse_anima/prompt/artist_mix.py",
       "owner": "removed by E-09b",
       "symbols": [],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_prompt_corrector.py"],
       "thread_safety": "No remaining state."
     },
@@ -288,7 +288,7 @@
       "module": "easyuse_anima/prompt/conditioning.py",
       "owner": "easyuse_anima.prompt.conditioning",
       "symbols": ["_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_node_contracts.py", "tests/test_python_compatibility_surface.py"],
       "thread_safety": "Unprotected membership/add; current execution accepts benign duplicate-warning races."
     },
@@ -312,13 +312,13 @@
       "module": "api.py",
       "owner": "easyuse_anima.api.router registrar composed through easyuse_anima.bootstrap",
       "symbols": ["_ROUTE_DEFINITIONS", "_ROUTE_SIGNATURE", "register_routes"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_api_contract.py", "tests/test_python_bootstrap.py"],
       "thread_safety": "Bootstrap serializes production registration; router markers guard duplicate signatures."
     },
     {
       "categories": ["atexit", "executor", "future", "single_flight"],
-      "cleanup": "Executor shutdown is registered with atexit and idempotent; package shutdown does not call it.",
+      "cleanup": "The bootstrap cleanup plan invokes idempotent executor shutdown first; admission closes without waiting for running work.",
       "id": "root-translation-route-worker",
       "lifetime": "Private bootstrap composition creates the route worker while root api binds its compatibility reference; ThreadPoolExecutor is lazy and process-lived until atexit.",
       "module": "api.py",
@@ -336,13 +336,13 @@
       "module": "easyuse_anima/runtime.py",
       "owner": "easyuse_anima.runtime.RuntimeServices",
       "symbols": ["RuntimeServices", "_RUNTIME_SERVICES"],
-      "target_phase": "E-09",
+      "target_phase": "E-09-complete",
       "test_evidence": ["tests/test_autocomplete_service.py", "tests/test_comfy_host_wiring.py", "tests/test_runtime_services.py", "tests/test_seed_reservation_service.py"],
       "thread_safety": "Bootstrap serializes install and detach; the private cleanup plan locks its once-only transition and continues the fixed callback sequence after failures."
     },
     {
       "categories": ["cache", "lock", "service", "single_flight"],
-      "cleanup": "PromptTranslationService.close idempotently clears its owned cache; flights self-remove after the last user settles; E-09 owns whole-runtime close ordering.",
+      "cleanup": "PromptTranslationService.close idempotently clears its owned cache after facade restoration in the E-09b whole-runtime plan; flights self-remove after the last user settles.",
       "id": "translation-default-service",
       "lifetime": "Bootstrap composes one process service from the runtime clock; RuntimeServices owns it and the service facade retains the same identity for node/API callbacks.",
       "module": "easyuse_anima/translation/service.py",
@@ -366,7 +366,7 @@
     },
     {
       "categories": ["cache", "condition", "single_flight"],
-      "cleanup": "The owner exposes idempotent completed-cache clear; active building keys and waiter settlement remain intact. Whole-runtime ordering remains E-09.",
+      "cleanup": "The E-09b whole-runtime plan invokes the owner's idempotent completed-cache clear; active building keys and waiter settlement remain intact.",
       "id": "wildcard-snapshot-cache",
       "lifetime": "Process lifetime with an LRU bound of 16 verified snapshots.",
       "module": "easyuse_anima/wildcard/snapshot.py",
@@ -379,5 +379,5 @@
   ],
   "ignored_mutable_global_names": ["__all__"],
   "schema_version": 1,
-  "scope": "Shipped Python process-wide state, import/bootstrap effects, and analyzer mutable-global disposition after D-08u and D-14 readiness."
+  "scope": "Shipped Python process-wide state, import/bootstrap effects, and analyzer mutable-global disposition through the E-09c lifecycle completion audit."
 }

--- a/tests/test_python_runtime_lifecycle_contract.py
+++ b/tests/test_python_runtime_lifecycle_contract.py
@@ -105,8 +105,9 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
                 "base_sha",
                 "classification",
                 "cleanup_order",
+                "completion_audit",
                 "current_state",
-                "e01_pending_dispositions",
+                "e01_dispositions",
                 "evidence",
                 "implementation_boundary",
                 "lifecycle_owner",
@@ -123,7 +124,7 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(self.fixture["production_changes"], 5)
         self.assertEqual(
             [item["id"] for item in self.fixture["sequence"]],
             ["E-09a", "E-09b", "E-09c"],
@@ -134,12 +135,12 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [item["status"] for item in self.fixture["sequence"]],
-            ["complete", "complete", "ready"],
+            ["complete", "complete", "complete"],
         )
         for evidence in self.fixture["evidence"]:
             self.assertTrue((ROOT / evidence).is_file(), evidence)
 
-    def test_e01_pending_entries_have_exact_dispositions(self):
+    def test_e01_completed_entries_have_exact_dispositions(self):
         expected = [
             "api-file-io-limiters",
             "bootstrap-initialize-state",
@@ -149,18 +150,66 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
             "root-route-registration",
             "runtime-services",
         ]
-        pending = [
+        completed = [
             entry["id"]
             for entry in self.e01_fixture["entries"]
-            if entry["target_phase"] == "E-09"
+            if entry["target_phase"] == "E-09-complete"
         ]
         dispositions = [
             item["id"]
-            for item in self.fixture["e01_pending_dispositions"]
+            for item in self.fixture["e01_dispositions"]
         ]
-        self.assertEqual(pending, expected)
+        self.assertEqual(completed, expected)
         self.assertEqual(dispositions, expected)
         self.assertEqual(len(set(dispositions)), len(dispositions))
+
+    def test_completion_audit_records_zero_ambiguous_owners(self):
+        audit = self.fixture["completion_audit"]
+        entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        dispositions = {
+            item["id"]: item["decision"]
+            for item in self.fixture["e01_dispositions"]
+        }
+        reconciliations = {
+            item["e01_entry"]: item
+            for item in audit["e01_reconciliation"]
+        }
+
+        self.assertEqual(audit["classification"], "Contract")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertEqual(audit["ambiguous_state_owners"], [])
+        self.assertEqual(
+            audit["base_sha"],
+            "05fc20eb366be8376a6d3a47a79d2b5d00654a08",
+        )
+        self.assertEqual(audit["next_phase"], "E-10 task card only")
+        self.assertEqual(set(reconciliations), set(dispositions))
+        self.assertNotIn(
+            "E-09",
+            {entry["target_phase"] for entry in entries.values()},
+        )
+        for entry_id, reconciliation in reconciliations.items():
+            with self.subTest(entry=entry_id):
+                self.assertEqual(
+                    entries[entry_id]["target_phase"],
+                    reconciliation["completed_phase"],
+                )
+                self.assertEqual(
+                    reconciliation["decision"],
+                    dispositions[entry_id],
+                )
+        self.assertEqual(
+            audit["verified_cleanup_order"],
+            [item["id"] for item in self.fixture["cleanup_order"]],
+        )
+        self.assertEqual(
+            set(audit["verified_noops"]),
+            {item["id"] for item in self.fixture["retained_noops"]},
+        )
+        for surface in audit["reused_evidence"]["surfaces"]:
+            self.assertTrue(surface.strip())
 
     def test_cleanup_order_reconciles_completed_feature_owners(self):
         expected_order = [
@@ -413,7 +462,8 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         )
         for task_id in ("E-09a", "E-09b", "E-09c"):
             self.assertIn(task_id, roadmap)
-        self.assertIn("E-10 remains blocked", roadmap)
+        self.assertIn("E-09 is complete", roadmap)
+        self.assertIn("E-10 is the next READY task", roadmap)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -172,6 +172,27 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
                     self.assertNotIn(pair, declarative_pairs)
                     declarative_pairs.add(pair)
 
+    def test_e09_lifecycle_entries_have_completed_dispositions(self):
+        expected = {
+            "api-file-io-limiters",
+            "bootstrap-initialize-state",
+            "package-bootstrap-effect",
+            "prompt-artist-mix-warning-dedupe",
+            "prompt-conditioning-warning-dedupe",
+            "root-route-registration",
+            "runtime-services",
+        }
+        completed = {
+            entry["id"]
+            for entry in self.fixture["entries"]
+            if entry["target_phase"] == "E-09-complete"
+        }
+        self.assertEqual(completed, expected)
+        self.assertNotIn(
+            "E-09",
+            {entry["target_phase"] for entry in self.fixture["entries"]},
+        )
+
     def test_runtime_entries_bind_existing_shipped_symbols(self):
         for entry in self.fixture["entries"]:
             module_path = ROOT / entry["module"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187의 E-09c production-free completion audit입니다. E-09b로 구현된 terminal lifecycle을 E-01과 다시 대조하고 E-09를 종료합니다.

- Base: `05fc20eb366be8376a6d3a47a79d2b5d00654a08`
- Head: `bffaa750497770a36731dfe83bd3473030b6efbe`
- Production 변경: 0
- E-01의 7개 lifecycle target을 `E-09-complete`로 조정
- lifecycle fixture에 `ambiguous_state_owners=[]`, cleanup/no-op reconciliation, E-09b 증거 재사용 고정
- roadmap 및 architecture/development index를 E-09 complete / E-10 next READY로 갱신

## 보존 계약

- bootstrap terminal/idempotent shutdown과 expected-identity detach
- 7단계 reverse cleanup과 bounded startup rollback
- route/file-I/O/provider/conditioning warning no-op
- root/package/runtime/route/API identity와 import boundary

## 검증

- JSON/Python syntax, fatal Ruff, `git diff --check` 통과
- E-09 lifecycle 11, E-01 ownership 6
- E-04 translation 7, E-05 autocomplete 10, E-06 wildcard 10, E-08 AiO 10
- package-skeleton direct import 1
- import-boundary 10 + 6, backend analyzer 18
- 최종 SHA에서 official full 정확히 1회 통과: Python 1,420 tests, frontend 120 JS files, Pyright ratchet, import boundary 11 groups
- production/import/archive/host-visible 변경이 없어 E-09b validate/pack/archive 및 격리 ComfyUI import/reload/shutdown 증거 재사용

## 위험과 rollback

production 동작 변경은 없습니다. rollback은 이 Contract/docs/test 커밋의 revert로 한정됩니다. production 보정이 필요하다는 증거는 발견되지 않았습니다.

## Next

merge 후 Issue #187 E-09 completion checkpoint를 남깁니다. 다음 READY는 별도 task card의 E-10뿐이며 D-14/release/Registry는 기존 roadmap gate를 따릅니다.