### PR TITLE
docs: re-audit typed Prompt boundary after F-02a

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02a Autocomplete typed result contracts.
+  / F-02b Prompt Studio Advanced field typed contract.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -28,8 +28,10 @@ then only the active task section, owning Issue, direct source, and direct tests
   not block `dev`; do not republish or mutate the release.
 
 ```text
-READY  F-02a Autocomplete typed result contracts
-  -> re-audit the affected Phase F row
+COMPLETE F-02a Autocomplete typed result contracts
+  -> COMPLETE affected-row re-audit
+  -> READY F-02b Prompt Studio Advanced field typed contract
+  -> re-audit the affected Prompt row
   -> next smallest F-02 while a finding remains
   -> G-04A public API snapshot coverage audit
   -> optional G-04B gap

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02a Autocomplete typed result contracts.
+- Active first task: Issue #563 / F-02b Prompt Studio Advanced field typed contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -65,8 +65,10 @@ ADR-002 result when evidence is absent or ambiguous.
 ### Lane A — Active maintainability work
 
 ```text
-READY F-02a   Autocomplete typed result contracts             #563
-  -> RE-AUDIT affected Phase F row
+COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
+  -> COMPLETE affected-row re-audit
+  -> READY F-02b Prompt Studio Advanced field typed contract   #563
+  -> RE-AUDIT affected Prompt row
   -> F-02      next smallest targeted gap while one remains
   -> G-04A    public API snapshot coverage audit              #188
   -> OPTIONAL G-04B  minimal missing public-surface gate
@@ -131,18 +133,21 @@ Rules:
 Exit:
 
 - no gap: record Phase F complete and start G-04A;
-- gap: execute only the smallest F-02, re-audit the affected row, then start G-04A.
+- gap: execute only the smallest F-02, re-audit the affected row, then select the
+  next smallest remaining finding or start G-04A when Phase F closes.
 
-Audit result at `bade01e36146456e163341998ab1a7a19a4ae0b3`:
+Audit result, updated after F-02a merged at
+`3a306498325c48126325aadc6d31665acf3517b4`:
 
 - [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md)
   records the production-free six-area inventory and reuses the existing
   deterministic fixtures;
-- Phase F remains open: settings typed migration, Prompt/Autocomplete result
-  boundaries, and the common feature error taxonomy have exact follow-up findings;
-- only the smallest follow-up, F-02a Autocomplete typed result contracts, is selected
-  as the next task card;
-- G-04A and Issue #188 remain blocked until the affected Phase F rows are re-audited.
+- Autocomplete and Wildcard are complete after F-02a; Prompt's normalized Advanced
+  fields and canonical Prompt Data remain exact, separable follow-up findings;
+- only the smallest follow-up, F-02b Prompt Studio Advanced field typed contract, is
+  selected as the next task card;
+- settings migration and common error taxonomy remain separate findings;
+- G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
 
 ## 4. G-04A — Public API snapshot coverage audit
 
@@ -357,31 +362,33 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #563 / F-02a only from latest origin/dev after F-01 merges.
+Start Issue #563 / F-02b only from latest origin/dev after the F-02a affected-row
+re-audit merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document's F-01 result and validation sections
-- python-typed-boundary-f01-audit.md F-02a task card
+- python-typed-boundary-f01-audit.md F-02b task card
 - Issue #563 latest checkpoint
-- python-runtime-e05-autocomplete-contract.md
-- direct Autocomplete owner source/tests and current Pyright/import/API fixtures
+- direct Prompt Advanced owner source/tests and current Pyright/import fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Define canonical Autocomplete source/status/search/classification TypedDict results
-and apply them to the runtime port, service, core, and API redaction adapter without
-changing runtime dictionaries, path redaction, owner identity, or public exports.
-Reuse the existing Autocomplete runtime fixture and direct owner tests; update only a
-direct generated analyzer baseline when the new canonical module requires it.
+Define one canonical internal TypedDict for the normalized eight-key Advanced-field
+shape and apply it through direct Prompt, Prompt Studio node-adapter, AiO-conditioning,
+wildcard, translation, and artist-mix consumers without changing runtime dictionaries,
+input/workflow migration, field order/defaults, behavior, identities, or public exports.
+Reuse the direct Prompt Studio, AiO conditioning, node-owner, Pyright, and import tests;
+update only a direct generated analyzer baseline if the canonical module requires it.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run official full once on the final production/test/tool SHA.
 Package/live are not triggered.
 
