### PR TITLE
refactor: type Prompt Studio field family

### DIFF
--- a/easyuse_anima/aio/conditioning.py
+++ b/easyuse_anima/aio/conditioning.py
@@ -12,6 +12,7 @@ from ..prompt.advanced import (
     _correct_advanced_field_sequence,
     _normalize_advanced_fields,
 )
+from ..prompt.contracts import AdvancedField
 from ..prompt.data import _normalize_prompt_data
 from .generation_defaults import AIO_USDU_PROMPT_FULL, AIO_USDU_PROMPT_NO_GENERAL
 from .negpip import _aio_negpip_execution_prompts
@@ -31,7 +32,9 @@ def _encode_with_comfy_clip(clip, text: str):
     return helper(clip, text)
 
 
-def _aio_prompt_data_fields_for_usdu(prompt_data: str | dict | None) -> list[dict]:
+def _aio_prompt_data_fields_for_usdu(
+    prompt_data: str | dict | None,
+) -> list[AdvancedField]:
     data = _normalize_prompt_data(prompt_data)
     fields = data.get("fields")
     if not isinstance(fields, list):

--- a/easyuse_anima/nodes/prompt_advanced_nodes.py
+++ b/easyuse_anima/nodes/prompt_advanced_nodes.py
@@ -62,6 +62,7 @@ from ..prompt.correction import (
     _translate_prompt_text,
 )
 from ..prompt.data import PROMPT_DATA_TYPE, _prompt_data_parameter_snapshot
