### PR TITLE
docs: correct F-02b Prompt field-family contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02b Prompt Studio Advanced field typed contract.
+  / F-02b Prompt field-family typed contract.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -30,7 +30,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 ```text
 COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE affected-row re-audit
-  -> READY F-02b Prompt Studio Advanced field typed contract
+  -> READY F-02b Prompt field-family typed contract
   -> re-audit the affected Prompt row
   -> next smallest F-02 while a finding remains
   -> G-04A public API snapshot coverage audit

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02b Prompt Studio Advanced field typed contract.
+- Active first task: Issue #563 / F-02b Prompt field-family typed contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -67,7 +67,7 @@ ADR-002 result when evidence is absent or ambiguous.
 ```text
 COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE affected-row re-audit
-  -> READY F-02b Prompt Studio Advanced field typed contract   #563
+  -> READY F-02b Prompt field-family typed contract            #563
   -> RE-AUDIT affected Prompt row
   -> F-02      next smallest targeted gap while one remains
   -> G-04A    public API snapshot coverage audit              #188
@@ -144,7 +144,7 @@ Audit result, updated after F-02a merged at
   deterministic fixtures;
 - Autocomplete and Wildcard are complete after F-02a; Prompt's normalized Advanced
   fields and canonical Prompt Data remain exact, separable follow-up findings;
-- only the smallest follow-up, F-02b Prompt Studio Advanced field typed contract, is
+- only the smallest cohesive follow-up, F-02b Prompt field-family typed contract, is
   selected as the next task card;
 - settings migration and common error taxonomy remain separate findings;
 - G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
@@ -371,16 +371,18 @@ Read:
 - this document's F-01 result and validation sections
 - python-typed-boundary-f01-audit.md F-02b task card
 - Issue #563 latest checkpoint
-- direct Prompt Advanced owner source/tests and current Pyright/import fixtures
+- direct Prompt Advanced/Regional owner source/tests and current Pyright/import fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Define one canonical internal TypedDict for the normalized eight-key Advanced-field
-shape and apply it through direct Prompt, Prompt Studio node-adapter, AiO-conditioning,
-wildcard, translation, and artist-mix consumers without changing runtime dictionaries,
-input/workflow migration, field order/defaults, behavior, identities, or public exports.
-Reuse the direct Prompt Studio, AiO conditioning, node-owner, Pyright, and import tests;
-update only a direct generated analyzer baseline if the canonical module requires it.
+Define internal PromptField, AdvancedField, and RegionalField TypedDicts, using a
+bounded generic only where shared correction/wildcard/translation helpers preserve the
+concrete subtype. Apply them through both normalizers, Prompt Studio node adapters,
+AiO conditioning, and artist mix without changing runtime dictionaries, input/workflow
+migration, field order/defaults, behavior, identities, or public exports. Preserve the
+legacy Extend adapter's omitted `pin`. Reuse direct Advanced/Regional Prompt Studio,
+AiO conditioning, node-owner, Pyright, and import tests; update only a direct generated
+analyzer baseline if the canonical module requires it.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run official full once on the final production/test/tool SHA.

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -20,7 +20,7 @@ owner tests can express every finding below.
 | --- | --- | --- | --- |
 | Settings, profile, and workflow schema/migration | Profile v2 identity/revision and pure read migration are owned by `easyuse_anima/profiles/contract.py`; the strict Pyright owner is fixed by `tests/fixtures/pyright_baseline.json`. Settings persistence/projection is owned by `easyuse_anima/settings/schema.py`, `repository.py`, and `service.py`. Read-only ComfyUI workflow lookup is owned by `easyuse_anima/workflow.py`. Direct evidence is in `tests/test_profile_contract.py`, `tests/test_lora_profiles.py`, `tests/test_aio_profiles.py`, `tests/test_api_contract.py`, and `tests/test_node_contracts.py`. | Profile payload mappings preserve legacy and future fields at the persisted JSON migration boundary. `_get_workflow_node` accepts dynamic host `extra_pnginfo` and returns a raw workflow node only at the ComfyUI adapter boundary. | **exact F-02 follow-up required.** Profile and workflow boundaries are complete or intentional, but ordinary settings have no version detection, pure migration sequence, or typed post-normalization model. Long-text settings write a v1 envelope, yet their normalized value and the settings service still cross feature code as unparameterized dictionaries. |
 | API request/result/error | `easyuse_anima/api/requests.py` validates JSON-object bodies and produces typed scalar fields; `easyuse_anima/api/errors.py` owns `ApiContractError`; `easyuse_anima/api/responses.py` owns the stable error envelope and request correlation. `tests/test_api_contract_compatibility.py` and the direct route classes in `tests/test_api_contract.py` freeze the behavior. | Request bodies and success/error dictionaries exist at the JSON serialization adapter. Profile and settings sub-objects remain mappings only while they are validated or handed to their persisted-schema boundary. | **intentional adapter/migration boundary.** Malformed/body/schema/conflict/not-found mappings and request-id correlation are typed or tested before feature calls; raw response dictionaries do not become feature-service state. |
-| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are now owned by `easyuse_anima/autocomplete/contracts.py`, while `AutocompleteEntry` and immutable snapshot/index records retain their existing owners. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing Autocomplete/Wildcard runtime fixtures. | Prompt data and Advanced field JSON accept old workflow layouts and future keys at their workflow migration boundary. Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, and the core ANIMA correction result are complete. Prompt Studio input JSON remains an intentional adapter/migration boundary, but `_normalize_advanced_fields` produces a fixed eight-key field shape that then crosses Prompt, node, AiO-conditioning, translation, wildcard, and artist-mix feature logic as `list[dict]`; canonical Prompt Data output/read mappings remain a separate later finding. |
+| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are now owned by `easyuse_anima/autocomplete/contracts.py`, while `AutocompleteEntry` and immutable snapshot/index records retain their existing owners. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_prompt_studio_regional.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing Autocomplete/Wildcard runtime fixtures. | Prompt data plus Advanced and Regional field JSON accept old workflow layouts and future keys at their workflow migration boundary. The legacy Extend adapter intentionally omits optional `pin`; Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, and the core ANIMA correction result are complete. Direct F-02b implementation evidence showed that normalized Advanced fields and normalized Regional fields share seven required keys and the same correction/wildcard/translation consumers, while Advanced adds an optional `pin` compatibility seam and Regional requires `pin`, `collapsed`, and `mask_ids`. They must be typed as one structural field family rather than misclassifying Regional as Advanced or weakening shared consumers to raw mappings. Canonical Prompt Data output/read mappings remain a separate later finding. |
 | AiO config/request/state/result | `AIOGenerationConfig` and its section dataclasses are owned by `easyuse_anima/aio/generation_settings.py` and adjacent strict generation modules. `GenerationRequest`, `GenerationState`, and `GenerationStage` are owned by `easyuse_anima/aio/generation_pipeline.py`; version detection and pure v1-to-v4 migration are owned by `generation_migrations.py`. Evidence is in the v1-v4 schema/surface fixtures and `tests/test_aio_schema_contract.py`, `tests/test_aio_generation_settings.py`, and `tests/test_aio_generation_migrations.py`. | `Mapping[str, object]` is retained only for JSON freeze/thaw, unknown-field preservation, host capability maps, prompt/workflow context, and final ComfyUI result serialization. Tensor/model values remain `object` at host boundaries. | **complete.** Normalized settings enter the generation pipeline as a typed config and typed request/state objects; strict per-file Pyright directives cover the generation contract modules. |
 | Node adapter raw input/output conversion | `easyuse_anima/nodes/aio_nodes.py`, `prompt_nodes.py`, and `wildcard_nodes.py` convert ComfyUI inputs into the typed AiO, Prompt, and Wildcard owners before feature work. `tests/test_node_contracts.py` and the 0.5.2 node/workflow fixtures freeze the public socket and result shapes. | Dynamic ComfyUI objects, tensor/model values, workflow metadata, input dictionaries, UI dictionaries, and output tuples are host adapter values. | **intentional adapter/migration boundary.** Their dynamic shape is not feature-service typing debt and no broad `Any` removal is justified. |
 | Common feature error taxonomy and adapter mappings | Existing concrete errors include `ProfileContractError`, `ProfileMutationError`, `InvalidProfileDataError`, `AutocompleteIndexUnavailable`, `KnowledgeBaseNotFound`, `AIOGenerationMigrationError`, and API-only `ApiContractError`. Their current behavior is covered by profile, Autocomplete, AiO migration, and API tests. | `ApiContractError` is allowed to carry HTTP status/code because it is an API request-adapter error. Node adapters may translate feature errors to the existing host-visible `RuntimeError` or UI status at the final adapter. | **exact F-02 follow-up required.** The documented `EasyUseAnimaError` category hierarchy does not exist, feature errors have no shared category base, and `ProfileMutationError` currently owns HTTP status alongside feature conflict meaning. Category-to-API/node mapping is therefore not a common tested contract. |
