### PR TITLE
test: centralize runtime isolation fixtures (E-10b)

### DIFF
--- a/tests/comfy_host_fakes.py
+++ b/tests/comfy_host_fakes.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import DEFAULT, Mock, patch
+from unittest.mock import DEFAULT, Mock
+
+from tests.runtime_test_support import (
+    build_runtime_services,
+    isolated_installed_runtime,
+)
 
 
 class FakeSeedReservationService:
@@ -185,7 +190,8 @@ def use_fake_comfy_host(root_module, provider):
     config, clock, translation, autocomplete, wildcard_snapshots, aio_cache = (
         _runtime_support(runtime_module)
     )
-    runtime = runtime_module.RuntimeServices(
+    runtime = build_runtime_services(
+        runtime_module,
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
         config=config,
@@ -195,7 +201,7 @@ def use_fake_comfy_host(root_module, provider):
         wildcard_snapshots=wildcard_snapshots,
         aio_first_pass_cache=aio_cache,
     )
-    with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
+    with isolated_installed_runtime(runtime_module, runtime):
         yield provider
 
 
@@ -226,7 +232,8 @@ def patch_comfy_helper(
     config, clock, translation, autocomplete, wildcard_snapshots, aio_cache = (
         _runtime_support(runtime_module)
     )
-    runtime = runtime_module.RuntimeServices(
+    runtime = build_runtime_services(
+        runtime_module,
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
         config=config,
@@ -236,5 +243,5 @@ def patch_comfy_helper(
         wildcard_snapshots=wildcard_snapshots,
         aio_first_pass_cache=aio_cache,
     )
-    with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
+    with isolated_installed_runtime(runtime_module, runtime):
         yield replacement

--- a/tests/fixtures/python_runtime_test_isolation_contract.v1.json
+++ b/tests/fixtures/python_runtime_test_isolation_contract.v1.json
@@ -5,19 +5,7 @@
     "module_reload_sites": [],
     "private_mutation_sites": [
       {
-        "module": "tests/comfy_host_fakes.py",
-        "symbols": ["_RUNTIME_SERVICES"]
-      },
-      {
-        "module": "tests/test_comfy_host_wiring.py",
-        "symbols": ["_RUNTIME_SERVICES"]
-      },
-      {
-        "module": "tests/test_prompt_translation.py",
-        "symbols": ["_DEFAULT_TRANSLATION_SERVICE"]
-      },
-      {
-        "module": "tests/test_python_bootstrap.py",
+        "module": "tests/runtime_test_support.py",
         "symbols": [
           "_ATEXIT_REGISTERED",
           "_DEFAULT_RUNTIME",
@@ -27,17 +15,6 @@
           "_TRANSLATION_ROUTE_EXECUTOR",
           "_WILDCARDS_INITIALIZED"
         ]
-      },
-      {
-        "module": "tests/test_runtime_services.py",
-        "symbols": [
-          "_ATEXIT_REGISTERED",
-          "_DEFAULT_RUNTIME",
-          "_DEFAULT_TRANSLATION_SERVICE",
-          "_RUNTIME_SERVICES",
-          "_SHUTDOWN",
-          "_WILDCARDS_INITIALIZED"
-        ]
       }
     ],
     "read_only_private_assertions": "Direct lifecycle tests may inspect private state to prove identity, terminal state, and rollback; E-10 moves reset/mutation ownership only."
@@ -45,6 +22,7 @@
   "evidence": [
     "easyuse_anima/runtime.py",
     "easyuse_anima/bootstrap.py",
+    "tests/runtime_test_support.py",
     "tests/comfy_host_fakes.py",
     "tests/test_comfy_host_wiring.py",
     "tests/test_prompt_translation.py",
@@ -89,17 +67,17 @@
       "classification": "Move",
       "goal": "Add the one test-only runtime fixture owner and migrate all five direct private-mutation sites without production changes.",
       "id": "E-10b",
-      "status": "ready"
+      "status": "complete"
     },
     {
       "classification": "Contract",
       "goal": "Record zero reload sites and zero direct private runtime mutations outside the helper, then close Phase E.",
       "id": "E-10c",
-      "status": "blocked-on-E-10b"
+      "status": "ready"
     }
   ],
   "schema_version": 1,
-  "scope": "E-10 isolated runtime test fixtures and private-reset ownership Contract",
+  "scope": "E-10 isolated runtime test fixtures and private-reset ownership through the E-10b Move",
   "target_fixture": {
     "invariants": [
       "restore exact prior identities and scalar lifecycle state after success or failure",

--- a/tests/runtime_test_support.py
+++ b/tests/runtime_test_support.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from unittest.mock import patch
+
+
+_RUNTIME_TEST_LOCK = threading.RLock()
+
+
+def build_runtime_services(
+    runtime_module,
+    *,
+    comfy,
+    seed_reservations,
+    config,
+    clock,
+    translation,
+    autocomplete,
+    wildcard_snapshots,
+    aio_first_pass_cache,
+    cleanup_plan=None,
+):
+    """Build one independent runtime value without installing it globally."""
+
+    values = {
+        "comfy": comfy,
+        "seed_reservations": seed_reservations,
+        "config": config,
+        "clock": clock,
+        "translation": translation,
+        "autocomplete": autocomplete,
+        "wildcard_snapshots": wildcard_snapshots,
+        "aio_first_pass_cache": aio_first_pass_cache,
+    }
+    if cleanup_plan is not None:
+        values["_cleanup_plan"] = cleanup_plan
+    return runtime_module.RuntimeServices(**values)
+
+
+def enter_test_context(test_case, manager):
+    """Enter a context and bind its exact exit to unittest cleanup."""
+
+    value = manager.__enter__()
+    test_case.addCleanup(manager.__exit__, None, None, None)
+    return value
+
+
+@contextmanager
+def isolated_installed_runtime(runtime_module, runtime=None):
+    """Temporarily replace one process runtime and restore its prior identity."""
+
+    with _RUNTIME_TEST_LOCK:
+        with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
+            yield runtime
+
+
+@contextmanager
+def isolated_translation_facade(translation_module, translation):
+    """Temporarily replace the call-time facade under the runtime fixture lock."""
+
+    with _RUNTIME_TEST_LOCK:
+        with patch.object(
+            translation_module,
+            "_DEFAULT_TRANSLATION_SERVICE",
+            translation,
+        ):
+            yield translation
+
+
+@contextmanager
+def isolated_translation_route_executor(bootstrap_module, executor):
+    """Temporarily replace the bootstrap-owned route executor for order tests."""
+
+    with _RUNTIME_TEST_LOCK:
+        with patch.object(
+            bootstrap_module,
+            "_TRANSLATION_ROUTE_EXECUTOR",
+            executor,
+        ):
+            yield executor
+
+
+@contextmanager
+def isolated_bootstrap_runtime(
+    bootstrap_module,
+    runtime_module,
+    translation_module,
+):
+    """Isolate terminal bootstrap state without adding a production reset seam."""
+
+    translation = translation_module.PromptTranslationService()
+    with _RUNTIME_TEST_LOCK:
+        with (
+            patch.object(bootstrap_module, "_WILDCARDS_INITIALIZED", False),
+            patch.object(bootstrap_module, "_DEFAULT_RUNTIME", None),
+            patch.object(
+                bootstrap_module,
+                "_TRANSLATION_ROUTE_EXECUTOR",
+                None,
+            ),
+            patch.object(bootstrap_module, "_ATEXIT_REGISTERED", False),
+            patch.object(bootstrap_module, "_SHUTDOWN", False),
+            patch.object(runtime_module, "_RUNTIME_SERVICES", None),
+            patch.object(bootstrap_module.atexit, "register"),
+            patch.object(
+                translation_module,
+                "_DEFAULT_TRANSLATION_SERVICE",
+                translation,
+            ),
+        ):
+            yield translation

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from easyuse_anima import runtime as runtime_module
 from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
 from easyuse_anima.infrastructure.comfy.wiring import resolve_comfy_host_helper
-from easyuse_anima.runtime import RuntimeConfig, RuntimeServices
+from easyuse_anima.runtime import RuntimeConfig
 from tests.comfy_host_fakes import (
     FakeAIOFirstPassCache,
     FakeAutocompleteService,
@@ -19,6 +19,11 @@ from tests.comfy_host_fakes import (
     FakeSeedReservationService,
     FakeTranslationService,
     FakeWildcardSnapshots,
+)
+from tests.runtime_test_support import (
+    build_runtime_services,
+    enter_test_context,
+    isolated_installed_runtime,
 )
 
 
@@ -29,11 +34,10 @@ class ClipTextEncode:
 
 class ComfyHostWiringTests(unittest.TestCase):
     def setUp(self):
-        self.runtime_state = patch.object(runtime_module, "_RUNTIME_SERVICES", None)
-        self.runtime_state.start()
-
-    def tearDown(self):
-        self.runtime_state.stop()
+        enter_test_context(
+            self,
+            isolated_installed_runtime(runtime_module),
+        )
 
     @staticmethod
     def _fallback(name: str):
@@ -245,7 +249,8 @@ class ComfyHostWiringTests(unittest.TestCase):
             mapping_classes={"Mapping": mapping},
             loaded_classes={"Loaded": loaded},
         )
-        runtime_module._RUNTIME_SERVICES = RuntimeServices(
+        runtime = build_runtime_services(
+            runtime_module,
             comfy=provider,
             seed_reservations=FakeSeedReservationService(),
             config=RuntimeConfig(
@@ -258,6 +263,10 @@ class ComfyHostWiringTests(unittest.TestCase):
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
             aio_first_pass_cache=FakeAIOFirstPassCache(),
+        )
+        enter_test_context(
+            self,
+            isolated_installed_runtime(runtime_module, runtime),
         )
 
         self.assertEqual(
@@ -299,7 +308,8 @@ class ComfyHostWiringTests(unittest.TestCase):
                 "CLIPTextEncode": ClipTextEncode,
             },
         )
-        runtime_module._RUNTIME_SERVICES = RuntimeServices(
+        runtime = build_runtime_services(
+            runtime_module,
             comfy=provider,
             seed_reservations=FakeSeedReservationService(),
             config=RuntimeConfig(
@@ -312,6 +322,10 @@ class ComfyHostWiringTests(unittest.TestCase):
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
             aio_first_pass_cache=FakeAIOFirstPassCache(),
+        )
+        enter_test_context(
+            self,
+            isolated_installed_runtime(runtime_module, runtime),
         )
 
         require = resolve_comfy_host_helper(

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -34,6 +34,7 @@ from easyuse_anima.translation.service import (
     PromptTranslationService,
     get_translation_provider,
 )
+from tests.runtime_test_support import isolated_translation_facade
 
 
 GOOGLE_SETTINGS = PromptTranslationSettings(
@@ -324,9 +325,8 @@ class PromptTranslationServiceTests(unittest.TestCase):
                 settings,
             )
         )
-        with patch.object(
+        with isolated_translation_facade(
             service,
-            "_DEFAULT_TRANSLATION_SERVICE",
             current,
         ):
             resolved = service.translate_prompt_markers(

--- a/tests/test_python_bootstrap.py
+++ b/tests/test_python_bootstrap.py
@@ -7,27 +7,24 @@ from unittest.mock import Mock, patch
 
 from easyuse_anima import bootstrap, runtime as runtime_module
 from easyuse_anima.translation import service as translation_service
+from tests.runtime_test_support import (
+    enter_test_context,
+    isolated_bootstrap_runtime,
+    isolated_translation_facade,
+    isolated_translation_route_executor,
+)
 
 
 class PythonBootstrapTests(unittest.TestCase):
     def setUp(self):
-        patchers = (
-            patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False),
-            patch.object(bootstrap, "_DEFAULT_RUNTIME", None),
-            patch.object(bootstrap, "_TRANSLATION_ROUTE_EXECUTOR", None),
-            patch.object(bootstrap, "_ATEXIT_REGISTERED", False),
-            patch.object(bootstrap, "_SHUTDOWN", False),
-            patch.object(runtime_module, "_RUNTIME_SERVICES", None),
-            patch.object(bootstrap.atexit, "register"),
-            patch.object(
+        enter_test_context(
+            self,
+            isolated_bootstrap_runtime(
+                bootstrap,
+                runtime_module,
                 translation_service,
-                "_DEFAULT_TRANSLATION_SERVICE",
-                translation_service.PromptTranslationService(),
             ),
         )
-        for state in patchers:
-            state.start()
-            self.addCleanup(state.stop)
 
     def test_repeated_initialize_keeps_routes_refreshable_and_wildcards_once(self):
         register_routes = Mock(return_value=True)
@@ -226,7 +223,7 @@ class PythonBootstrapTests(unittest.TestCase):
             return restore(expected, replacement)
 
         with (
-            patch.object(bootstrap, "_TRANSLATION_ROUTE_EXECUTOR", worker),
+            isolated_translation_route_executor(bootstrap, worker),
             patch.object(bootstrap, "_DEFAULT_AIO_FIRST_PASS_CACHE", aio_cache),
             patch.object(
                 bootstrap,
@@ -308,24 +305,26 @@ class PythonBootstrapTests(unittest.TestCase):
         )
         runtime = runtime_module.get_runtime()
         foreign_translation = translation_service.PromptTranslationService()
-        translation_service._DEFAULT_TRANSLATION_SERVICE = foreign_translation
-
-        with (
-            patch.object(runtime.translation, "close") as close,
-            self.assertRaisesRegex(RuntimeError, "routes"),
-        ):
-            bootstrap.initialize(
-                register_routes=Mock(side_effect=RuntimeError("routes")),
-                initialize_wildcards=Mock(return_value=object()),
-            )
-
-        self.assertIs(runtime_module.get_runtime(), runtime)
-        self.assertIs(bootstrap._DEFAULT_RUNTIME, runtime)
-        self.assertIs(
-            translation_service._DEFAULT_TRANSLATION_SERVICE,
+        with isolated_translation_facade(
+            translation_service,
             foreign_translation,
-        )
-        close.assert_not_called()
+        ):
+            with (
+                patch.object(runtime.translation, "close") as close,
+                self.assertRaisesRegex(RuntimeError, "routes"),
+            ):
+                bootstrap.initialize(
+                    register_routes=Mock(side_effect=RuntimeError("routes")),
+                    initialize_wildcards=Mock(return_value=object()),
+                )
+
+            self.assertIs(runtime_module.get_runtime(), runtime)
+            self.assertIs(bootstrap._DEFAULT_RUNTIME, runtime)
+            self.assertIs(
+                translation_service._DEFAULT_TRANSLATION_SERVICE,
+                foreign_translation,
+            )
+            close.assert_not_called()
 
     def test_startup_exception_survives_rollback_cleanup_failure(self):
         startup_error = ValueError("wildcards")

--- a/tests/test_python_runtime_test_isolation_contract.py
+++ b/tests/test_python_runtime_test_isolation_contract.py
@@ -2,9 +2,19 @@ from __future__ import annotations
 
 import ast
 import json
+import threading
 import unittest
 from functools import lru_cache
 from pathlib import Path
+
+from easyuse_anima import bootstrap, runtime as runtime_module
+from easyuse_anima.translation import service as translation_service
+from tests.runtime_test_support import (
+    build_runtime_services,
+    isolated_bootstrap_runtime,
+    isolated_installed_runtime,
+    isolated_translation_facade,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -161,7 +171,7 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [item["status"] for item in self.fixture["queue"]],
-            ["complete", "ready", "blocked-on-E-10b"],
+            ["complete", "complete", "ready"],
         )
         for evidence in self.fixture["evidence"]:
             self.assertTrue((ROOT / evidence).is_file(), evidence)
@@ -180,6 +190,7 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         target = self.fixture["target_fixture"]
         self.assertTrue(target["single_owner"])
         self.assertEqual(target["module"], "tests/runtime_test_support.py")
+        self.assertTrue((ROOT / target["module"]).is_file())
         self.assertEqual(target["production_reset_api"], "forbidden")
         self.assertIn("RLock", target["synchronization"])
         self.assertEqual(
@@ -258,6 +269,139 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         for task_id in ("E-10a", "E-10b", "E-10c"):
             self.assertIn(task_id, roadmap)
         self.assertIn("E-10b is the next READY task", roadmap)
+
+
+class PythonRuntimeTestSupportTests(unittest.TestCase):
+    def test_constructed_runtimes_are_independent_and_not_installed(self):
+        prior = runtime_module._RUNTIME_SERVICES
+        values = {
+            "comfy": object(),
+            "seed_reservations": object(),
+            "config": object(),
+            "clock": object(),
+            "translation": object(),
+            "autocomplete": object(),
+            "wildcard_snapshots": object(),
+            "aio_first_pass_cache": object(),
+        }
+
+        first = build_runtime_services(runtime_module, **values)
+        second = build_runtime_services(runtime_module, **values)
+
+        self.assertIsNot(first, second)
+        self.assertIs(runtime_module._RUNTIME_SERVICES, prior)
+
+    def test_installed_runtime_context_is_nested_and_identity_restoring(self):
+        prior = runtime_module._RUNTIME_SERVICES
+        first = object()
+        second = object()
+
+        with self.assertRaisesRegex(RuntimeError, "stop"):
+            with isolated_installed_runtime(runtime_module, first):
+                self.assertIs(runtime_module._RUNTIME_SERVICES, first)
+                with isolated_installed_runtime(runtime_module, second):
+                    self.assertIs(runtime_module._RUNTIME_SERVICES, second)
+                self.assertIs(runtime_module._RUNTIME_SERVICES, first)
+                raise RuntimeError("stop")
+
+        self.assertIs(runtime_module._RUNTIME_SERVICES, prior)
+
+    def test_bootstrap_context_suppresses_atexit_and_restores_exact_state(self):
+        prior = {
+            "runtime": runtime_module._RUNTIME_SERVICES,
+            "default_runtime": bootstrap._DEFAULT_RUNTIME,
+            "executor": bootstrap._TRANSLATION_ROUTE_EXECUTOR,
+            "atexit_registered": bootstrap._ATEXIT_REGISTERED,
+            "shutdown": bootstrap._SHUTDOWN,
+            "wildcards": bootstrap._WILDCARDS_INITIALIZED,
+            "facade": translation_service._DEFAULT_TRANSLATION_SERVICE,
+            "register": bootstrap.atexit.register,
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "stop"):
+            with isolated_bootstrap_runtime(
+                bootstrap,
+                runtime_module,
+                translation_service,
+            ):
+                self.assertIsNone(runtime_module._RUNTIME_SERVICES)
+                self.assertIsNone(bootstrap._DEFAULT_RUNTIME)
+                self.assertIsNone(bootstrap._TRANSLATION_ROUTE_EXECUTOR)
+                self.assertFalse(bootstrap._ATEXIT_REGISTERED)
+                self.assertFalse(bootstrap._SHUTDOWN)
+                self.assertFalse(bootstrap._WILDCARDS_INITIALIZED)
+                self.assertIsNot(
+                    translation_service._DEFAULT_TRANSLATION_SERVICE,
+                    prior["facade"],
+                )
+                self.assertIsNot(bootstrap.atexit.register, prior["register"])
+                raise RuntimeError("stop")
+
+        self.assertIs(runtime_module._RUNTIME_SERVICES, prior["runtime"])
+        self.assertIs(bootstrap._DEFAULT_RUNTIME, prior["default_runtime"])
+        self.assertIs(
+            bootstrap._TRANSLATION_ROUTE_EXECUTOR,
+            prior["executor"],
+        )
+        self.assertIs(bootstrap._ATEXIT_REGISTERED, prior["atexit_registered"])
+        self.assertIs(bootstrap._SHUTDOWN, prior["shutdown"])
+        self.assertIs(bootstrap._WILDCARDS_INITIALIZED, prior["wildcards"])
+        self.assertIs(
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+            prior["facade"],
+        )
+        self.assertIs(bootstrap.atexit.register, prior["register"])
+
+    def test_translation_facade_context_restores_after_failure(self):
+        prior = translation_service._DEFAULT_TRANSLATION_SERVICE
+        replacement = object()
+
+        with self.assertRaisesRegex(RuntimeError, "stop"):
+            with isolated_translation_facade(
+                translation_service,
+                replacement,
+            ):
+                self.assertIs(
+                    translation_service._DEFAULT_TRANSLATION_SERVICE,
+                    replacement,
+                )
+                raise RuntimeError("stop")
+
+        self.assertIs(
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+            prior,
+        )
+
+    def test_process_global_contexts_are_serialized_for_full_lifetime(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_entered = threading.Event()
+
+        def hold_first():
+            with isolated_installed_runtime(runtime_module, object()):
+                first_entered.set()
+                release_first.wait(timeout=1)
+
+        def enter_second():
+            first_entered.wait(timeout=1)
+            with isolated_installed_runtime(runtime_module, object()):
+                second_entered.set()
+
+        first = threading.Thread(target=hold_first)
+        second = threading.Thread(target=enter_second)
+        first.start()
+        second.start()
+        try:
+            self.assertTrue(first_entered.wait(timeout=1))
+            self.assertFalse(second_entered.wait(timeout=0.05))
+        finally:
+            release_first.set()
+            first.join(timeout=1)
+            second.join(timeout=1)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertTrue(second_entered.is_set())
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -31,6 +31,12 @@ from easyuse_anima.seed.service import InMemorySeedReservationService
 from easyuse_anima.translation import service as translation_service
 from easyuse_anima.translation.service import PromptTranslationService
 from easyuse_anima.wildcard import snapshot as wildcard_snapshot
+from tests.runtime_test_support import (
+    build_runtime_services,
+    enter_test_context,
+    isolated_bootstrap_runtime,
+    isolated_translation_facade,
+)
 
 
 class FakeComfyHostProvider:
@@ -157,33 +163,21 @@ class RuntimeBaseContractTests(unittest.TestCase):
 
 class RuntimeServicesTests(unittest.TestCase):
     def setUp(self):
-        self.runtime_state = patch.object(runtime_module, "_RUNTIME_SERVICES", None)
-        self.runtime_state.start()
-        self.default_runtime_state = patch.object(bootstrap, "_DEFAULT_RUNTIME", None)
-        self.default_runtime_state.start()
-        self.shutdown_state = patch.object(bootstrap, "_SHUTDOWN", False)
-        self.shutdown_state.start()
-        self.atexit_state = patch.object(bootstrap, "_ATEXIT_REGISTERED", False)
-        self.atexit_state.start()
-        self.wildcard_state = patch.object(
-            bootstrap,
-            "_WILDCARDS_INITIALIZED",
-            False,
+        enter_test_context(
+            self,
+            isolated_bootstrap_runtime(
+                bootstrap,
+                runtime_module,
+                translation_service,
+            ),
         )
-        self.wildcard_state.start()
-
-    def tearDown(self):
-        self.wildcard_state.stop()
-        self.atexit_state.stop()
-        self.shutdown_state.stop()
-        self.default_runtime_state.stop()
-        self.runtime_state.stop()
 
     @staticmethod
     def make_runtime(
         cleanup_plan=None,
     ) -> RuntimeServices:
-        return RuntimeServices(
+        return build_runtime_services(
+            runtime_module,
             comfy=FakeComfyHostProvider(),
             seed_reservations=InMemorySeedReservationService(),
             config=RuntimeConfig(
@@ -196,7 +190,7 @@ class RuntimeServicesTests(unittest.TestCase):
             autocomplete=FakeAutocompleteService(),
             wildcard_snapshots=FakeWildcardSnapshots(),
             aio_first_pass_cache=FakeAIOFirstPassCache(),
-            _cleanup_plan=(
+            cleanup_plan=(
                 cleanup_plan
                 if cleanup_plan is not None
                 else runtime_module._RuntimeCleanupPlan()
@@ -259,9 +253,8 @@ class RuntimeServicesTests(unittest.TestCase):
         replacement = PromptTranslationService()
         foreign = PromptTranslationService()
 
-        with patch.object(
+        with isolated_translation_facade(
             translation_service,
-            "_DEFAULT_TRANSLATION_SERVICE",
             original,
         ):
             previous = translation_service._install_default_translation_service(
@@ -324,14 +317,11 @@ class RuntimeServicesTests(unittest.TestCase):
         host = type("Host", (), {"MAX_RESOLUTION": "8192"})()
         load_comfy_nodes = Mock(return_value=host)
 
-        with (
-            patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False),
-            patch.object(
-                bootstrap,
-                "_load_runtime_config",
-                wraps=bootstrap._load_runtime_config,
-            ) as load_runtime_config,
-        ):
+        with patch.object(
+            bootstrap,
+            "_load_runtime_config",
+            wraps=bootstrap._load_runtime_config,
+        ) as load_runtime_config:
             bootstrap.initialize(
                 register_routes=register_routes,
                 initialize_wildcards=initialize_wildcards,
@@ -396,14 +386,11 @@ class RuntimeServicesTests(unittest.TestCase):
         initialize_wildcards = Mock(return_value=object())
         install_runtime(runtime)
 
-        with (
-            patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False),
-            self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    r"^\[EasyUseAnima\] A different RuntimeServices instance "
-                    r"is already installed\.$"
-                ),
+        with self.assertRaisesRegex(
+            RuntimeError,
+            (
+                r"^\[EasyUseAnima\] A different RuntimeServices instance "
+                r"is already installed\.$"
             ),
         ):
             bootstrap.initialize(


### PR DESCRIPTION
## 목적과 변경 경계

- E-10b Move: 테스트에서 직접 소유하던 runtime/bootstrap private-state mutation을 단일 test-only helper로 이동합니다.
- production 변경은 없으며 public reset API, hot reinitialize, route rollback 동작을 추가하지 않습니다.

## Base -> Head

- `acc38f1a8823e83e40dd46491e64c29330559811` -> `6d1d65198385122bfdb6d31e0b0f1513b2714502`

## 주요 변경과 보존 계약

- `tests/runtime_test_support.py`가 constructed runtime, installed runtime, bootstrap lifecycle, translation facade 격리를 한 `RLock` 아래 소유합니다.
- 이전 identity와 scalar lifecycle state를 성공/예외 모두에서 정확히 복원합니다.
- 다섯 기존 owner의 직접 mutation을 helper 사용으로 교체했습니다.
- 기존 assertion, fake provider, E-09 terminal lifecycle, route/API identity와 production behavior를 유지합니다.
- contract inventory는 helper 외 direct mutation 0개, module reload 0개를 증명합니다.

## 검증

- changed-file Python compile: 통과
- fatal Ruff (`E9,F63,F7,F82`): 통과
- direct E-10/bootstrap/runtime/host/translation/E-01/E-09/package/import/analyzer focused targets: 모두 통과
- official full (`6d1d651`, 정확히 1회): Python 1,431 tests / frontend 120 files 통과
- `git diff --check`: 통과
- package/live: production/import/archive/host 경계 변경이 없어 E-10a 증거 재사용

## 남은 위험과 rollback

- process-global fixture는 의도적으로 전체 context 수명 동안 직렬화됩니다. constructed runtime은 병렬 안전합니다.
- rollback은 이 PR의 squash commit revert로 제한됩니다.

## Next

- E-10c completion-audit Contract만 별도 진행합니다. D-14, release, Registry는 그 전에 시작하지 않습니다.