+from ..prompt.contracts import AdvancedField
 from ..seed.compatibility import _scrub_reserved_wildcard_next_seed
 from ..settings.service import (
     resolve_metadata_filter_words,
@@ -1106,7 +1107,10 @@ class EasyUseAnimaPromptStudioExtend:
         return {str(name) for name in parsed if str(name) in valid_names}
 
     @staticmethod
-    def _fields_from_slots(values: dict[str, str], active_slots: Any = None) -> list[dict]:
+    def _fields_from_slots(
+        values: dict[str, str],
+        active_slots: Any = None,
+    ) -> list[AdvancedField]:
         active_slot_names = EasyUseAnimaPromptStudioExtend._active_slot_set(active_slots)
         fields = []
         for name, pane, field_type, label, _default, height in EXTEND_PROMPT_SLOT_SPECS:

--- a/easyuse_anima/prompt/advanced.py
+++ b/easyuse_anima/prompt/advanced.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, TypeVar, cast
 
 from ..common.values import _as_bool, _as_int, _single_value
 from ..naia.resolution import (
@@ -38,6 +39,7 @@ from .artist_mix import (
     _parse_artist_mix_items,
 )
 from .correction import _translate_prompt_text
+from .contracts import AdvancedField, PromptField
 from .data import PROMPT_DATA_SCHEMA, PROMPT_DATA_TYPE, PROMPT_DATA_VERSION
 from .fields import (
     DEFAULT_QUALITY_TAGS,
@@ -129,6 +131,7 @@ PROMPT_STUDIO_ADVANCED_RETURN_NAMES = (
 
 _ADVANCED_FIELD_SOCKET_PREFIX = "field_"
 _ADVANCED_FIELD_SOCKET_RE = re.compile(r"[^A-Za-z0-9_]")
+_PromptFieldT = TypeVar("_PromptFieldT", bound=PromptField)
 
 
 def _normalize_prompt_studio_wildcard_seed_control(
@@ -144,10 +147,10 @@ def _normalize_prompt_studio_wildcard_seed_control(
     )
 
 
-def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
-    translated: list[dict] = []
+def _translate_prompt_fields(fields: list[_PromptFieldT]) -> list[_PromptFieldT]:
+    translated: list[_PromptFieldT] = []
     for field in fields:
-        item = dict(field)
+        item = cast(_PromptFieldT, dict(field))
         text = str(item.get("text") or "")
         if text and has_prompt_translation_markers(text):
             item["text"] = _translate_prompt_text(text)
@@ -155,7 +158,7 @@ def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
     return translated
 
 
-def _advanced_default_fields() -> list[dict]:
+def _advanced_default_fields() -> list[AdvancedField]:
     return [
         {
             "id": "positive_quality",
@@ -215,7 +218,7 @@ def _advanced_default_fields() -> list[dict]:
     ]
 
 
-def _advanced_fields_json(fields: list[dict] | None = None) -> str:
+def _advanced_fields_json(fields: list[AdvancedField] | None = None) -> str:
     return json.dumps(
         fields if fields is not None else _advanced_default_fields(),
         ensure_ascii=False,
@@ -227,7 +230,7 @@ def _as_advanced_height(value, default: int = 72) -> int:
     return max(36, _as_int(value, default))
 
 
-def _normalize_advanced_fields(value: str | list | None) -> list[dict]:
+def _normalize_advanced_fields(value: str | list | None) -> list[AdvancedField]:
     raw = value
     if isinstance(value, str):
         try:
@@ -239,7 +242,7 @@ def _normalize_advanced_fields(value: str | list | None) -> list[dict]:
     if not raw:
         raw = _advanced_default_fields()
 
-    fields: list[dict] = []
+    fields: list[AdvancedField] = []
     seen_naia_panes: set[str] = set()
     seen_trigger = False
     for index, item in enumerate(raw):
@@ -286,11 +289,11 @@ def _normalize_advanced_fields(value: str | list | None) -> list[dict]:
     return fields or _advanced_default_fields()
 
 
-def _clone_advanced_fields(fields: list[dict]) -> list[dict]:
-    return [dict(field) for field in fields]
+def _clone_advanced_fields(fields: list[AdvancedField]) -> list[AdvancedField]:
+    return [cast(AdvancedField, dict(field)) for field in fields]
 
 
-def _advanced_field_socket_name(field: dict) -> str:
+def _advanced_field_socket_name(field: PromptField) -> str:
     raw = _ADVANCED_FIELD_SOCKET_RE.sub(
         "_",
         str(field.get("id") or "field"),
@@ -310,7 +313,10 @@ def _advanced_field_input_values(field_inputs: dict) -> dict[str, str]:
     return values
 
 
-def _apply_advanced_field_inputs(fields: list[dict], field_inputs: dict) -> list[dict]:
+def _apply_advanced_field_inputs(
+    fields: list[AdvancedField],
+    field_inputs: dict,
+) -> list[AdvancedField]:
     values = _advanced_field_input_values(field_inputs)
     if not values:
         return _clone_advanced_fields(fields)
@@ -323,7 +329,7 @@ def _apply_advanced_field_inputs(fields: list[dict], field_inputs: dict) -> list
     return effective
 
 
-def _advanced_enabled_naia_panes(fields: list[dict]) -> set[str]:
+def _advanced_enabled_naia_panes(fields: list[AdvancedField]) -> set[str]:
     return {
         str(field.get("pane") or "positive")
         for field in fields
@@ -331,7 +337,7 @@ def _advanced_enabled_naia_panes(fields: list[dict]) -> set[str]:
     }
 
 
-def _advanced_has_enabled_naia(fields: list[dict]) -> bool:
+def _advanced_has_enabled_naia(fields: list[AdvancedField]) -> bool:
     return bool(_advanced_enabled_naia_panes(fields))
 
 
@@ -339,7 +345,11 @@ def _advanced_uses_naia_resolution(bucket) -> bool:
     return _normalize_resolution_bucket(bucket) == NAIA_ADVANCED_RESOLUTION_BUCKET
 
 
-def _set_naia_field_text(fields: list[dict], pane: str, prompt: str) -> list[dict]:
+def _set_naia_field_text(
+    fields: list[AdvancedField],
+    pane: str,
+    prompt: str,
+) -> list[AdvancedField]:
     normalized = _normalize_advanced_fields(fields)
     for field in normalized:
         if field["pane"] == pane and field["type"] == "naia":
@@ -350,7 +360,7 @@ def _set_naia_field_text(fields: list[dict], pane: str, prompt: str) -> list[dic
 
 
 def _advanced_naia_field_updates(
-    fields: list[dict],
+    fields: list[AdvancedField],
     prompts_by_pane: dict[str, str],
 ) -> dict[str, str]:
     updates: dict[str, str] = {}
@@ -367,7 +377,10 @@ def _advanced_naia_field_updates(
     return updates
 
 
-def _advanced_pane_parts(fields: list[dict], pane: str) -> dict[str, list[str]]:
+def _advanced_pane_parts(
+    fields: list[AdvancedField],
+    pane: str,
+) -> dict[str, list[str]]:
     parts = {
         "quality": [],
         "artist": [],
@@ -396,7 +409,10 @@ def _advanced_pane_parts(fields: list[dict], pane: str) -> dict[str, list[str]]:
     return parts
 
 
-def _advanced_enabled_pane_fields(fields: list[dict], pane: str) -> list[dict]:
+def _advanced_enabled_pane_fields(
+    fields: list[_PromptFieldT],
+    pane: str,
+) -> list[_PromptFieldT]:
     return [
         field
         for field in fields
@@ -405,7 +421,7 @@ def _advanced_enabled_pane_fields(fields: list[dict], pane: str) -> list[dict]:
 
 
 def _correct_advanced_field_sequence(
-    fields: list[dict],
+    fields: Sequence[PromptField],
     include_quality: bool,
     artist_overrides: str,
     force_pin_triggers: bool = False,
@@ -446,7 +462,7 @@ def _correct_advanced_field_sequence(
 
 
 def _build_advanced_prompts(
-    fields: list[dict],
+    fields: list[AdvancedField],
     use_anima_mod_guidance: bool,
     use_negative_anima_mod_guidance: bool,
     pin_trigger_tags_to_front: bool,
@@ -506,12 +522,12 @@ def _build_advanced_prompts(
 
 
 def _expand_advanced_wildcard_fields(
-    fields: list[dict],
+    fields: list[_PromptFieldT],
     seed: int,
     mode: str,
-) -> tuple[list[dict], dict[str, Any]]:
+) -> tuple[list[_PromptFieldT], dict[str, Any]]:
     mode_key = normalize_prompt_studio_wildcard_mode(mode)
-    expanded_fields = _clone_advanced_fields(fields)
+    expanded_fields = [cast(_PromptFieldT, dict(field)) for field in fields]
 
     wildcard_fields = []
     wildcard_texts = []
@@ -552,8 +568,8 @@ def _expand_advanced_wildcard_fields(
     }
 
 
-def _advanced_prompt_data_fields(fields: list[dict]) -> list[dict[str, Any]]:
-    output = []
+def _advanced_prompt_data_fields(fields: list[AdvancedField]) -> list[AdvancedField]:
+    output: list[AdvancedField] = []
     for field in fields:
         output.append(
             {
@@ -570,7 +586,7 @@ def _advanced_prompt_data_fields(fields: list[dict]) -> list[dict[str, Any]]:
     return output
 
 
-def _advanced_artist_field_prompt(fields: list[dict], pane: str) -> str:
+def _advanced_artist_field_prompt(fields: Sequence[PromptField], pane: str) -> str:
     # Artist data is sourced only from Advanced artist fields, not from @ tags in other fields.
     return _join_artist_mix_source_prompts(
         *(
@@ -584,21 +600,21 @@ def _advanced_artist_field_prompt(fields: list[dict], pane: str) -> str:
 
 
 def _advanced_fields_with_artist_override(
-    fields: list[dict],
+    fields: list[AdvancedField],
     artist_prompt: str,
-) -> list[dict]:
+) -> list[AdvancedField]:
     artist_text = _join_prompt_tokens(artist_prompt)
-    output: list[dict] = []
+    output: list[AdvancedField] = []
     inserted = False
     for field in fields:
         if field.get("type") == "artist":
             if artist_text and not inserted:
-                item = dict(field)
+                item = cast(AdvancedField, dict(field))
                 item["text"] = artist_text
                 output.append(item)
                 inserted = True
             continue
-        output.append(dict(field))
+        output.append(cast(AdvancedField, dict(field)))
 
     if artist_text and not inserted:
         insert_at = 0
@@ -622,7 +638,7 @@ def _advanced_fields_with_artist_override(
 
 
 def _advanced_prompt_with_artist_override(
-    fields: list[dict],
+    fields: list[AdvancedField],
     artist_prompt: str,
     include_quality: bool,
     force_pin_triggers: bool = False,
@@ -637,8 +653,8 @@ def _advanced_prompt_with_artist_override(
 
 def _build_advanced_prompt_data(
     compat_result: tuple,
-    effective_fields: list[dict],
-    saved_fields: list[dict],
+    effective_fields: list[AdvancedField],
+    saved_fields: list[AdvancedField],
     field_inputs: dict[str, str],
     resolution_bucket: str,
     resolution_size: str,

--- a/easyuse_anima/prompt/artist_mix.py
+++ b/easyuse_anima/prompt/artist_mix.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..common.values import _as_bool, _as_float, _as_int
 from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from .contracts import AdvancedField
 from .data import _normalize_prompt_data, _prompt_data_nested, _prompt_data_output
 from .fields import _correct_builder_prompt, _join_prompt_tokens
 
@@ -665,7 +666,7 @@ def _conditionings_with_strength(conditioning, strength: float) -> list:
 def _mark_artist_mix_conditioning(conditioning, key: str) -> list:
     return _conditionings_with_values(conditioning, {key: True})
 
-def _prompt_data_positive_fields(data: dict[str, Any]) -> list[dict]:
+def _prompt_data_positive_fields(data: dict[str, Any]) -> list[AdvancedField]:
     fields = data.get("fields")
     if not isinstance(fields, list) or not fields:
         return []

--- a/easyuse_anima/prompt/contracts.py
+++ b/easyuse_anima/prompt/contracts.py
@@ -1,0 +1,35 @@
+"""Internal typed contracts for Prompt Studio feature data."""
+
+from typing import TypedDict
+
+
+class PromptField(TypedDict):
+    """Fields shared by Advanced and Regional Prompt Studio flows."""
+
+    id: str
+    pane: str
+    type: str
+    label: str
+    text: str
+    height: int
+    enabled: bool
+
+
+class AdvancedField(PromptField, total=False):
+    """Advanced field preserving the legacy Extend adapter's omitted pin."""
+
+    pin: bool
+
+
+class _RegionalFieldRequired(PromptField):
+    mask_ids: list[int]
+
+
+class RegionalField(_RegionalFieldRequired, total=False):
+    """Regional field preserving the legacy default's omitted optional flags."""
+
+    pin: bool
+    collapsed: bool
+
+
+__all__ = ()

--- a/easyuse_anima/prompt/regional.py
+++ b/easyuse_anima/prompt/regional.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
 from ..common.values import _as_bool, _as_float, _as_int, _single_value
 from ..naia.resolution import _ratio_label
@@ -15,6 +15,7 @@ from .advanced import (
     _as_advanced_height,
     _correct_advanced_field_sequence,
 )
+from .contracts import RegionalField
 from ..settings.service import resolve_metadata_filter_words
 from .fields import _filter_metadata_prompt, _join_prompt_tokens
 
@@ -36,18 +37,18 @@ ADVANCED_FIELD_LABELS = {
 }
 
 
-def _regional_default_fields() -> list[dict]:
-    fields = []
+def _regional_default_fields() -> list[RegionalField]:
+    fields: list[RegionalField] = []
     for field in _advanced_default_fields():
         if field.get("type") == "naia":
             continue
-        item = dict(field)
+        item = cast(RegionalField, dict(field))
         item["mask_ids"] = []
         fields.append(item)
     return fields
 
 
-def _regional_fields_json(fields: list[dict] | None = None) -> str:
+def _regional_fields_json(fields: list[RegionalField] | None = None) -> str:
     return json.dumps(
         fields if fields is not None else _regional_default_fields(),
         ensure_ascii=False,
@@ -74,7 +75,7 @@ def _normalize_mask_ids(value) -> list[int]:
     return mask_ids
 
 
-def _normalize_regional_fields(value: str | list | None) -> list[dict]:
+def _normalize_regional_fields(value: str | list | None) -> list[RegionalField]:
     raw = value
     if isinstance(value, str):
         try:
@@ -86,7 +87,7 @@ def _normalize_regional_fields(value: str | list | None) -> list[dict]:
     if not raw:
         raw = _regional_default_fields()
 
-    fields: list[dict] = []
+    fields: list[RegionalField] = []
     seen_trigger = False
     for index, item in enumerate(raw):
         if not isinstance(item, dict):
@@ -128,17 +129,20 @@ def _normalize_regional_fields(value: str | list | None) -> list[dict]:
     return fields or _regional_default_fields()
 
 
-def _clone_regional_fields(fields: list[dict]) -> list[dict]:
+def _clone_regional_fields(fields: list[RegionalField]) -> list[RegionalField]:
     return [
-        {
+        cast(RegionalField, {
             **dict(field),
             "mask_ids": list(field.get("mask_ids") or []),
-        }
+        })
         for field in fields
     ]
 
 
-def _apply_regional_field_inputs(fields: list[dict], field_inputs: dict) -> list[dict]:
+def _apply_regional_field_inputs(
+    fields: list[RegionalField],
+    field_inputs: dict,
+) -> list[RegionalField]:
     values = _advanced_field_input_values(field_inputs)
     if not values:
         return _clone_regional_fields(fields)
@@ -283,7 +287,7 @@ def _regional_config_json(config: dict[str, Any] | None = None) -> str:
     )
 
 
-def _regional_field_prompt(field: dict, artist_overrides: str = "") -> str:
+def _regional_field_prompt(field: RegionalField, artist_overrides: str = "") -> str:
     return _correct_advanced_field_sequence(
         [field],
         include_quality=True,
@@ -293,7 +297,7 @@ def _regional_field_prompt(field: dict, artist_overrides: str = "") -> str:
 
 
 def _build_regional_outputs(
-    fields: list[dict],
+    fields: list[RegionalField],
     config: dict[str, Any],
     width: int,
     height: int,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6583,6 +6583,24 @@
       },
       {
         "alias": null,
+        "bound_name": "AdvancedField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.contracts:AdvancedField",
+        "kind": "static_from",
+        "line": 15,
+        "name": "AdvancedField",
+        "optional": false,
+        "requested": "..prompt.contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_normalize_prompt_data",
         "branch_context": [],
         "classification": "internal",
@@ -6590,7 +6608,7 @@
         "conditional": false,
         "imported": "..prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "..prompt.data",
@@ -6608,7 +6626,7 @@
         "conditional": false,
         "imported": ".generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": ".generation_defaults",
@@ -6626,7 +6644,7 @@
         "conditional": false,
         "imported": ".generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": ".generation_defaults",
@@ -6644,7 +6662,7 @@
         "conditional": false,
         "imported": ".negpip:_aio_negpip_execution_prompts",
         "kind": "static_from",
-        "line": 17,
+        "line": 18,
         "name": "_aio_negpip_execution_prompts",
         "optional": false,
         "requested": ".negpip",
@@ -23377,6 +23395,24 @@
       },
       {
         "alias": null,
+        "bound_name": "AdvancedField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.contracts:AdvancedField",
+        "kind": "static_from",
+        "line": 65,
+        "name": "AdvancedField",
+        "optional": false,
+        "requested": "..prompt.contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_scrub_reserved_wildcard_next_seed",
         "branch_context": [],
         "classification": "internal",
@@ -23384,7 +23420,7 @@
         "conditional": false,
         "imported": "..seed.compatibility:_scrub_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_scrub_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "..seed.compatibility",
@@ -23402,7 +23438,7 @@
         "conditional": false,
         "imported": "..settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "..settings.service",
@@ -23420,7 +23456,7 @@
         "conditional": false,
         "imported": "..settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "..settings.service",
@@ -23438,7 +23474,7 @@
         "conditional": false,
         "imported": "..wildcard.seed:next_seed",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "next_seed",
         "optional": false,
         "requested": "..wildcard.seed",
@@ -23456,7 +23492,7 @@
         "conditional": false,
         "imported": "..wildcard.service:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 71,
+        "line": 72,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "..wildcard.service",
@@ -23474,7 +23510,7 @@
         "conditional": false,
         "imported": "..workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 72,
+        "line": 73,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "..workflow",
@@ -23492,7 +23528,7 @@
         "conditional": false,
         "imported": ".input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 73,
+        "line": 74,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".input_types",
@@ -23510,7 +23546,7 @@
         "conditional": false,
         "imported": ".naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 74,
+        "line": 75,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".naia_nodes",
@@ -23528,7 +23564,7 @@
         "conditional": false,
         "imported": ".seed_adapters:PROMPT_STUDIO_ADVANCED_SEED_FEATURE",
         "kind": "static_from",
-        "line": 75,
+        "line": 76,
         "name": "PROMPT_STUDIO_ADVANCED_SEED_FEATURE",
         "optional": false,
         "requested": ".seed_adapters",
@@ -23546,7 +23582,7 @@
         "conditional": false,
         "imported": ".seed_adapters:PromptStudioSeedExecution",
         "kind": "static_from",
-        "line": 75,
+        "line": 76,
         "name": "PromptStudioSeedExecution",
         "optional": false,
         "requested": ".seed_adapters",
@@ -23564,7 +23600,7 @@
         "conditional": false,
         "imported": ".seed_adapters:prompt_studio_seed_execution",
         "kind": "static_from",
-        "line": 75,
+        "line": 76,
         "name": "prompt_studio_seed_execution",
         "optional": false,
         "requested": ".seed_adapters",
@@ -27843,6 +27879,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Sequence",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Sequence",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -27850,8 +27903,42 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeVar",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeVar",
+        "kind": "static_from",
+        "line": 8,
+        "name": "TypeVar",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 8,
+        "name": "cast",
         "optional": false,
         "requested": "typing",
         "role": "ordinary",
@@ -27867,7 +27954,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -27885,7 +27972,7 @@
         "conditional": false,
         "imported": "..common.values:_as_int",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_as_int",
         "optional": false,
         "requested": "..common.values",
@@ -27903,7 +27990,7 @@
         "conditional": false,
         "imported": "..common.values:_single_value",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_single_value",
         "optional": false,
         "requested": "..common.values",
@@ -27921,7 +28008,7 @@
         "conditional": false,
         "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "..naia.resolution",
@@ -27939,7 +28026,7 @@
         "conditional": false,
         "imported": "..naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "..naia.resolution",
@@ -27957,7 +28044,7 @@
         "conditional": false,
         "imported": "..naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "..naia.resolution",
@@ -27975,7 +28062,7 @@
         "conditional": false,
         "imported": "..settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "..settings.service",
@@ -27993,7 +28080,7 @@
         "conditional": false,
         "imported": "..translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "..translation.markers",
@@ -28011,7 +28098,7 @@
         "conditional": false,
         "imported": "..wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 17,
+        "line": 18,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "..wildcard.expansion",
@@ -28029,7 +28116,7 @@
         "conditional": false,
         "imported": "..wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "..wildcard.mode",
@@ -28047,7 +28134,7 @@
         "conditional": false,
         "imported": "..wildcard.seed:normalize_seed",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "normalize_seed",
         "optional": false,
         "requested": "..wildcard.seed",
@@ -28065,7 +28152,7 @@
         "conditional": false,
         "imported": "..wildcard.service:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "..wildcard.service",
@@ -28083,7 +28170,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".artist_mix",
@@ -28101,7 +28188,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".artist_mix",
@@ -28119,7 +28206,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".artist_mix",
@@ -28137,7 +28224,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".artist_mix",
@@ -28155,7 +28242,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".artist_mix",
@@ -28173,7 +28260,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".artist_mix",
@@ -28191,7 +28278,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".artist_mix",
@@ -28209,7 +28296,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".artist_mix",
@@ -28227,7 +28314,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".artist_mix",
@@ -28245,7 +28332,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".artist_mix",
@@ -28263,7 +28350,7 @@
         "conditional": false,
         "imported": ".artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".artist_mix",
@@ -28281,7 +28368,7 @@
         "conditional": false,
         "imported": ".artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".artist_mix",
@@ -28299,7 +28386,7 @@
         "conditional": false,
         "imported": ".artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".artist_mix",
@@ -28317,7 +28404,7 @@
         "conditional": false,
         "imported": ".artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".artist_mix",
@@ -28335,7 +28422,7 @@
         "conditional": false,
         "imported": ".artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".artist_mix",
@@ -28353,7 +28440,7 @@
         "conditional": false,
         "imported": ".artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".artist_mix",
@@ -28371,7 +28458,7 @@
         "conditional": false,
         "imported": ".artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".artist_mix",
@@ -28389,7 +28476,7 @@
         "conditional": false,
         "imported": ".correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 40,
+        "line": 41,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".correction",
@@ -28400,6 +28487,42 @@
       },
       {
         "alias": null,
+        "bound_name": "AdvancedField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:AdvancedField",
+        "kind": "static_from",
+        "line": 42,
+        "name": "AdvancedField",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PromptField",
+        "kind": "static_from",
+        "line": 42,
+        "name": "PromptField",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PROMPT_DATA_SCHEMA",
         "branch_context": [],
         "classification": "internal",
@@ -28407,7 +28530,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".data",
@@ -28425,7 +28548,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".data",
@@ -28443,7 +28566,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".data",
@@ -28461,7 +28584,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -28479,7 +28602,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -28497,7 +28620,7 @@
         "conditional": false,
         "imported": ".fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".fields",
@@ -28515,7 +28638,7 @@
         "conditional": false,
         "imported": ".fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".fields",
@@ -28533,7 +28656,7 @@
         "conditional": false,
         "imported": ".fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".fields",
@@ -29443,6 +29566,24 @@
       },
       {
         "alias": null,
+        "bound_name": "AdvancedField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:AdvancedField",
+        "kind": "static_from",
+        "line": 10,
+        "name": "AdvancedField",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_normalize_prompt_data",
         "branch_context": [],
         "classification": "internal",
@@ -29450,7 +29591,7 @@
         "conditional": false,
         "imported": ".data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".data",
@@ -29468,7 +29609,7 @@
         "conditional": false,
         "imported": ".data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": ".data",
@@ -29486,7 +29627,7 @@
         "conditional": false,
         "imported": ".data:_prompt_data_output",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": ".data",
@@ -29504,7 +29645,7 @@
         "conditional": false,
         "imported": ".fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".fields",
@@ -29522,7 +29663,7 @@
         "conditional": false,
         "imported": ".fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".fields",
@@ -29540,7 +29681,7 @@
         "conditional": false,
         "imported": ".advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 126,
+        "line": 127,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".advanced",
@@ -29558,7 +29699,7 @@
         "conditional": false,
         "imported": ".advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".advanced",
@@ -29576,7 +29717,7 @@
         "conditional": false,
         "imported": ".advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".advanced",
@@ -29594,7 +29735,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 408
+            "line": 409
           }
         ],
         "classification": "external",
@@ -29602,7 +29743,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 409,
+        "line": 410,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29619,7 +29760,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 425
           }
         ],
         "classification": "external",
@@ -29627,7 +29768,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 425,
+        "line": 426,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29644,7 +29785,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 445
           }
         ],
         "classification": "external",
@@ -29652,7 +29793,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 445,
+        "line": 446,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29669,7 +29810,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 519
+            "line": 520
           }
         ],
         "classification": "external",
@@ -29677,7 +29818,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 520,
+        "line": 521,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29694,7 +29835,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1108
+            "line": 1109
           }
         ],
         "classification": "external",
@@ -29702,7 +29843,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1109,
+        "line": 1110,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -29796,6 +29937,23 @@
         "scope": "<module>",
         "source": "easyuse_anima/prompt/conditioning.py",
         "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypedDict",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypedDict",
+        "kind": "static_from",
+        "line": 3,
+        "name": "TypedDict",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/contracts.py"
       },
       {
         "alias": null,
@@ -30113,6 +30271,23 @@
       },
       {
         "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 7,
+        "name": "cast",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_as_bool",
         "branch_context": [],
         "classification": "internal",
@@ -30293,6 +30468,24 @@
       },
       {
         "alias": null,
+        "bound_name": "RegionalField",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:RegionalField",
+        "kind": "static_from",
+        "line": 18,
+        "name": "RegionalField",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "alias": null,
         "bound_name": "resolve_metadata_filter_words",
         "branch_context": [],
         "classification": "internal",
@@ -30300,7 +30493,7 @@
         "conditional": false,
         "imported": "..settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "..settings.service",
@@ -30318,7 +30511,7 @@
         "conditional": false,
         "imported": ".fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".fields",
@@ -30336,7 +30529,7 @@
         "conditional": false,
         "imported": ".fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".fields",
@@ -30354,7 +30547,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 475
+            "line": 479
           }
         ],
         "classification": "external",
@@ -30362,7 +30555,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 476,
+        "line": 480,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -30379,7 +30572,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 513
+            "line": 517
           }
         ],
         "classification": "external",
@@ -30387,7 +30580,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 514,
+        "line": 518,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -66212,6 +66405,10 @@
       },
       {
         "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/aio/conditioning.py",
         "to": "easyuse_anima/prompt/data.py"
       },
       {
@@ -67100,6 +67297,10 @@
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/prompt/correction.py"
       },
       {
@@ -67384,6 +67585,10 @@
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
+        "to": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/advanced.py",
         "to": "easyuse_anima/prompt/correction.py"
       },
       {
@@ -67492,6 +67697,10 @@
       },
       {
         "from": "easyuse_anima/prompt/artist_mix.py",
+        "to": "easyuse_anima/prompt/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/artist_mix.py",
         "to": "easyuse_anima/prompt/data.py"
       },
       {
@@ -67541,6 +67750,10 @@
       {
         "from": "easyuse_anima/prompt/regional.py",
         "to": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "easyuse_anima/prompt/contracts.py"
       },
       {
         "from": "easyuse_anima/prompt/regional.py",
@@ -68900,6 +69113,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/prompt/contracts.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/prompt/correction.py"
         ]
       },
@@ -69146,7 +69365,7 @@
     ]
   },
   "inventory": {
-    "module_count": 174,
+    "module_count": 175,
     "modules": [
       {
         "is_package": true,
@@ -69318,9 +69537,9 @@
       },
       {
         "is_package": false,
-        "loc": 127,
+        "loc": 130,
         "module": "easyuse_anima.aio.conditioning",
-        "normalized_git_blob_sha1": "37ab4f25419f9a1cb0b0c56a6d377518e3c87772",
+        "normalized_git_blob_sha1": "406bddfe59ffd24e6aca9148b9b62668236c4a85",
         "path": "easyuse_anima/aio/conditioning.py",
         "top_level": {
           "class_count": 0,
@@ -70458,9 +70677,9 @@
       },
       {
         "is_package": false,
-        "loc": 1201,
+        "loc": 1205,
         "module": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "normalized_git_blob_sha1": "8beec122ad15ff6b02ecc2f5a7303950ec048df3",
+        "normalized_git_blob_sha1": "118b36d1c647e5a6264181258ad29eac7c784fbc",
         "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "top_level": {
           "class_count": 3,
@@ -70626,14 +70845,14 @@
       },
       {
         "is_package": false,
-        "loc": 863,
+        "loc": 879,
         "module": "easyuse_anima.prompt.advanced",
-        "normalized_git_blob_sha1": "c6451c3536951b3d09d264413fabf3396229ccd7",
+        "normalized_git_blob_sha1": "6adfa4eafa7d6041f1ceb96f144a7408fc35fa10",
         "path": "easyuse_anima/prompt/advanced.py",
         "top_level": {
           "class_count": 0,
           "function_count": 25,
-          "global_count": 17
+          "global_count": 18
         }
       },
       {
@@ -70722,9 +70941,9 @@
       },
       {
         "is_package": false,
-        "loc": 1496,
+        "loc": 1497,
         "module": "easyuse_anima.prompt.artist_mix",
-        "normalized_git_blob_sha1": "4b87698d8c7f87066e2533e924ef7f706c2fa86c",
+        "normalized_git_blob_sha1": "fbf1843e72604fb88a72a618aa11687bc4c424cc",
         "path": "easyuse_anima/prompt/artist_mix.py",
         "top_level": {
           "class_count": 0,
@@ -70742,6 +70961,18 @@
           "class_count": 0,
           "function_count": 8,
           "global_count": 9
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 35,
+        "module": "easyuse_anima.prompt.contracts",
+        "normalized_git_blob_sha1": "e18777bb7141370dffacbbdd738fa25074374c9c",
+        "path": "easyuse_anima/prompt/contracts.py",
+        "top_level": {
+          "class_count": 4,
+          "function_count": 0,
+          "global_count": 1
         }
       },
       {
@@ -70782,9 +71013,9 @@
       },
       {
         "is_package": false,
-        "loc": 552,
+        "loc": 556,
         "module": "easyuse_anima.prompt.regional",
-        "normalized_git_blob_sha1": "bc7cdc829f1f0f31f3ad0388b0a61e1997727973",
+        "normalized_git_blob_sha1": "de5c3c9795cfa37813d52af7b9249120458f364d",
         "path": "easyuse_anima/prompt/regional.py",
         "top_level": {
           "class_count": 0,
@@ -88868,9 +89099,42 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "collections.abc:Sequence",
         "kind": "static_from",
         "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeVar",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 8,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/prompt/advanced.py"
@@ -89091,14 +89355,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 408
+            "line": 409
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 409,
+        "line": 410,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -89110,14 +89374,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 425
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 425,
+        "line": 426,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -89129,14 +89393,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 445
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 445,
+        "line": 446,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -89148,14 +89412,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 519
+            "line": 520
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 520,
+        "line": 521,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -89167,14 +89431,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1108
+            "line": 1109
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1109,
+        "line": 1110,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -89211,6 +89475,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypedDict",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/contracts.py"
       },
       {
         "branch_context": [],
@@ -89323,20 +89598,31 @@
         "source": "easyuse_anima/prompt/regional.py"
       },
       {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 475
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 476,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -89348,14 +89634,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 513
+            "line": 517
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 514,
+        "line": 518,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -91632,14 +91918,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 408
+            "line": 409
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 409,
+        "line": 410,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -91651,14 +91937,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 425
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 425,
+        "line": 426,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -91670,14 +91956,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 445
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 445,
+        "line": 446,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -91689,14 +91975,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 519
+            "line": 520
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 520,
+        "line": 521,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -91708,14 +91994,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1108
+            "line": 1109
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1109,
+        "line": 1110,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -91727,14 +92013,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 475
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 476,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -91746,14 +92032,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 513
+            "line": 517
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 514,
+        "line": 518,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -91970,6 +92256,7 @@
       "easyuse_anima/prompt/anima/parser.py",
       "easyuse_anima/prompt/artist_mix.py",
       "easyuse_anima/prompt/conditioning.py",
+      "easyuse_anima/prompt/contracts.py",
       "easyuse_anima/prompt/correction.py",
       "easyuse_anima/prompt/data.py",
       "easyuse_anima/prompt/fields.py",
@@ -92146,6 +92433,7 @@
       "easyuse_anima/prompt/anima/parser.py",
       "easyuse_anima/prompt/artist_mix.py",
       "easyuse_anima/prompt/conditioning.py",
+      "easyuse_anima/prompt/contracts.py",
       "easyuse_anima/prompt/correction.py",
       "easyuse_anima/prompt/data.py",
       "easyuse_anima/prompt/fields.py",
@@ -93647,7 +93935,16 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 131,
+        "line": 133,
+        "module": "easyuse_anima/prompt/advanced.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "TypeVar",
+        "column": 16,
+        "context": "assign:_PromptFieldT",
+        "kind": "import_time_call",
+        "line": 134,
         "module": "easyuse_anima/prompt/advanced.py",
         "scope": "<module>"
       },
@@ -93800,7 +94097,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 103,
+        "line": 104,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -93809,7 +94106,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 106,
+        "line": 107,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -93818,7 +94115,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 110,
+        "line": 111,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -94416,37 +94713,37 @@
       },
       {
         "kind": "dict",
-        "line": 52,
+        "line": 54,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 51,
+        "line": 53,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 50,
+        "line": 52,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "list",
-        "line": 81,
+        "line": 83,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 75,
+        "line": 77,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES"
       },
       {
         "kind": "dict",
-        "line": 65,
+        "line": 67,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
       },
@@ -94470,7 +94767,7 @@
       },
       {
         "kind": "dict",
-        "line": 74,
+        "line": 75,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
@@ -94482,19 +94779,19 @@
       },
       {
         "kind": "dict",
-        "line": 31,
+        "line": 32,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 30,
+        "line": 31,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 24,
+        "line": 25,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "REGIONAL_FIELD_TYPES"
       },

--- a/tests/test_aio_conditioning.py
+++ b/tests/test_aio_conditioning.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
 import unittest
+from typing import get_type_hints
 from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import conditioning
+from easyuse_anima.prompt.contracts import AdvancedField
 from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOConditioningMoveTests(unittest.TestCase):
+    def test_prompt_data_fields_use_canonical_advanced_field_contract(self):
+        self.assertEqual(
+            get_type_hints(conditioning._aio_prompt_data_fields_for_usdu)["return"],
+            list[AdvancedField],
+        )
+
     def test_root_symbols_are_direct_canonical_aliases(self):
         for name in (
             "_aio_prompt_data_fields_for_usdu",

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -9,6 +9,7 @@ import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import get_type_hints
 from unittest.mock import patch
 
 import nodes
@@ -21,7 +22,11 @@ from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioEx
 from easyuse_anima.prompt import artist_mix as prompt_artist_mix
 from easyuse_anima.prompt import conditioning as prompt_conditioning
 from easyuse_anima.prompt import correction as prompt_correction
-from easyuse_anima.prompt.advanced import ADVANCED_FIELDS_WORKFLOW_PROPERTY
+from easyuse_anima.prompt.advanced import (
+    ADVANCED_FIELDS_WORKFLOW_PROPERTY,
+    _advanced_prompt_data_fields,
+    _normalize_advanced_fields,
+)
 from easyuse_anima.prompt.artist_mix import (
     ARTIST_MIX_CONTROL_KEY,
     ARTIST_MIX_EXACT_KEY,
@@ -36,6 +41,7 @@ from easyuse_anima.prompt.artist_mix import (
 from easyuse_anima.prompt.conditioning import (
     _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
 )
+from easyuse_anima.prompt.contracts import AdvancedField
 from easyuse_anima.prompt.data import PROMPT_DATA_SCHEMA
 from easyuse_anima.settings import repository as settings_repository
 from easyuse_anima.settings import schema as settings_schema
@@ -394,6 +400,56 @@ class PromptCorrectorTests(unittest.TestCase):
 
 
 class PromptBuilderTests(unittest.TestCase):
+    def test_advanced_field_contract_preserves_normalized_and_extend_shapes(self):
+        self.assertEqual(
+            AdvancedField.__required_keys__,
+            frozenset({"id", "pane", "type", "label", "text", "height", "enabled"}),
+        )
+        self.assertEqual(AdvancedField.__optional_keys__, frozenset({"pin"}))
+        self.assertEqual(
+            get_type_hints(_normalize_advanced_fields)["return"],
+            list[AdvancedField],
+        )
+        self.assertEqual(
+            get_type_hints(_advanced_prompt_data_fields)["return"],
+            list[AdvancedField],
+        )
+        self.assertEqual(
+            get_type_hints(prompt_artist_mix._prompt_data_positive_fields)["return"],
+            list[AdvancedField],
+        )
+
+        normalized = _normalize_advanced_fields([
+            {
+                "id": "positive_general",
+                "pane": "positive",
+                "type": "general",
+                "label": "General Tags",
+                "text": "1girl",
+                "height": 150,
+                "enabled": True,
+                "pin": False,
+                "future_key": "ignored",
+            }
+        ])
+        self.assertEqual(
+            list(normalized[0]),
+            ["id", "pane", "type", "label", "text", "height", "enabled", "pin"],
+        )
+
+        extended = EasyUseAnimaPromptStudioExtend._fields_from_slots(
+            {"quality_tags_1": "best quality"},
+            ["quality_tags_1"],
+        )
+        self.assertEqual(
+            list(extended[0]),
+            ["id", "pane", "type", "label", "text", "height", "enabled"],
+        )
+        self.assertEqual(
+            get_type_hints(EasyUseAnimaPromptStudioExtend._fields_from_slots)["return"],
+            list[AdvancedField],
+        )
+
     def test_prompt_builder_and_studio_default_quality_tags(self):
         builder_inputs = EasyUseAnimaPromptBuilder.INPUT_TYPES()["required"]
         studio_inputs = EasyUseAnimaPromptStudio.INPUT_TYPES()["required"]

--- a/tests/test_prompt_studio_regional.py
+++ b/tests/test_prompt_studio_regional.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import unittest
+from typing import get_type_hints
 from unittest.mock import patch
 
 import nodes as easy_nodes
 from easyuse_anima.nodes import regional_nodes
 from easyuse_anima.prompt import regional as regional_service
+from easyuse_anima.prompt.contracts import PromptField, RegionalField
 from tests.comfy_host_fakes import patch_comfy_helper
 from nodes import (
     EasyUseAnimaRegionalConditioning,
@@ -15,6 +17,62 @@ from nodes import (
 
 
 class PromptStudioRegionalTests(unittest.TestCase):
+    def test_regional_field_contract_preserves_normalized_and_default_shapes(self):
+        shared_keys = {"id", "pane", "type", "label", "text", "height", "enabled"}
+        self.assertEqual(PromptField.__required_keys__, frozenset(shared_keys))
+        self.assertEqual(
+            RegionalField.__required_keys__,
+            frozenset({*shared_keys, "mask_ids"}),
+        )
+        self.assertEqual(
+            RegionalField.__optional_keys__,
+            frozenset({"pin", "collapsed"}),
+        )
+        self.assertEqual(
+            get_type_hints(regional_service._normalize_regional_fields)["return"],
+            list[RegionalField],
+        )
+        self.assertEqual(
+            get_type_hints(regional_service._build_regional_outputs)["fields"],
+            list[RegionalField],
+        )
+
+        normalized = regional_service._normalize_regional_fields([
+            {
+                "id": "masked_general",
+                "pane": "positive",
+                "type": "general",
+                "label": "Masked prompt",
+                "text": "red dress",
+                "height": 120,
+                "enabled": True,
+                "pin": False,
+                "collapsed": True,
+                "mask_ids": [1],
+                "future_key": "ignored",
+            }
+        ])
+        self.assertEqual(
+            list(normalized[0]),
+            [
+                "id",
+                "pane",
+                "type",
+                "label",
+                "text",
+                "height",
+                "enabled",
+                "pin",
+                "collapsed",
+                "mask_ids",
+            ],
+        )
+
+        fallback = regional_service._normalize_regional_fields([None])
+        self.assertNotIn("collapsed", fallback[0])
+        self.assertNotIn("pin", fallback[0])
+        self.assertIn("mask_ids", fallback[0])
+
     def test_root_exports_are_canonical_regional_identities(self):
         self.assertIs(
             EasyUseAnimaPromptStudioRegional,

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 174)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 174)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 174)
+        self.assertEqual(report["inventory"]["module_count"], 175)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 175)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 175)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [


### PR DESCRIPTION
## 목적과 변경 경계

Issue #563 / F-02b의 수정된 Prompt field-family 계약을 구현합니다.

- Base: `b9179f0082525705131eead752b09b8f5cd1bc22`
- Head: `e9fa34f23e2ba1e607db5b619cf61275ebf95269`
- 공통 `PromptField`, optional `pin`을 가진 `AdvancedField`, required `mask_ids`와 optional `pin/collapsed`를 가진 `RegionalField` 내부 계약 추가
- correction / wildcard / translation 공유 helper가 bounded generic으로 concrete subtype을 보존
- Advanced, Extend, Regional, AiO conditioning, artist mix, node adapter의 기존 값·키 생략·순서·오류 동작 보존
- 공개 package/root export, schema/persistence/API 동작 변경 없음

## 주요 파일

- `easyuse_anima/prompt/contracts.py`
- `easyuse_anima/prompt/advanced.py`
- `easyuse_anima/prompt/regional.py`
- 직접 consumer 및 owner tests
- 실제 source에서 재생성한 Python backend analyzer fixture

## 검증

Focused:
- PromptBuilderTests: 64 passed
- Prompt Studio Regional: 10 passed
- AIOConditioningMoveTests: 6 passed
- PromptAdvancedMoveContractTests: 6 passed
- RegionalMoveContractTests: 2 passed
- Pyright baseline owners: 11 passed
- Python backend analyzer: 18 passed
- changed-file Python syntax/static: passed
- Pyright baseline ratchet: 158 files, 기존 14 errors, 신규 증가 없음
- import-boundary: 11 groups, 0 violations
- `git diff --check`: passed

Final SHA official full (정확히 1회):
- Python: 1,438 tests passed
- Frontend: 120 JavaScript files passed
- Pyright/import-boundary/diff gates passed

Package/live는 typed internal boundary가 실행·배포 경계를 바꾸지 않아 수행하지 않았습니다.

## 위험과 rollback

위험은 내부 annotation/generic 보존이 legacy optional field 형태를 잘못 좁히는 경우입니다. 직접 fixture로 Extend의 `pin` 생략 및 Regional fallback의 optional flags 생략을 고정했습니다. 필요 시 이 squash commit 하나를 되돌릴 수 있습니다.

## 다음 작업

별도 production-free Prompt-row completion re-audit 후, 남은 canonical Prompt Data typed output/read mapping을 가장 작은 후속 task card로 확정합니다.