@@ -69,23 +69,28 @@ settings migration, and common error taxonomy remain separate findings and are n
 silently combined into this task.
 
 ```text
-Task ID: F-02b Prompt Studio Advanced field typed contract
+Task ID: F-02b Prompt field-family typed contract
 Owner Issue: #563
 Primary class: CONTRACT
 Base SHA: latest origin/dev after this completion re-audit merges
-Goal: define one internal canonical TypedDict for the normalized eight-key Advanced
-      field shape and apply it from `_normalize_advanced_fields` through its direct
-      Prompt, Prompt Studio node-adapter, AiO-conditioning, wildcard, translation,
-      and artist-mix consumers without changing any runtime dictionary.
-Prerequisites: merged F-02a and this production-free affected-row re-audit
+Goal: define internal `PromptField`, `AdvancedField`, and `RegionalField` TypedDicts;
+      use a bounded generic only where shared correction/wildcard/translation helpers
+      must preserve the concrete field subtype; apply the family from both normalizers
+      through Prompt Studio node adapters, AiO conditioning, and artist mix without
+      changing any runtime dictionary.
+Prerequisites: merged F-02a, affected-row re-audit, and the direct Pyright evidence
+  that rejected an Advanced-only contract at the shared Regional boundary
 Allowed production files:
   easyuse_anima/prompt/contracts.py
   easyuse_anima/prompt/advanced.py
-  easyuse_anima/prompt/artist_mix.py only for direct Advanced-field annotations
-  easyuse_anima/aio/conditioning.py only for direct Advanced-field annotations
+  easyuse_anima/prompt/regional.py
+  easyuse_anima/prompt/artist_mix.py only for direct field-family annotations
+  easyuse_anima/aio/conditioning.py only for direct field-family annotations
   easyuse_anima/nodes/prompt_advanced_nodes.py only for direct adapter annotations
+  easyuse_anima/nodes/regional_nodes.py only for direct adapter annotations
 Allowed test/config files:
   tests/test_prompt_corrector.py
+  tests/test_prompt_studio_regional.py
   tests/test_aio_conditioning.py
   tests/test_node_contracts.py
   tests/test_pyright_baseline.py
@@ -94,22 +99,27 @@ Allowed test/config files:
   pyrightconfig.json and tests/fixtures/pyright_baseline.json only if the exact
   touched owners are strict-clean and are deliberately enrolled without new debt
 Forbidden changes: Prompt Data typing, input JSON/workflow migration behavior,
-  field keys/order/defaults/values, prompt construction, wildcard/translation/NAIA/
-  artist-mix behavior, node sockets/results, root/canonical exports, broad Any cleanup,
-  ignore additions, settings/error work
-Preserved invariants: default-field order, duplicate NAIA/trigger normalization,
-  unknown input-key tolerance, saved/effective field separation, socket overrides,
-  field identity and serialized JSON, Prompt/AiO/artist-mix outputs, public identities
+  Advanced/Regional keys/order/defaults/values, prompt/mask construction,
+  wildcard/translation/NAIA/artist-mix behavior, node sockets/results,
+  root/canonical exports, broad Any cleanup, ignore additions, settings/error work
+Preserved invariants: Advanced and Regional default-field order, duplicate NAIA/
+  trigger normalization, Extend's omitted `pin`, unknown input-key tolerance,
+  saved/effective field separation, socket overrides, field identity and serialized
+  JSON, mask assignments, Prompt/AiO/artist-mix outputs, public identities
 Focused tests and purpose:
   tests.test_prompt_corrector.PromptBuilderTests — Advanced normalization, field inputs,
     translation, wildcard, NAIA, prompt construction, and serialized outputs stay exact
+  tests.test_prompt_studio_regional — Regional normalization, mask fields, wildcard,
+    translation, and serialized outputs stay exact
   tests.test_aio_conditioning.AIOConditioningMoveTests — AiO consumes the same fields
-  tests.test_node_contracts.PromptAdvancedMoveContractTests — owner/signature/identity stay exact
+  tests.test_node_contracts.PromptAdvancedMoveContractTests and RegionalMoveContractTests
+    — owner/signature/identity stay exact
   tests.test_pyright_baseline plus the current quality gate — no new baseline or strict debt
 Promotion gates: changed-file syntax/static, focused tests, import boundary,
   git diff --check, official full once on the final test/config candidate; no package/live
 Stop conditions: a runtime field conversion, Prompt Data schema change, public export,
-  root-shim change, behavior change, ignore, or broader cross-feature model is required
+  root-shim change, behavior change, ignore, or a field owner outside this fixed family
+  is required
 Next task: re-audit the Prompt row and select only its next smallest remaining finding;
   do not start G-04A while any Phase F follow-up row remains
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02b Prompt Studio Advanced field typed contract;
+   - first READY task: Issue #563 / F-02b Prompt field-family typed contract;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -54,7 +54,7 @@ COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 PARKED    D-14 / Phase H root removal
 COMPLETE  #563 F-02a Autocomplete typed result contracts
-READY     #563 F-02b Prompt Studio Advanced field typed contract
+READY     #563 F-02b Prompt field-family typed contract
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
@@ -76,14 +76,16 @@ Start with targeted owners rather than the full repository:
 ```text
 docs/architecture/python-typed-boundary-f01-audit.md  # F-02b task card
 Issue #563 latest checkpoint
