### PR TITLE
docs: complete runtime test isolation audit (E-10c)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-09 are complete; E-10a fixes the isolated-runtime
-  fixture Contract and E-10b is the next READY task.
+  owns Phase E. E-01 through E-10 are complete; E-10c records the production-free
+  completion audit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- E-10a Contract base: E-09c / PR #558 at
-  `5e99b702731b896ce6a424b7315e98eaff21133f`.
+- E-10c audit base: E-10b / PR #560 at
+  `87a1689f7c5d6452888e7bb8a8f92856d3f2f76f`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -44,14 +44,15 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md).
 - E-10 isolated runtime test fixture Contract and bounded queue:
   [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md).
-- E-09 is complete with `ambiguous_state_owners=[]`; E-10b is the next READY task.
+- Phase E is complete with `ambiguous_state_owners=[]`, module reload sites `[]`,
+  and direct private runtime mutation outside the test helper `[]`.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- Root removal, release, and Registry remain governed by the active roadmap; E-10a
-  authorizes only the E-10b test-infrastructure migration next.
+- Root removal, release, and Registry remain governed by the active roadmap; Phase E
+  completion does not itself authorize those operations.
 
 ## Current code boundary
 
@@ -77,7 +78,7 @@ aliases or absorbing feature behavior.
 
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 evidence, D-14 readiness verdict, completed Phase E units, and the
-  bounded E-08 handoff.
+  completed E-10 audit.
 - [`python-backend.md`](python-backend.md): target ownership and dependency direction.
   Its early implementation snapshot is historical where the active checkpoint differs.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
@@ -108,8 +109,8 @@ aliases or absorbing feature behavior.
   bootstrap terminal lifecycle, reverse cleanup order, partial-initialization
   rollback, retained no-op resources, and the bounded E-09a/b/c queue.
 - [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md):
-  current test reset inventory, one test-only fixture owner, isolation modes, and the
-  bounded E-10a/b/c queue.
+  completed test reset inventory, one test-only fixture owner, isolation modes, and
+  the completed E-10a/b/c queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,13 +2,12 @@
 
 ## Status and authority
 
-- Status: D-08 and E-01 through E-09 are completed; E-10a Contract is fixed and
-  E-10b is the next READY task;
+- Status: D-08 and Phase E (E-01 through E-10) are completed;
   the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- E-10a Contract base:
-  `dev@5e99b702731b896ce6a424b7315e98eaff21133f` after E-09c / PR #558.
-- Document baseline: E-10 isolated runtime test fixture Contract.
+- E-10c completion-audit base:
+  `dev@87a1689f7c5d6452888e7bb8a8f92856d3f2f76f` after E-10b / PR #560.
+- Document baseline: completed E-10 isolated runtime test fixture Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
@@ -19,8 +18,10 @@
   audit Contract, the completed E-07 bridge, the E-08a AiO first-pass cache
   ownership Contract, the E-08b owner Move, the E-08c narrow composition Move, and
   the E-08d completion audit Contract, the E-09a lifecycle Contract, the E-09b
-  cohesive LIFECYCLE implementation, the E-09c completion audit Contract, and the
-  E-10a isolated-runtime-fixture Contract. The next bounded task is E-10b only.
+  cohesive LIFECYCLE implementation, the E-09c completion audit Contract, the E-10a
+  isolated-runtime-fixture Contract, the E-10b test-only owner Move, and the E-10c
+  completion audit Contract. Phase E is complete; this audit does not itself
+  authorize D-14 implementation, release, or Registry work.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -444,8 +445,9 @@ production changes. E-08 is complete. E-09a fixed one bootstrap-owned terminal
 lifecycle, reverse cleanup order, partial-initialization rollback, and explicit
 file-I/O/route/provider/warning no-op dispositions. E-09b implemented the cohesive
 lifecycle and E-09c reconciled E-01 with zero ambiguous owners without production
