### PR TITLE
docs: refresh D-14 readiness after Phase E

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,17 +9,18 @@ then only the active task section, owning Issue, direct source, and direct tests
 
 ## Active sequencing
 
-- Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-10 are complete; E-10c records the production-free
-  completion audit.
-  Issue #186 retains D-14/shim decisions.
+- Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187) is
+  completed: E-01 through E-10 and Phase E are closed.
+  Issue #186 remains open as the retained D-14/shim decision ledger.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- E-10c audit base: E-10b / PR #560 at
-  `87a1689f7c5d6452888e7bb8a8f92856d3f2f76f`.
+- E-10c completion and D-14 post-Phase-E audit base: PR #561 at
+  `121ee8a1cae826fc1b5227208f964d143b5b6324`.
 - D-08 is complete and D-08v is not required.
-- D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
+- D-14 post-Phase-E readiness retains every root surface; lifecycle ownership is
+  complete, but production imports, release windows, and consumer evidence still
+  block retirement/final-freeze work.
 - E-01 inventory Contract:
   [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md).
 - E-02b base Contract:
@@ -145,5 +146,5 @@ The efficiency protocol chooses the smallest sufficient evidence; it does not we
 correctness, compatibility, package, live, or release gates.
 
 The D-14 readiness audit authorizes no deletion. Root removal still needs the recorded
-consumer/release/lifecycle gates and a separate breaking-change decision. The E-01
-inventory authorizes no behavior change, release publication, tag, or Registry action.
+production-import, consumer, release, rollback, and breaking-change gates. Phase E
+completion authorizes no release publication, tag, or Registry action.

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,11 +2,11 @@
 
 ## Status and authority
 
-- Status: D-08 and Phase E (E-01 through E-10) are completed;
-  the D-14
-  readiness audit retains every root surface and blocks retirement/final-freeze work.
-- E-10c completion-audit base:
-  `dev@87a1689f7c5d6452888e7bb8a8f92856d3f2f76f` after E-10b / PR #560.
+- Status: D-08 and Phase E (E-01 through E-10) are completed; the D-14
+  post-Phase-E readiness audit retains every root surface and blocks
+  retirement/final-freeze work.
+- E-10c completion merge and D-14 post-Phase-E audit base:
+  `dev@121ee8a1cae826fc1b5227208f964d143b5b6324` after E-10c / PR #561.
 - Document baseline: completed E-10 isolated runtime test fixture Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
@@ -260,7 +260,7 @@ small implementation choices do not require PRO review.
 
 ## 5. D-14 readiness result and next owner
 
-The D-08u audit found no required D-08v. After D-08:
+The original D-08u audit found no required D-08v. At that checkpoint:
 
 1. Issue #186, local release-tag trees, production consumers, and the compatibility
    registry were reconciled at `dev@597d1c9`;
@@ -299,7 +299,33 @@ The D-08u audit found no required D-08v. After D-08:
     and
 18. never remove root files merely to make the directory tree appear complete.
 
+### D-14 post-Phase-E re-audit
+
+The lifecycle trigger was re-audited at
+`dev@121ee8a1cae826fc1b5227208f964d143b5b6324` after E-10c:
+
+- E-09 completed bootstrap lifecycle ownership, but root `__init__.py` still imports
+  `api.py`, whose injected payload/runtime callbacks and registrar facade remain
+  production composition inputs;
+- E-06d/E-06e completed wildcard runtime binding and cleanup audit, but root
+  `nodes.py` and `api.py` still import `wildcard_engine.py` directly and rely on its
+  call-time seams;
+- the available release tags remain v0.6.0, v0.6.1, and v0.6.2, so the final API,
+  wildcard, `api_contract.py`, `autocomplete_dataset.py`, and `anima_prompt/` forms
+  completed after v0.6.2 have no release N;
+- the older direct/public shims still lack removal-supporting consumer evidence and
+  an approved breaking-change decision; and
+- removal-approved surfaces remain zero. D-14 retirement/final freeze, root deletion,
+  release, and Registry work are not authorized by this audit.
+
+Issue #186 remains open as the retained compatibility ledger. No root-removal task is
+READY until one of its release-window, consumer, production-import, breaking-change,
+or rollback gates materially changes.
+
 ## 6. E-01/E-02/E-03/E-04c result and Codex resume instruction
+
+Phase E is now complete; the block below is accumulated execution history, not a
+READY queue. Current Codex work must use the post-Phase-E D-14 verdict above.
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -58,20 +58,21 @@ import them.
 | --- | --- | --- | --- | --- | --- | --- |
 | Root `__init__.py` exports | Permanent ComfyUI entrypoint, not a shim | root entrypoint plus `easyuse_anima.registration`/`bootstrap` | #184/#185 | Existing 0.5.2 surface; B-11 rewires internals | ComfyUI loader; node contract fixture | Not removable as a package entrypoint |
 | `nodes.py` mapped public classes | Explicit 18-class compatibility re-export shim; no residual root definitions | `easyuse_anima.nodes.*_nodes` | #184 B-04 through B-11, #188 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | Root mappings and saved workflows; exact identity fixture; no confirmed external direct importer | Retained; v0.6.1/v0.6.2 satisfy the minimum window, but there is no consumer evidence or approved public breaking change |