-Push a dev-targeted Draft PR. After review and merge, execute the smallest F-02 only
-if required; otherwise start #188 G-04A.
+Push a dev-targeted Draft PR. After review and merge, re-audit the Prompt row and
+execute only its next smallest F-02 while a finding remains; otherwise continue the
+remaining Phase F rows before #188 G-04A.
 
 Do not remove root files, add deprecation warnings/telemetry, publish a release, or
 perform Registry work.

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -3,13 +3,14 @@
 ## Status
 
 - Owner: Issue #563
-- Base: `bade01e36146456e163341998ab1a7a19a4ae0b3`
+- Base: `3a306498325c48126325aadc6d31665acf3517b4`
 - Class: Contract/gate
 - Production changes: none
 - Result: Phase F remains open; G-04A is not READY
 
 This audit reuses the current Pyright, import-boundary, API, profile, workflow,
-Autocomplete, Wildcard, and AiO schema/migration evidence. It adds no second
+Autocomplete, Wildcard, and AiO schema/migration evidence. The Prompt/Wildcard/
+Autocomplete row was re-audited after F-02a merged as PR #566. It adds no second
 machine-readable inventory because the current deterministic fixtures and direct
 owner tests can express every finding below.
 
@@ -19,7 +20,7 @@ owner tests can express every finding below.
 | --- | --- | --- | --- |
 | Settings, profile, and workflow schema/migration | Profile v2 identity/revision and pure read migration are owned by `easyuse_anima/profiles/contract.py`; the strict Pyright owner is fixed by `tests/fixtures/pyright_baseline.json`. Settings persistence/projection is owned by `easyuse_anima/settings/schema.py`, `repository.py`, and `service.py`. Read-only ComfyUI workflow lookup is owned by `easyuse_anima/workflow.py`. Direct evidence is in `tests/test_profile_contract.py`, `tests/test_lora_profiles.py`, `tests/test_aio_profiles.py`, `tests/test_api_contract.py`, and `tests/test_node_contracts.py`. | Profile payload mappings preserve legacy and future fields at the persisted JSON migration boundary. `_get_workflow_node` accepts dynamic host `extra_pnginfo` and returns a raw workflow node only at the ComfyUI adapter boundary. | **exact F-02 follow-up required.** Profile and workflow boundaries are complete or intentional, but ordinary settings have no version detection, pure migration sequence, or typed post-normalization model. Long-text settings write a v1 envelope, yet their normalized value and the settings service still cross feature code as unparameterized dictionaries. |
 | API request/result/error | `easyuse_anima/api/requests.py` validates JSON-object bodies and produces typed scalar fields; `easyuse_anima/api/errors.py` owns `ApiContractError`; `easyuse_anima/api/responses.py` owns the stable error envelope and request correlation. `tests/test_api_contract_compatibility.py` and the direct route classes in `tests/test_api_contract.py` freeze the behavior. | Request bodies and success/error dictionaries exist at the JSON serialization adapter. Profile and settings sub-objects remain mappings only while they are validated or handed to their persisted-schema boundary. | **intentional adapter/migration boundary.** Malformed/body/schema/conflict/not-found mappings and request-id correlation are typed or tested before feature calls; raw response dictionaries do not become feature-service state. |
-| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete owns `AutocompleteEntry` and immutable snapshot/index records. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing Autocomplete/Wildcard runtime fixtures. | Prompt data and Advanced field JSON accept old workflow layouts and future keys at their workflow migration boundary. Wildcard status/signature and Autocomplete payload dictionaries are serialized by API adapters. | **exact F-02 follow-up required.** Wildcard and the core ANIMA correction result are complete, but `AutocompletePort` and its service/core methods expose unparameterized result dictionaries across the runtime feature port. Normalized Prompt Studio Advanced fields and prompt-data mappings also continue through feature logic as raw dictionaries after parsing. |
+| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are now owned by `easyuse_anima/autocomplete/contracts.py`, while `AutocompleteEntry` and immutable snapshot/index records retain their existing owners. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing Autocomplete/Wildcard runtime fixtures. | Prompt data and Advanced field JSON accept old workflow layouts and future keys at their workflow migration boundary. Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, and the core ANIMA correction result are complete. Prompt Studio input JSON remains an intentional adapter/migration boundary, but `_normalize_advanced_fields` produces a fixed eight-key field shape that then crosses Prompt, node, AiO-conditioning, translation, wildcard, and artist-mix feature logic as `list[dict]`; canonical Prompt Data output/read mappings remain a separate later finding. |
 | AiO config/request/state/result | `AIOGenerationConfig` and its section dataclasses are owned by `easyuse_anima/aio/generation_settings.py` and adjacent strict generation modules. `GenerationRequest`, `GenerationState`, and `GenerationStage` are owned by `easyuse_anima/aio/generation_pipeline.py`; version detection and pure v1-to-v4 migration are owned by `generation_migrations.py`. Evidence is in the v1-v4 schema/surface fixtures and `tests/test_aio_schema_contract.py`, `tests/test_aio_generation_settings.py`, and `tests/test_aio_generation_migrations.py`. | `Mapping[str, object]` is retained only for JSON freeze/thaw, unknown-field preservation, host capability maps, prompt/workflow context, and final ComfyUI result serialization. Tensor/model values remain `object` at host boundaries. | **complete.** Normalized settings enter the generation pipeline as a typed config and typed request/state objects; strict per-file Pyright directives cover the generation contract modules. |
 | Node adapter raw input/output conversion | `easyuse_anima/nodes/aio_nodes.py`, `prompt_nodes.py`, and `wildcard_nodes.py` convert ComfyUI inputs into the typed AiO, Prompt, and Wildcard owners before feature work. `tests/test_node_contracts.py` and the 0.5.2 node/workflow fixtures freeze the public socket and result shapes. | Dynamic ComfyUI objects, tensor/model values, workflow metadata, input dictionaries, UI dictionaries, and output tuples are host adapter values. | **intentional adapter/migration boundary.** Their dynamic shape is not feature-service typing debt and no broad `Any` removal is justified. |
 | Common feature error taxonomy and adapter mappings | Existing concrete errors include `ProfileContractError`, `ProfileMutationError`, `InvalidProfileDataError`, `AutocompleteIndexUnavailable`, `KnowledgeBaseNotFound`, `AIOGenerationMigrationError`, and API-only `ApiContractError`. Their current behavior is covered by profile, Autocomplete, AiO migration, and API tests. | `ApiContractError` is allowed to carry HTTP status/code because it is an API request-adapter error. Node adapters may translate feature errors to the existing host-visible `RuntimeError` or UI status at the final adapter. | **exact F-02 follow-up required.** The documented `EasyUseAnimaError` category hierarchy does not exist, feature errors have no shared category base, and `ProfileMutationError` currently owns HTTP status alongside feature conflict meaning. Category-to-API/node mapping is therefore not a common tested contract. |
@@ -42,7 +43,7 @@ selected F-02 row is complete:
   `request_id`) plus `X-Request-ID` correlation;
 - Prompt correction models and the serialized Prompt Data/Advanced field shapes;
 - Wildcard expansion result plus list/source-signature API payloads;
-- Autocomplete source/status/search/classification payloads after F-02a assigns
+- Autocomplete source/status/search/classification payloads owned by the F-02a
   canonical typed result contracts;
 - AiO generation settings v4, `AIOGenerationConfig`, `GenerationRequest`,
   `GenerationState`, and final node/API serialization shapes;
@@ -52,55 +53,63 @@ selected F-02 row is complete:
 Root shims, deprecation warnings, telemetry, release metadata, tags, and Registry
 state are not part of this handoff.
 
-## Selected next task: F-02a
+## F-02a completion re-audit
 