-changes. E-09 is complete and E-10 is the next READY task. D-14 retirement, release,
-and Registry work remain blocked by their existing roadmap gates.
+changes. E-10 then centralized test-only reset ownership and completed the Phase E
+audit. D-14 retirement, release, and Registry work remain blocked by their existing
+roadmap gates.
 ```
 
 ## 7. E-09 runtime shutdown and cleanup queue
@@ -467,9 +469,9 @@ RuntimeServices close, executor admission, feature cleanup order, global detach,
 unexpected-startup rollback share one lifecycle/concurrency invariant. E-09c changes
 no production and reconciles `ambiguous_state_owners=[]`, the seven completed E-01
 lifecycle dispositions, package/import safety, and the E-09b promotion evidence.
-E-09 is complete. E-10a fixes the test-isolation migration boundary and E-10b is the
-next READY task; D-14, release, and Registry work remain governed by their existing
-blockers.
+E-09 is complete. E-10a fixed the test-isolation migration boundary, E-10b completed
+the test-only Move, and E-10c closes Phase E. D-14, release, and Registry work remain
+governed by their existing blockers.
 
 ### E-09a validation
 
@@ -492,21 +494,22 @@ evidence.
 
 ```text
 E-10a  Contract   current reset inventory and one test-only owner gate complete