-| `api.py` route-registration surface | Transitional API composition/runtime facade after D-08u; not yet an ADR-002 direct re-export shim | `easyuse_anima.api.router`, `.requests`, `.responses`, `.errors`, feature route modules, `easyuse_anima.profiles.*`, and bootstrap composition | #162, #163, #165, #186 D-02-D-08/D-14 | Existing 0.5.2 route surface; D-08u/PR #525 locks the current 21-route composition after v0.6.2 | Root entrypoint side-effect import, frontend endpoints, `wildcard_engine` callback, profile/API tests | Blocked and retained; root entrypoint/runtime consumers remain and no published release contains the current complete facade/canonical composition |
+| `api.py` route-registration surface | Transitional API composition/runtime facade after D-08u and E-09; not yet an ADR-002 direct re-export shim | `easyuse_anima.api.router`, `.requests`, `.responses`, `.errors`, feature route modules, `easyuse_anima.profiles.*`, and bootstrap composition/lifecycle | #162, #163, #165, #186 D-02-D-08/D-14, #187 E-09 | Existing 0.5.2 route surface; D-08u locks the 21-route composition and E-09 completes bootstrap lifecycle after v0.6.2 | Root entrypoint side-effect import, frontend endpoints, `wildcard_engine` callback, injected payload/runtime/registrar seams, profile/API tests | Blocked and retained; root entrypoint/runtime consumers remain and no published release contains the current complete facade/canonical composition/lifecycle |
 | `api_contract.py` request/error helpers | Explicit 12-symbol request/error/response identity shim (D-02) | `easyuse_anima.api.requests`, `.responses`, and `.errors` | #165, #186 D-02/D-14 | Canonicalized in PR #481 after v0.6.2; exact root surface and flat/package identity fixture | External/legacy imports and compatibility tests; production `api.py` uses canonical owners | Retained; first canonical-plus-shim release N has not shipped |
 | `settings.py` | Explicit direct re-export shim (D-09) | `easyuse_anima.settings.schema`, `.repository`, and `.service` | #163, #186 D-09 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports and settings compatibility tests; production callers use canonical modules | Retained; minimum window passed, but consumer evidence does not support removal |
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports and storage compatibility tests; production callers use canonical modules | Retained; minimum window passed, but consumer evidence does not support removal |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Exact seven-name `__all__`; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports; production dataset/search owners use the canonical module | Retained; minimum window passed, but consumer evidence does not support removal |
 | `autocomplete_dataset.py` | Explicit 15-symbol dataset/search/classification identity shim (D-11) | `easyuse_anima.autocomplete.dataset`, `.search`, and `.classification` | #162, #186 D-11 | Final classification shim completed in PR #480 after v0.6.2 | External/legacy imports and direct compatibility tests; production API uses canonical owners | Retained; first complete canonical-plus-shim release N has not shipped |
-| `wildcard_engine.py` | Compatibility adapter over canonical wildcard snapshot/service owners; not yet an ADR-002 direct re-export shim because call-time source/build seams and root composition consumers remain | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, `.service`, `.seed`, `.mode`, `.selector`, `.library`, and `.expansion`; E-06d owns remaining runtime composition | #184, #186 D-12, #187 E-06 | D-12 completed in PR #469; E-06b/E-06c after v0.6.2 install the final snapshot/service owners and canonical internal imports | `nodes.py`, `api.py`, external/legacy imports, wildcard/workflow tests | Blocked and retained; E-06d/E-06e composition/audit and a later release window are required |
+| `wildcard_engine.py` | Compatibility adapter over completed canonical wildcard snapshot/service/runtime owners; not an ADR-002 direct re-export shim because call-time source/build seams and root production consumers remain | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, `.service`, `.seed`, `.mode`, `.selector`, `.library`, and `.expansion` | #184, #186 D-12, #187 E-06 | D-12 and E-06b-E-06e complete the canonical owner, internal caller, runtime binding, and audit after v0.6.2 | `nodes.py`, `api.py`, external/legacy imports, wildcard/workflow tests | Blocked and retained; direct root production consumers remain and the final post-v0.6.2 adapter/canonical form has no release N |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports and translation compatibility tests; production callers use canonical modules | Retained; minimum window passed, but consumer evidence does not support removal |
 | `anima_prompt/` package | Explicit package and submodule identity shims (D-13) | `easyuse_anima.prompt.anima.*` | #184, #186 D-13/D-14 | Canonicalized in PR #479 after v0.6.2 with explicit `__all__`, flat/package identity, and packed closure | External/legacy imports and direct compatibility tests; production callers use the canonical package | Retained; first canonical-plus-shim release N has not shipped |
 
 ## D-14 readiness checkpoint
 