-Only the smallest confirmed leak is selected now. The settings typed migration,
-Prompt workflow models, and common error taxonomy remain audit findings and are not
+F-02a merged as PR #566 at `3a306498325c48126325aadc6d31665acf3517b4`.
+Its final candidate passed the 1,435-test official full gate, Pyright/import checks,
+frontend checks, and `git diff --check`; package/live were not triggered. The runtime
+port and core methods now use canonical Autocomplete payload contracts, while the API
+adapter preserves the exact dictionaries, redaction, future-key seam, and public
+exports. Autocomplete is therefore **complete** and Wildcard remains **complete**.
+
+## Selected next task: F-02b
+
+Only the smallest remaining Prompt leak is selected now. Canonical Prompt Data,
+settings migration, and common error taxonomy remain separate findings and are not
 silently combined into this task.
 
 ```text
-Task ID: F-02a Autocomplete typed result contracts
+Task ID: F-02b Prompt Studio Advanced field typed contract
 Owner Issue: #563
 Primary class: CONTRACT
-Base SHA: latest origin/dev after F-01 merges
-Goal: define canonical TypedDict result contracts for Autocomplete source/status,
-      search entry/result, and classification token/result payloads; apply them to
-      the Autocomplete runtime port, service, dataset, search, classification, and
-      API redaction adapter without changing any runtime dictionary.
-Prerequisites: merged F-01 audit; current Autocomplete runtime contract remains valid
+Base SHA: latest origin/dev after this completion re-audit merges
+Goal: define one internal canonical TypedDict for the normalized eight-key Advanced
+      field shape and apply it from `_normalize_advanced_fields` through its direct
+      Prompt, Prompt Studio node-adapter, AiO-conditioning, wildcard, translation,
+      and artist-mix consumers without changing any runtime dictionary.
+Prerequisites: merged F-02a and this production-free affected-row re-audit
 Allowed production files:
-  easyuse_anima/autocomplete/contracts.py
-  easyuse_anima/autocomplete/ports.py
-  easyuse_anima/autocomplete/service.py
-  easyuse_anima/autocomplete/dataset.py
-  easyuse_anima/autocomplete/search.py
-  easyuse_anima/autocomplete/classification.py
-  easyuse_anima/api/routes/autocomplete.py
+  easyuse_anima/prompt/contracts.py
+  easyuse_anima/prompt/advanced.py
+  easyuse_anima/prompt/artist_mix.py only for direct Advanced-field annotations
+  easyuse_anima/aio/conditioning.py only for direct Advanced-field annotations
+  easyuse_anima/nodes/prompt_advanced_nodes.py only for direct adapter annotations
 Allowed test/config files:
-  tests/test_autocomplete_service.py
   tests/test_prompt_corrector.py
-  tests/test_api_contract.py
-  tests/test_python_autocomplete_runtime_contract.py
+  tests/test_aio_conditioning.py
+  tests/test_node_contracts.py
   tests/test_pyright_baseline.py
+  tests/test_python_backend_analyzer.py
+  tests/fixtures/python_backend_baseline.json only for generated analyzer evidence
   pyrightconfig.json and tests/fixtures/pyright_baseline.json only if the exact
   touched owners are strict-clean and are deliberately enrolled without new debt
-Forbidden changes: payload keys/order/values, path redaction, CSV/index behavior,
-  runtime owner identity, root/canonical exports, request parsing, broad Any cleanup,
-  ignore additions, settings/Prompt/error work
-Preserved invariants: source selection, exact result/status/classification shapes,
-  missing/locked/corrupt index fallback, request limits, runtime port composition,
-  root signatures and identities
+Forbidden changes: Prompt Data typing, input JSON/workflow migration behavior,
+  field keys/order/defaults/values, prompt construction, wildcard/translation/NAIA/
+  artist-mix behavior, node sockets/results, root/canonical exports, broad Any cleanup,
+  ignore additions, settings/error work
+Preserved invariants: default-field order, duplicate NAIA/trigger normalization,
+  unknown input-key tolerance, saved/effective field separation, socket overrides,
+  field identity and serialized JSON, Prompt/AiO/artist-mix outputs, public identities
 Focused tests and purpose:
-  tests.test_autocomplete_service — runtime port uses the same snapshot/index owners
-  tests.test_prompt_corrector.AutocompleteDatasetTests — source/status/search/classify
-    payload values remain exact
-  tests.test_api_contract.ApiAutocompleteRouteTests — redaction and API shapes remain exact
-  tests.test_python_autocomplete_runtime_contract — owner/import/runtime fixture remains exact
+  tests.test_prompt_corrector.PromptBuilderTests — Advanced normalization, field inputs,
+    translation, wildcard, NAIA, prompt construction, and serialized outputs stay exact
+  tests.test_aio_conditioning.AIOConditioningMoveTests — AiO consumes the same fields
+  tests.test_node_contracts.PromptAdvancedMoveContractTests — owner/signature/identity stay exact
   tests.test_pyright_baseline plus the current quality gate — no new baseline or strict debt
 Promotion gates: changed-file syntax/static, focused tests, import boundary,
   git diff --check, official full once on the final test/config candidate; no package/live
-Stop conditions: a runtime payload conversion, public export, root-shim change,
-  schema behavior change, ignore, or cross-feature contract is required
-Next task: re-audit the Prompt/Wildcard/Autocomplete row; do not start G-04A while
-  any Phase F follow-up row remains
+Stop conditions: a runtime field conversion, Prompt Data schema change, public export,
+  root-shim change, behavior change, ignore, or broader cross-feature model is required
+Next task: re-audit the Prompt row and select only its next smallest remaining finding;
+  do not start G-04A while any Phase F follow-up row remains
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -89,7 +89,7 @@ Prompt Data, settings, or error-taxonomy work.
 
 After F-02b:
 
-1. re-audit the Prompt/Wildcard/Autocomplete row;
+1. re-audit the affected Prompt row;
 2. execute the next smallest F-02 while any Phase F finding remains;
 3. only after Phase F closes, run #188 G-04A against existing
    compatibility/node/API/package fixtures;

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02a Autocomplete typed result contracts;
+   - first READY task: Issue #563 / F-02b Prompt Studio Advanced field typed contract;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -53,7 +53,8 @@ ordinary `dev` work.
 COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 PARKED    D-14 / Phase H root removal
-READY     #563 F-02a Autocomplete typed result contracts
+COMPLETE  #563 F-02a Autocomplete typed result contracts
+READY     #563 F-02b Prompt Studio Advanced field typed contract
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
@@ -68,25 +69,25 @@ The D-14 stop is correct:
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02a source map
+## Active F-02b source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-typed-boundary-f01-audit.md  # F-02a task card
-docs/architecture/python-runtime-e05-autocomplete-contract.md
+docs/architecture/python-typed-boundary-f01-audit.md  # F-02b task card
 Issue #563 latest checkpoint
-direct Autocomplete owner source/tests
-current Pyright, import-boundary, and API fixtures
+easyuse_anima/prompt/advanced.py and direct typed consumers
+direct Prompt Studio, AiO conditioning, node-owner, Pyright, and import fixtures
 ```
 