-E-10b  Move       cohesive helper and five-owner migration              next
-E-10c  Contract   zero-direct-reset and Phase E completion audit        blocked on E-10b
+E-10b  Move       cohesive helper and five-owner migration              complete
+E-10c  Contract   zero-direct-reset and Phase E completion audit        complete
 ```
 
-The current executable inventory records zero module-reload sites and five direct
-private runtime mutation owners. E-10b moves those mutations behind one serialized
-`tests/runtime_test_support.py` owner while independently constructed RuntimeServices
-values remain parallel-safe. Direct lifecycle assertions may keep reading private
-state; only reset/mutation ownership moves.
+The executable inventory records zero module-reload sites and one serialized
+`tests/runtime_test_support.py` mutation owner. There are zero direct private runtime
+mutation sites outside that helper, while independently constructed RuntimeServices
+values remain parallel-safe. Direct lifecycle assertions keep reading private state;
+only reset/mutation ownership moved.
 
 [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md)
 forbids a production reset API, hot shutdown-to-reinitialize, ContextVar runtime
 behavior, overlapping global installs, route rollback, provider close, and public
-export changes. E-10c must record zero direct private reset outside the helper before
-Phase E closes. D-14, release, and Registry work remain blocked.
+export changes. E-10c records zero direct private reset outside the helper and Phase E
+is complete. That completion does not waive the existing D-14, release, or Registry
+gates.
 
 ### E-10a validation
 
@@ -516,3 +519,16 @@ boundaries, analyzer, maintained-document links, and `git diff --check`. Run off
 full once on the exact final candidate. Because E-10a changes no production, import
 closure, archive, metadata, or host-visible behavior, reuse E-09b package/live
 evidence.
+
+### E-10b and E-10c validation
+
+E-10b passed its direct runtime/bootstrap/host/translation owners, E-10/E-01/E-09
+Contracts, package/no-host import, current import boundaries, analyzer, and diff gate.
+Official full at candidate `6d1d65198385122bfdb6d31e0b0f1513b2714502`
+passed 1,431 Python tests and 120 frontend files exactly once.
+
+E-10c runs changed-file JSON/Python syntax, E-10/E-01/E-09 Contracts,
+package/no-host import, current import boundaries, analyzer, maintained-document links,
+and `git diff --check`. Run official full exactly once on the final candidate SHA.
+Because both tasks change no production, import closure, archive, metadata, or
+host-visible behavior, package/live evidence is reused.

--- a/docs/architecture/python-runtime-e10-test-isolation-contract.md
+++ b/docs/architecture/python-runtime-e10-test-isolation-contract.md
@@ -2,9 +2,10 @@
 
 ## Scope and authority
 
-E-10 starts from `dev@5e99b702731b896ce6a424b7315e98eaff21133f` after
-the production-free E-09c lifecycle completion audit. Issue #187 owns the decision
-ledger. The executable source is
+E-10 started from `dev@5e99b702731b896ce6a424b7315e98eaff21133f` after
+the production-free E-09c lifecycle completion audit. E-10b merged as PR #560 at
+`87a1689f7c5d6452888e7bb8a8f92856d3f2f76f`; E-10c records the completion
+audit. Issue #187 owns the decision ledger. The executable source is
 `tests/fixtures/python_runtime_test_isolation_contract.v1.json`, checked by
 `tests/test_python_runtime_test_isolation_contract.py`.
 
@@ -12,21 +13,12 @@ E-10 changes test ownership, not the production lifecycle. The E-09 terminal
 bootstrap contract remains authoritative: shutdown is process-terminal, no hot
 shutdown-to-reinitialize contract exists, and production exposes no reset API.
 
-## Current inventory
+## Completion inventory
 
-The repository already has zero test calls to `importlib.reload()` or `reload()`.
-The remaining process-runtime reset or mutation is limited to five test owners:
-
-- `tests/test_python_bootstrap.py` resets bootstrap, installed runtime, translation
-  facade, executor, atexit, and wildcard lifecycle state;
-- `tests/test_runtime_services.py` resets installed/default runtime and bootstrap
-  lifecycle state;
-- `tests/test_comfy_host_wiring.py` resets or replaces the installed runtime for
-  adapter tests;
-- `tests/test_prompt_translation.py` temporarily replaces the canonical translation
-  facade for one direct service contract; and
-- `tests/comfy_host_fakes.py` temporarily replaces the installed runtime while
-  layering a fake Comfy provider.
+The repository has zero test calls to `importlib.reload()` or `reload()`. E-10b moved
+all seven lifecycle-global mutations from the five former test owners into
+`tests/runtime_test_support.py`. The helper is now the only mutation owner and the
+direct-private-mutation inventory outside it is empty.
 
 Direct tests may continue to read private lifecycle state when the assertion proves
 identity, terminal state, or rollback behavior. E-10 moves reset and mutation
@@ -70,31 +62,36 @@ It must not add production `reset_runtime`, ContextVar runtime selection, hot
 reinitialize behavior, route deregistration/rollback, provider close, or a public
 export.
 
-## Bounded queue
+## Completed queue
 
-1. **E-10a Contract — complete:** freeze current inventory, the one test-only owner,
+1. **E-10a Contract — complete:** froze the inventory, the one test-only owner,
    isolation modes, migration files, validation, and stop conditions. Production
    changes: zero.
-2. **E-10b Move — next:** add the helper and migrate the five direct mutation
+2. **E-10b Move — complete:** added the helper and migrated the five direct mutation
    owners in one cohesive test-only rollback boundary.
-3. **E-10c Contract — blocked on E-10b:** record reload sites `[]`, direct private
-   mutation outside the helper `[]`, retained direct lifecycle assertions, and the
-   Phase E completion audit without production changes.
+3. **E-10c Contract — complete:** records reload sites `[]`, direct private mutation
+   outside the helper `[]`, retained direct lifecycle assertions, and the Phase E
+   completion audit without production changes.
 
-E-10b is one cohesive migration because all five current sites manipulate the same
+E-10b is one cohesive migration because all five former sites manipulate the same
 process-global runtime identity. Splitting the helper from its consumers would leave
-two competing reset owners. E-10c must merge before Phase E can close. D-14, release,
-and Registry work remain blocked by the active roadmap.
+two competing reset owners. E-10c closes Phase E. That completion does not itself
+authorize D-14 implementation, release, or Registry work; those remain governed by
+their existing roadmap gates.
 
 ## Validation and evidence reuse
 
-E-10a runs changed-file JSON/Python syntax, the new Contract, E-01 and E-09 direct
-Contracts, bootstrap/runtime/Comfy owner tests, package/no-host import, current import
-boundaries, analyzer, maintained-document links, and `git diff --check`.
+E-10b passed the E-10 Contract/support tests, E-01/E-09 Contracts, direct bootstrap,
+runtime, Comfy host, and translation owners, package/no-host import, current import
+boundaries, analyzer, and `git diff --check`. Its official full on candidate
+`6d1d65198385122bfdb6d31e0b0f1513b2714502` passed 1,431 Python tests and 120
+frontend files exactly once.
 
-Run the official full profile once on the exact final candidate SHA. E-10a changes no
-production, import closure, archive, metadata, or host-visible behavior, so reuse the
-E-09b validate/pack/archive and isolated ComfyUI import/reload/shutdown evidence.
+E-10c runs changed-file JSON/Python syntax, the E-10/E-01/E-09 Contracts,
+package/no-host import, current import boundaries, analyzer, maintained-document
+links, and `git diff --check`, then runs official full once on its exact final
+candidate SHA. E-10b and E-10c change no production, import closure, archive,
+metadata, or host-visible behavior, so package/live evidence is reused.
 
 ## Stop conditions
 

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -9,8 +9,9 @@ The executable source of truth is
 rejects stale symbols, missing evidence, analyzer owner candidates without an owner,
 and mutable globals without an explicit disposition.
 
-E-01 records the current state. It does not move state, add lifecycle behavior, or
-claim that Phase E is complete.
+E-01 records the current state. It did not move state or add lifecycle behavior; the
+separate E-10c completion audit now confirms that every recorded Phase E owner has a
+completed disposition.
 
 ## Method
 
@@ -211,5 +212,14 @@ E-09b implements that one cohesive lifecycle, and the production-free E-09c audi
 reconciles the seven E-01 lifecycle targets as `E-09-complete`. The callerless Artist
 Mix warning set is removed, the Conditioning set remains process-lifetime, all six
 feature cleanup owners retain their existing semantics, package/import surfaces are
-unchanged, and `ambiguous_state_owners=[]`. E-09 is complete; E-10 is the next READY
-task and requires its own bounded task card.
+unchanged, and `ambiguous_state_owners=[]`. E-09 is complete.
+
+## E-10 and Phase E completion result
+
+The production-free E-10a Contract selected one test-only runtime fixture owner.
+E-10b moved the five former mutation sites behind that owner while preserving direct
+read-only lifecycle assertions and exact prior identity/state restoration. E-10c
+records module reload sites `[]`, direct private lifecycle mutation outside
+`tests/runtime_test_support.py` `[]`, and ambiguous test reset owners `[]`. Every E-01
+target disposition ends in `-complete`; Phase E is complete without a production,
+public-surface, package, import, or host-visible behavior change.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -60,15 +60,16 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- E-10a Contract base: E-09c / PR #558 at
-  `5e99b702731b896ce6a424b7315e98eaff21133f`.
+- E-10c audit base: E-10b / PR #560 at
+  `87a1689f7c5d6452888e7bb8a8f92856d3f2f76f`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-09 are complete with `ambiguous_state_owners=[]`. E-10a fixes the
-  test-isolation Contract and E-10b is the next READY task. The #323
+- E-01 through E-10 and Phase E are complete with `ambiguous_state_owners=[]`, zero
+  module reload sites, and zero direct private runtime mutation outside the test-only
+  helper. The #323
   E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -379,5 +379,5 @@
   ],
   "ignored_mutable_global_names": ["__all__"],
   "schema_version": 1,
-  "scope": "Shipped Python process-wide state, import/bootstrap effects, and analyzer mutable-global disposition through the E-09c lifecycle completion audit."
+  "scope": "Shipped Python process-wide state, import/bootstrap effects, and analyzer mutable-global disposition through the E-10c Phase E completion audit."
 }

--- a/tests/fixtures/python_runtime_test_isolation_contract.v1.json
+++ b/tests/fixtures/python_runtime_test_isolation_contract.v1.json
@@ -1,6 +1,14 @@
 {
   "base_sha": "5e99b702731b896ce6a424b7315e98eaff21133f",
   "classification": "Contract",
+  "completion_audit": {
+    "ambiguous_test_reset_owners": [],
+    "direct_private_mutation_sites_outside_helper": [],
+    "module_reload_sites": [],
+    "phase_e_status": "complete",
+    "production_changes": 0,
+    "retained_read_only_assertion_policy": "Direct lifecycle tests may continue to inspect private state; only mutation and reset ownership is centralized."
+  },
   "current_inventory": {
     "module_reload_sites": [],
     "private_mutation_sites": [
@@ -73,11 +81,11 @@
       "classification": "Contract",
       "goal": "Record zero reload sites and zero direct private runtime mutations outside the helper, then close Phase E.",
       "id": "E-10c",
-      "status": "ready"
+      "status": "complete"
     }
   ],
   "schema_version": 1,
-  "scope": "E-10 isolated runtime test fixtures and private-reset ownership through the E-10b Move",
+  "scope": "E-10 isolated runtime test fixtures and private-reset ownership through the E-10c Phase E completion audit",
   "target_fixture": {
     "invariants": [
       "restore exact prior identities and scalar lifecycle state after success or failure",

--- a/tests/test_python_runtime_lifecycle_contract.py
+++ b/tests/test_python_runtime_lifecycle_contract.py
@@ -463,7 +463,7 @@ class PythonRuntimeLifecycleContractTests(unittest.TestCase):
         for task_id in ("E-09a", "E-09b", "E-09c"):
             self.assertIn(task_id, roadmap)
         self.assertIn("E-09 is complete", roadmap)
-        self.assertIn("E-10 is the next READY task", roadmap)
+        self.assertIn("Phase E is complete", roadmap)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -193,6 +193,15 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
             {entry["target_phase"] for entry in self.fixture["entries"]},
         )
 
+    def test_phase_e_completion_has_no_active_owner_targets(self):
+        self.assertTrue(
+            all(
+                entry["target_phase"].endswith("-complete")
+                for entry in self.fixture["entries"]
+            )
+        )
+        self.assertIn("E-10c Phase E completion audit", self.fixture["scope"])
+
     def test_runtime_entries_bind_existing_shipped_symbols(self):
         for entry in self.fixture["entries"]:
             module_path = ROOT / entry["module"]

--- a/tests/test_python_runtime_test_isolation_contract.py
+++ b/tests/test_python_runtime_test_isolation_contract.py
@@ -148,6 +148,7 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
             {
                 "base_sha",
                 "classification",
+                "completion_audit",
                 "current_inventory",
                 "evidence",
                 "implementation_boundary",
@@ -171,7 +172,7 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [item["status"] for item in self.fixture["queue"]],
-            ["complete", "complete", "ready"],
+            ["complete", "complete", "complete"],
         )
         for evidence in self.fixture["evidence"]:
             self.assertTrue((ROOT / evidence).is_file(), evidence)
@@ -185,6 +186,30 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         self.assertEqual(_module_reload_sites(), inventory["module_reload_sites"])
         self.assertEqual(_private_mutation_sites(), expected_mutations)
         self.assertEqual(inventory["module_reload_sites"], [])
+        helper = self.fixture["target_fixture"]["module"]
+        self.assertEqual(
+            {
+                module: symbols
+                for module, symbols in expected_mutations.items()
+                if module != helper
+            },
+            {},
+        )
+
+    def test_completion_audit_closes_phase_e_without_new_behavior(self):
+        audit = self.fixture["completion_audit"]
+        self.assertEqual(audit["ambiguous_test_reset_owners"], [])
+        self.assertEqual(
+            audit["direct_private_mutation_sites_outside_helper"],
+            [],
+        )
+        self.assertEqual(audit["module_reload_sites"], [])
+        self.assertEqual(audit["phase_e_status"], "complete")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertIn(
+            "inspect private state",
+            audit["retained_read_only_assertion_policy"],
+        )
 
     def test_target_fixture_has_one_test_only_serialized_owner(self):
         target = self.fixture["target_fixture"]
@@ -268,7 +293,8 @@ class PythonRuntimeTestIsolationContractTests(unittest.TestCase):
         )
         for task_id in ("E-10a", "E-10b", "E-10c"):
             self.assertIn(task_id, roadmap)
-        self.assertIn("E-10b is the next READY task", roadmap)
+        self.assertIn("Phase E is complete", roadmap)
+        self.assertIn("E-10c", roadmap)
 
 
 class PythonRuntimeTestSupportTests(unittest.TestCase):


### PR DESCRIPTION
## 목적과 변경 경계

- E-10c Contract: test-runtime isolation inventory를 완료 상태로 고정하고 Phase E를 닫습니다.
- production 변경은 0개이며 lifecycle/public/import/package 동작을 바꾸지 않습니다.

## Base -> Head

- `87a1689f7c5d6452888e7bb8a8f92856d3f2f76f` -> `799787654fd7aa51414e09921146d34a1573e2ef`

## 완료 계약

- module reload sites: `[]`
- `tests/runtime_test_support.py` 외 direct private runtime mutation: `[]`
- ambiguous test reset owners: `[]`
- 모든 E-01 target disposition: `-complete`
- direct lifecycle tests의 read-only private-state assertion은 유지
- E-09 terminal/idempotent lifecycle, cleanup order, identity restoration과 public surfaces는 변경 없음

## 검증

- changed-file JSON/Python syntax 및 fatal Ruff: 통과
- E-10 Contract/support, E-01, E-09 focused targets: 통과
- package/no-host import, current import boundaries, analyzer: 통과
- `git diff --check`: 통과
- official full (`7997876`, 정확히 1회): Python 1,433 tests / frontend 120 files 통과
- package/live: production/import/archive/host 경계 변경이 없어 E-10b 증거 재사용

## 남은 위험과 rollback

- 이 PR은 문서·executable fixture·contract assertion만 변경합니다.
- rollback은 squash commit revert로 제한됩니다.

## Next

- Phase E 완료를 Issue #187에 기록합니다.
- 기존 D-14 gate를 별도로 재평가하되, 이 PR은 D-14 구현·release·Registry를 승인하지 않습니다.