-easyuse_anima/prompt/advanced.py and direct typed consumers
-direct Prompt Studio, AiO conditioning, node-owner, Pyright, and import fixtures
+easyuse_anima/prompt/advanced.py, prompt/regional.py, and direct typed consumers
+direct Advanced/Regional Prompt Studio, AiO conditioning, node-owner, Pyright,
+and import fixtures
 ```
 
-F-02b adds one internal normalized eight-key Advanced-field type without changing runtime
-dictionaries, JSON/workflow migration, field order/defaults, Prompt/AiO/wildcard/
-translation/artist-mix behavior, node results, or public exports. Do not expand into
-Prompt Data, settings, or error-taxonomy work.
+F-02b adds the internal PromptField/AdvancedField/RegionalField structural family
+without changing runtime dictionaries, JSON/workflow migration, field order/defaults,
+Prompt/AiO/wildcard/translation/artist-mix behavior, Regional mask assignments, node
+results, or public exports. Preserve Extend's omitted `pin`; do not expand into Prompt
+Data, settings, or error-taxonomy work.
 
 ## Following queue
 


### PR DESCRIPTION
## 목적과 변경 경계

F-02b Advanced-only implementation smoke가 드러낸 shared Prompt/Regional field seam을 production 변경 없이 계약에 반영합니다.

- Base: `1afd41e8f990a7fa2b9cd19e6a2a24cb09dfeb1c`
- Head: `920200803861fb0f4b68a096feaf7be52a05b410`
- Advanced normalized field: 공통 7-key + `pin`
- legacy Extend adapter: 공통 7-key, `pin` 생략 유지
- Regional normalized field: 공통 7-key + `pin` + `collapsed` + `mask_ids`
- shared correction/wildcard/translation helper는 concrete subtype을 보존하는 bounded generic으로 고정

## 결정

F-02b를 `PromptField` / `AdvancedField` / `RegionalField` typed family로 교정합니다. Regional을 Advanced로 오표기하거나 shared consumer를 raw Mapping으로 약화하는 안은 완료 조건을 충족하지 않아 기각합니다. canonical Prompt Data, settings migration, common error taxonomy는 여전히 별도 후속입니다.

## 변경 파일

- `docs/architecture/python-typed-boundary-f01-audit.md`
- `docs/architecture/post-phase-e-maintenance-roadmap.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

## 검증

- `tests.test_prompt_studio_regional`: 9 pass
- `tests.test_python_autocomplete_runtime_contract`: 12 pass
- `tests.test_pyright_baseline`: 11 pass
- `git diff --check`: pass
- test/tool 변경 없음: 기존 official-full evidence 재사용
- package/live: 미실행(비트리거)

## 위험과 rollback

production 변경은 없습니다. rollback은 이 문서 commit의 revert입니다.