-F-02a adds internal Autocomplete result types without changing runtime dictionary
-keys, order, values, redaction, owner identity, or public exports. Reuse the direct
-runtime/API contracts and do not expand into settings, Prompt, or error-taxonomy work.
+F-02b adds one internal normalized eight-key Advanced-field type without changing runtime
+dictionaries, JSON/workflow migration, field order/defaults, Prompt/AiO/wildcard/
+translation/artist-mix behavior, node results, or public exports. Do not expand into
+Prompt Data, settings, or error-taxonomy work.
 
 ## Following queue
 
-After F-02a:
+After F-02b:
 
 1. re-audit the Prompt/Wildcard/Autocomplete row;
 2. execute the next smallest F-02 while any Phase F finding remains;


### PR DESCRIPTION
## 목적과 변경 경계

F-02a 병합 후 Prompt/Wildcard/Autocomplete typed-boundary 행을 production 변경 없이 재감사합니다.

- Base: `3a306498325c48126325aadc6d31665acf3517b4`
- Head: `d8c59446f4cf36c89fe74690e9de8ee1d783d14e`
- Autocomplete: F-02a canonical payload contracts로 complete
- Wildcard: 기존 typed core/result 계약으로 complete 유지
- Prompt: workflow JSON 입력은 intentional adapter/migration boundary로 유지
- 다음 최소 gap: 정규화된 8-key Advanced field가 feature logic에서 `list[dict]`로 전파되는 경계

## 변경 파일

- `docs/architecture/python-typed-boundary-f01-audit.md`
- `docs/architecture/post-phase-e-maintenance-roadmap.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

## 다음 task

F-02b는 internal `AdvancedField` TypedDict 하나만 도입합니다. Prompt Data, settings migration, common error taxonomy는 결합하지 않습니다. G-04A/#188은 Phase F가 닫힐 때까지 BLOCKED입니다.

## 검증

- `tests.test_python_autocomplete_runtime_contract`: 12 pass
- `tests.test_python_wildcard_runtime_contract`: 10 pass
- `tests.test_pyright_baseline`: 11 pass
- `git diff --check`: pass
- test/tool 변경 없음: PR #566 final SHA의 official full 증거 재사용
- package/live: 미실행(비트리거)

## 위험과 rollback

production 변경이 없으며 rollback은 이 문서 commit의 revert입니다.