-The 2026-07-28 audit at `dev@597d1c9` records a retention decision, not a
-retirement authorization:
+The 2026-07-29 post-Phase-E audit at
+`dev@121ee8a1cae826fc1b5227208f964d143b5b6324` confirms the original retention
+decision rather than authorizing retirement:
 
 - release-tree inspection covers tags v0.6.0, v0.6.1, and v0.6.2; it does not
   substitute for a future published-package read-back when a removal is proposed;
@@ -81,17 +82,18 @@ retirement authorization:
   available consumer evidence is insufficient for removal;
 - `api_contract.py`, `autocomplete_dataset.py`, and `anima_prompt/` reached their
   final shim form after v0.6.2, so release N has not started;
-- `api.py` remains the imported API composition/runtime facade, and
-  `wildcard_engine.py` remains an E-06 compatibility/composition adapter with direct
-  root production consumers and call-time seams; neither is a removable direct
-  re-export shim; and
+- `api.py` remains the root-entrypoint-imported API composition/runtime facade even
+  though E-09 completed bootstrap lifecycle ownership;
+- E-06d/E-06e are complete, but `wildcard_engine.py` still has direct `nodes.py` and
+  `api.py` production consumers plus call-time seams, and its final form has not
+  shipped in a release N; neither surface is a removable direct re-export shim; and
 - there are zero removal-approved root surfaces. D-14 retirement/final-freeze work
-  stays blocked until the recorded release, consumer, production-import, lifecycle,
+  stays blocked until the recorded release, consumer, production-import,
   breaking-change, and rollback gates pass.
 
-The next independent roadmap unit is #187 E-01 global-state inventory. It may
-inventory the remaining runtime owners, but it does not remove or weaken any root
-compatibility surface.
+Issue #187 and Phase E are complete. No root-removal task is READY: Issue #186 stays
+open as the retained ledger until release-window, consumer, production-import,
+breaking-change, and rollback evidence changes.
 
 ## Entry details
 
@@ -1385,10 +1387,10 @@ EasyUseAnimaWildcard
   LoRA profile operations/repair to `easyuse_anima.profiles.repository`,
   `.aio`, and `.lora`. Existing envelope/CAS owners remain `.contract` and
   `.mutation`.
-- `api.py` keeps explicit identical aliases for the synchronous profile
-  operations called by its handlers. Request parsing, the bounded file-I/O
-  adapter, error-to-response mapping, response construction, preview handling,
-  and route registration remain root API responsibilities until D-02-D-07.
+- After D-08u, `api.py` keeps compatibility aliases plus injected payload/runtime
+  callbacks and the registrar facade. Concrete handler factories and request
+  correlation are bootstrap-composed, but the root entrypoint still imports the
+  module and passes its registration/runtime seams into bootstrap.
 - Directory, size, mutation, and storage test seams move to their canonical
   owner. The aliases are not promoted into a declared public `api.py`
   `__all__`; D-14 decides the supported root surface after consumer evidence.
@@ -1398,8 +1400,9 @@ EasyUseAnimaWildcard
   composition passes dynamic callables so the established translation service,
   timeout worker, error response, and test patch seams remain effective.
 - D-03b moves the bounded worker implementation and wait/cancel/timeout policy
-  to a side-effect-free canonical executor. Root constructs the singleton,
-  registers shutdown, and keeps the established worker and timeout patch seams.
+  to a side-effect-free canonical executor. E-04d composes the route worker in
+  bootstrap, and E-09 closes admission through the bootstrap lifecycle while root
+  retains its compatibility reference and timeout patch seams.
 - D-04a moves the read-only AiO Torch Compile recommendation handler to a pure
   canonical factory while root keeps diagnostics/recommendation patch seams,
   correlation, route order, and registration composition.
@@ -1515,18 +1518,15 @@ EasyUseAnimaWildcard
   `Generator(PCG64(normalized_seed))`.
 - D-12f2 moves only `_Selector` under that contract. Root retains direct class
   identity, its NumPy binding, and every expansion caller.
-- Root binds the 12 model names, eight supported source names, two private
-  snapshot seams, and nine seed-control names directly to canonical objects.
-  D-12e adds ten direct mode aliases, including the identical mutable alias
-  dictionary. D-12f2 adds the direct private selector alias while preserving
-  root eager NumPy. Source verification, snapshot publication/cache/condition/
-  single-flight/retry, expansion, enforcement, and diagnostics remain
-  root-owned for later D-12 slices and E-06.
-- Canonical target for the remaining implementation:
-  `easyuse_anima.wildcard` sources/snapshot/expansion modules. Snapshot
-  lifecycle/factory/cleanup remains E-06.
-- Removal gate: #159/#160 behavior fixtures, seed and expansion parity,
-  0.5.2 workflow load/save/reload, root/canonical identity, and archive closure.
+- Root binds the supported model/source/seed/mode/selector identities to canonical
+  objects while preserving eager NumPy and call-time source/build patch seams.
+  D-12 and E-06b-E-06e complete canonical materialization, snapshot/service
+  ownership, internal callers, narrow RuntimeServices binding, and cleanup audit.
+  Root `nodes.py` and `api.py` nevertheless still import the adapter directly.
+- Removal gate: eliminate or explicitly migrate those production consumers, ship the
+  final canonical-plus-adapter form through release N, retain #159/#160 behavior,
+  seed/expansion and workflow parity, root/canonical identities, archive closure,
+  consumer evidence, and a separate breaking-change decision.
 
 ### `prompt_translation.py`
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -59,14 +59,15 @@ ordinary `dev` roadmap work.
 ## Active state
 
 - Released baseline: 0.6.2.
-- Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- E-10c audit base: E-10b / PR #560 at
-  `87a1689f7c5d6452888e7bb8a8f92856d3f2f76f`.
+- Issue #187 and Phase E are complete. Issue #186 remains open as the retained
+  D-14/shim decision ledger.
+- E-10c completion and D-14 post-Phase-E audit base: PR #561 at
+  `121ee8a1cae826fc1b5227208f964d143b5b6324`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
-- D-14 readiness is audited: every root surface is retained and retirement/final
-  freeze is blocked by production/lifecycle consumers, missing release windows, or
-  insufficient consumer evidence.
+- D-14 post-Phase-E readiness retains every root surface. Lifecycle ownership is
+  complete, but direct production imports, missing release windows, and insufficient
+  consumer evidence still block retirement/final freeze.
 - E-01 through E-10 and Phase E are complete with `ambiguous_state_owners=[]`, zero
   module reload sites, and zero direct private runtime mutation outside the test-only
   helper. The #323
@@ -166,8 +167,7 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. The production-free E-08d
-  audit reconciles the exact AiO cache owner, cleanup, import/root/runtime binding,
-  and zero ambiguous state; use that evidence only to start the separate E-09
-  Contract. Do not infer E-09 implementation, release
-  publication, or Registry actions.
+- D-14 post-Phase-E readiness is recorded and authorizes no removal. E-09/E-10 and
+  Phase E are complete, but `api.py` and `wildcard_engine.py` still have direct
+  production consumers and final post-v0.6.2 forms without release N. Do not infer
+  root deletion, release publication, or Registry actions.


### PR DESCRIPTION
## 목적과 변경 경계

- Phase E 완료 후 D-14 root-surface readiness를 current production imports와 release-window evidence로 재평가합니다.
- docs-only Contract/gate이며 production, tests, fixtures, root files와 aliases는 변경하지 않습니다.

## Base -> Head

- `121ee8a1cae826fc1b5227208f964d143b5b6324` -> `d44999b0aaae21e0770398df0eff997e9f51d9d3`

## 판정

- removal-approved surface: 0
- `api.py`: E-09 lifecycle 완료 후에도 root `__init__.py` import와 payload/runtime/registrar production composition이 남아 retained
- `wildcard_engine.py`: E-06d/E-06e 완료를 반영했지만 `nodes.py`/`api.py` direct consumers와 call-time seams가 남고 final post-v0.6.2 form에 release N이 없어 retained
- `api_contract.py`, `autocomplete_dataset.py`, `anima_prompt/`: v0.6.2 이후 final form이라 release N 미시작
- 기존 direct/public shims: removal-supporting consumer evidence와 breaking-change 승인 없음
- D-14 retirement/final freeze, root deletion, release, Registry: 승인되지 않음

## 검증과 증거 재사용

- exact production import scan: root `__init__.py -> api.py`; `api.py`/`nodes.py -> wildcard_engine.py` 확인
- local release tags: v0.6.0, v0.6.1, v0.6.2만 존재
- maintained roadmap/readme link smoke 1 target: 통과
- stale E-06/E-09 blocker 문구 scan: 0건
- `git diff --check`: 통과
- docs-only이므로 official full/package/live 미재실행; E-10c full과 E-09b package/live 증거 재사용

## 남은 위험과 Next

- external consumer evidence는 새로 확인되지 않았습니다. evidence가 없으면 retain하는 ADR-002 판정입니다.
- Issue #186을 retained compatibility ledger로 open 유지합니다. release-window, consumer, production-import, breaking-change 또는 rollback gate가 달라질 때만 재평가합니다.
