### PR TITLE
docs: re-audit Prompt boundary after F-02b

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02b Prompt field-family typed contract.
+  / F-02c canonical Prompt Data typed read/output contract.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -30,7 +30,9 @@ then only the active task section, owning Issue, direct source, and direct tests
 ```text
 COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE affected-row re-audit
-  -> READY F-02b Prompt field-family typed contract
+  -> COMPLETE F-02b Prompt field-family typed contract
+  -> COMPLETE affected Prompt-row re-audit
+  -> READY F-02c canonical Prompt Data typed read/output contract
   -> re-audit the affected Prompt row
   -> next smallest F-02 while a finding remains
   -> G-04A public API snapshot coverage audit

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02b Prompt field-family typed contract.
+- Active first task: Issue #563 / F-02c canonical Prompt Data typed read/output contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -67,7 +67,9 @@ ADR-002 result when evidence is absent or ambiguous.
 ```text
 COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE affected-row re-audit
-  -> READY F-02b Prompt field-family typed contract            #563
+  -> COMPLETE F-02b Prompt field-family typed contract         #563 / PR #569
+  -> COMPLETE affected Prompt-row re-audit
+  -> READY F-02c canonical Prompt Data typed read/output       #563
   -> RE-AUDIT affected Prompt row
   -> F-02      next smallest targeted gap while one remains
   -> G-04A    public API snapshot coverage audit              #188
@@ -136,16 +138,18 @@ Exit:
 - gap: execute only the smallest F-02, re-audit the affected row, then select the
   next smallest remaining finding or start G-04A when Phase F closes.
 
-Audit result, updated after F-02a merged at
-`3a306498325c48126325aadc6d31665acf3517b4`:
+Audit result, updated after F-02b merged at
+`4cf0c82ee459d37e67fa0b8d7b80cd162e111658`:
 
 - [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md)
   records the production-free six-area inventory and reuses the existing
   deterministic fixtures;
-- Autocomplete and Wildcard are complete after F-02a; Prompt's normalized Advanced
-  fields and canonical Prompt Data remain exact, separable follow-up findings;
-- only the smallest cohesive follow-up, F-02b Prompt field-family typed contract, is
-  selected as the next task card;
+- Autocomplete and Wildcard are complete after F-02a; the Prompt field family is
+  complete after F-02b;
+- legacy/future Prompt Data JSON remains intentionally raw only at the workflow and
+  node adapter boundary;
+- only the smallest remaining Prompt leak, F-02c canonical Prompt Data typed
+  read/output contract, is selected as the next task card;
 - settings migration and common error taxonomy remain separate findings;
 - G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
 
@@ -362,27 +366,28 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #563 / F-02b only from latest origin/dev after the F-02a affected-row
+Start Issue #563 / F-02c only from latest origin/dev after the F-02b affected Prompt-row
 re-audit merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document's F-01 result and validation sections
-- python-typed-boundary-f01-audit.md F-02b task card
+- python-typed-boundary-f01-audit.md F-02c task card
 - Issue #563 latest checkpoint
-- direct Prompt Advanced/Regional owner source/tests and current Pyright/import fixtures
+- direct Prompt Data/Advanced/AiO/artist-mix owner source/tests and current
+  Pyright/import fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Define internal PromptField, AdvancedField, and RegionalField TypedDicts, using a
-bounded generic only where shared correction/wildcard/translation helpers preserve the
-concrete subtype. Apply them through both normalizers, Prompt Studio node adapters,
-AiO conditioning, and artist mix without changing runtime dictionaries, input/workflow
-migration, field order/defaults, behavior, identities, or public exports. Preserve the
-legacy Extend adapter's omitted `pin`. Reuse direct Advanced/Regional Prompt Studio,
-AiO conditioning, node-owner, Pyright, and import tests; update only a direct generated
-analyzer baseline if the canonical module requires it.
+Define internal canonical Prompt Data output and nested TypedDicts plus a typed
+feature-side read mapping. Apply them from the Advanced v2 builder through Prompt Data
+helpers and direct Prompt/AiO/artist-mix consumers without changing runtime
+dictionaries, schema/version, nested key order/values, fallback precedence,
+copy-on-update behavior, input/workflow acceptance, identities, or public exports.
+Keep legacy and future JSON raw only at the adapter boundary. Reuse direct Prompt Data,
+AiO conditioning/generation, node-owner, Pyright, and import tests; update only a direct
+generated analyzer baseline if the canonical type surface requires it.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run official full once on the final production/test/tool SHA.

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -3,14 +3,14 @@
 ## Status
 
 - Owner: Issue #563
-- Base: `3a306498325c48126325aadc6d31665acf3517b4`
+- Base: `4cf0c82ee459d37e67fa0b8d7b80cd162e111658`
 - Class: Contract/gate
 - Production changes: none
 - Result: Phase F remains open; G-04A is not READY
 
 This audit reuses the current Pyright, import-boundary, API, profile, workflow,
 Autocomplete, Wildcard, and AiO schema/migration evidence. The Prompt/Wildcard/
-Autocomplete row was re-audited after F-02a merged as PR #566. It adds no second
+Autocomplete row was re-audited after F-02b merged as PR #569. It adds no second
 machine-readable inventory because the current deterministic fixtures and direct
 owner tests can express every finding below.
 
@@ -20,7 +20,7 @@ owner tests can express every finding below.
 | --- | --- | --- | --- |
 | Settings, profile, and workflow schema/migration | Profile v2 identity/revision and pure read migration are owned by `easyuse_anima/profiles/contract.py`; the strict Pyright owner is fixed by `tests/fixtures/pyright_baseline.json`. Settings persistence/projection is owned by `easyuse_anima/settings/schema.py`, `repository.py`, and `service.py`. Read-only ComfyUI workflow lookup is owned by `easyuse_anima/workflow.py`. Direct evidence is in `tests/test_profile_contract.py`, `tests/test_lora_profiles.py`, `tests/test_aio_profiles.py`, `tests/test_api_contract.py`, and `tests/test_node_contracts.py`. | Profile payload mappings preserve legacy and future fields at the persisted JSON migration boundary. `_get_workflow_node` accepts dynamic host `extra_pnginfo` and returns a raw workflow node only at the ComfyUI adapter boundary. | **exact F-02 follow-up required.** Profile and workflow boundaries are complete or intentional, but ordinary settings have no version detection, pure migration sequence, or typed post-normalization model. Long-text settings write a v1 envelope, yet their normalized value and the settings service still cross feature code as unparameterized dictionaries. |
 | API request/result/error | `easyuse_anima/api/requests.py` validates JSON-object bodies and produces typed scalar fields; `easyuse_anima/api/errors.py` owns `ApiContractError`; `easyuse_anima/api/responses.py` owns the stable error envelope and request correlation. `tests/test_api_contract_compatibility.py` and the direct route classes in `tests/test_api_contract.py` freeze the behavior. | Request bodies and success/error dictionaries exist at the JSON serialization adapter. Profile and settings sub-objects remain mappings only while they are validated or handed to their persisted-schema boundary. | **intentional adapter/migration boundary.** Malformed/body/schema/conflict/not-found mappings and request-id correlation are typed or tested before feature calls; raw response dictionaries do not become feature-service state. |
-| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are now owned by `easyuse_anima/autocomplete/contracts.py`, while `AutocompleteEntry` and immutable snapshot/index records retain their existing owners. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_prompt_studio_regional.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing Autocomplete/Wildcard runtime fixtures. | Prompt data plus Advanced and Regional field JSON accept old workflow layouts and future keys at their workflow migration boundary. The legacy Extend adapter intentionally omits optional `pin`; Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, and the core ANIMA correction result are complete. Direct F-02b implementation evidence showed that normalized Advanced fields and normalized Regional fields share seven required keys and the same correction/wildcard/translation consumers, while Advanced adds an optional `pin` compatibility seam and Regional requires `pin`, `collapsed`, and `mask_ids`. They must be typed as one structural field family rather than misclassifying Regional as Advanced or weakening shared consumers to raw mappings. Canonical Prompt Data output/read mappings remain a separate later finding. |
+| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. `easyuse_anima/prompt/contracts.py` now owns the shared `PromptField`, `AdvancedField`, and `RegionalField` family used by Prompt, Regional, AiO-conditioning, wildcard, translation, and artist-mix consumers. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are owned by `easyuse_anima/autocomplete/contracts.py`. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_prompt_studio_regional.py`, `tests/test_aio_conditioning.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing runtime fixtures. | Prompt Data JSON accepts old layouts, malformed nested values, and future keys at the workflow/node adapter boundary. The legacy Extend adapter intentionally omits optional `pin`, and legacy Regional fallback may omit optional `pin`/`collapsed`; Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, core ANIMA correction results, and the Prompt field family are complete. Canonical Prompt Data is still built as `dict[str, Any]`, normalized to `dict[str, Any]`, and read across Prompt/AiO/artist-mix feature code through untyped nested/output mappings. F-02c must type the canonical builder result and feature-side read mapping while leaving legacy/future JSON acceptance at the adapter boundary. |
 | AiO config/request/state/result | `AIOGenerationConfig` and its section dataclasses are owned by `easyuse_anima/aio/generation_settings.py` and adjacent strict generation modules. `GenerationRequest`, `GenerationState`, and `GenerationStage` are owned by `easyuse_anima/aio/generation_pipeline.py`; version detection and pure v1-to-v4 migration are owned by `generation_migrations.py`. Evidence is in the v1-v4 schema/surface fixtures and `tests/test_aio_schema_contract.py`, `tests/test_aio_generation_settings.py`, and `tests/test_aio_generation_migrations.py`. | `Mapping[str, object]` is retained only for JSON freeze/thaw, unknown-field preservation, host capability maps, prompt/workflow context, and final ComfyUI result serialization. Tensor/model values remain `object` at host boundaries. | **complete.** Normalized settings enter the generation pipeline as a typed config and typed request/state objects; strict per-file Pyright directives cover the generation contract modules. |
 | Node adapter raw input/output conversion | `easyuse_anima/nodes/aio_nodes.py`, `prompt_nodes.py`, and `wildcard_nodes.py` convert ComfyUI inputs into the typed AiO, Prompt, and Wildcard owners before feature work. `tests/test_node_contracts.py` and the 0.5.2 node/workflow fixtures freeze the public socket and result shapes. | Dynamic ComfyUI objects, tensor/model values, workflow metadata, input dictionaries, UI dictionaries, and output tuples are host adapter values. | **intentional adapter/migration boundary.** Their dynamic shape is not feature-service typing debt and no broad `Any` removal is justified. |
 | Common feature error taxonomy and adapter mappings | Existing concrete errors include `ProfileContractError`, `ProfileMutationError`, `InvalidProfileDataError`, `AutocompleteIndexUnavailable`, `KnowledgeBaseNotFound`, `AIOGenerationMigrationError`, and API-only `ApiContractError`. Their current behavior is covered by profile, Autocomplete, AiO migration, and API tests. | `ApiContractError` is allowed to carry HTTP status/code because it is an API request-adapter error. Node adapters may translate feature errors to the existing host-visible `RuntimeError` or UI status at the final adapter. | **exact F-02 follow-up required.** The documented `EasyUseAnimaError` category hierarchy does not exist, feature errors have no shared category base, and `ProfileMutationError` currently owns HTTP status alongside feature conflict meaning. Category-to-API/node mapping is therefore not a common tested contract. |
@@ -62,64 +62,77 @@ port and core methods now use canonical Autocomplete payload contracts, while th
 adapter preserves the exact dictionaries, redaction, future-key seam, and public
 exports. Autocomplete is therefore **complete** and Wildcard remains **complete**.
 
-## Selected next task: F-02b
+## F-02b completion re-audit
 
-Only the smallest remaining Prompt leak is selected now. Canonical Prompt Data,
-settings migration, and common error taxonomy remain separate findings and are not
-silently combined into this task.
+F-02b merged as PR #569 at `4cf0c82ee459d37e67fa0b8d7b80cd162e111658`.
+Its final candidate passed 1,438 Python tests, 120-file frontend validation,
+Pyright/import-boundary checks, and `git diff --check`; package/live were not
+triggered. The shared Prompt field family now crosses Advanced, Regional, AiO,
+wildcard, translation, and artist-mix consumers without changing runtime
+dictionaries. The legacy optional-key forms remain intentional workflow adapters.
+
+## Selected next task: F-02c
+
+Only the remaining canonical Prompt Data leak is selected now. Settings migration
+and common error taxonomy remain separate findings and are not silently combined
+into this task.
 
 ```text
-Task ID: F-02b Prompt field-family typed contract
+Task ID: F-02c canonical Prompt Data typed read/output contract
 Owner Issue: #563
 Primary class: CONTRACT
 Base SHA: latest origin/dev after this completion re-audit merges
-Goal: define internal `PromptField`, `AdvancedField`, and `RegionalField` TypedDicts;
-      use a bounded generic only where shared correction/wildcard/translation helpers
-      must preserve the concrete field subtype; apply the family from both normalizers
-      through Prompt Studio node adapters, AiO conditioning, and artist mix without
-      changing any runtime dictionary.
-Prerequisites: merged F-02a, affected-row re-audit, and the direct Pyright evidence
-  that rejected an Advanced-only contract at the shared Regional boundary
+Goal: define internal canonical Prompt Data output and nested TypedDicts plus a typed
+      feature-side read mapping; apply them from the Advanced v2 builder through
+      Prompt Data helpers and direct Prompt/AiO/artist-mix consumers without changing
+      a runtime dictionary, rejecting legacy/future keys, or treating adapter input as
+      already canonical.
+Prerequisites: merged F-02b and this affected Prompt-row completion re-audit
 Allowed production files:
   easyuse_anima/prompt/contracts.py
+  easyuse_anima/prompt/data.py
   easyuse_anima/prompt/advanced.py
-  easyuse_anima/prompt/regional.py
-  easyuse_anima/prompt/artist_mix.py only for direct field-family annotations
-  easyuse_anima/aio/conditioning.py only for direct field-family annotations
-  easyuse_anima/nodes/prompt_advanced_nodes.py only for direct adapter annotations
-  easyuse_anima/nodes/regional_nodes.py only for direct adapter annotations
+  easyuse_anima/prompt/artist_mix.py only for direct Prompt Data read annotations
+  easyuse_anima/aio/conditioning.py only for direct Prompt Data read annotations
+  easyuse_anima/aio/legacy_generation.py only for direct Prompt Data annotations
+  easyuse_anima/nodes/prompt_advanced_nodes.py only for direct builder/result annotations
+  easyuse_anima/nodes/prompt_data_nodes.py only for direct adapter annotations
+  easyuse_anima/nodes/aio_nodes.py only for direct Prompt Data copy/update annotations
 Allowed test/config files:
   tests/test_prompt_corrector.py
-  tests/test_prompt_studio_regional.py
   tests/test_aio_conditioning.py
+  tests/test_aio_legacy_generation.py
+  tests/test_aio_nodes.py
   tests/test_node_contracts.py
   tests/test_pyright_baseline.py
   tests/test_python_backend_analyzer.py
   tests/fixtures/python_backend_baseline.json only for generated analyzer evidence
   pyrightconfig.json and tests/fixtures/pyright_baseline.json only if the exact
   touched owners are strict-clean and are deliberately enrolled without new debt
-Forbidden changes: Prompt Data typing, input JSON/workflow migration behavior,
-  Advanced/Regional keys/order/defaults/values, prompt/mask construction,
-  wildcard/translation/NAIA/artist-mix behavior, node sockets/results,
-  root/canonical exports, broad Any cleanup, ignore additions, settings/error work
-Preserved invariants: Advanced and Regional default-field order, duplicate NAIA/
-  trigger normalization, Extend's omitted `pin`, unknown input-key tolerance,
-  saved/effective field separation, socket overrides, field identity and serialized
-  JSON, mask assignments, Prompt/AiO/artist-mix outputs, public identities
+Forbidden changes: Prompt Data schema/version or nested keys/order/defaults/values,
+  validation/migration policy, runtime conversion, field-family changes,
+  Prompt/AiO/artist-mix behavior, node sockets/results, root/canonical exports,
+  broad Any cleanup, ignore additions, settings/error work
+Preserved invariants: `str | dict | None` and malformed JSON acceptance, unknown-key
+  preservation, outputs-before-top-level-before-legacy-fallback read precedence,
+  copy-on-update nested ownership, override alias writes, JSON-safe snapshots,
+  exact canonical builder dictionaries, Prompt/AiO/artist-mix outputs, monkeypatch
+  seams, node/public identities
 Focused tests and purpose:
-  tests.test_prompt_corrector.PromptBuilderTests — Advanced normalization, field inputs,
-    translation, wildcard, NAIA, prompt construction, and serialized outputs stay exact
-  tests.test_prompt_studio_regional — Regional normalization, mask fields, wildcard,
-    translation, and serialized outputs stay exact
-  tests.test_aio_conditioning.AIOConditioningMoveTests — AiO consumes the same fields
-  tests.test_node_contracts.PromptAdvancedMoveContractTests and RegionalMoveContractTests
-    — owner/signature/identity stay exact
+  tests.test_prompt_corrector.PromptBuilderTests — canonical output, fallbacks,
+    overrides, fields, wildcard, NAIA, artist mix, and serialization stay exact
+  tests.test_aio_conditioning.AIOConditioningMoveTests — AiO reads the same Prompt Data
+  tests.test_aio_legacy_generation.AIOGeneratorLegacyMoveTests — generation reads and
+    dispatch remain exact
+  tests.test_aio_nodes.AIONodeContractTests — input-context copies preserve shape
+  tests.test_node_contracts.PromptDataConditioningMoveContractTests and
+    PromptAdvancedMoveContractTests — owner/signature/identity stay exact
   tests.test_pyright_baseline plus the current quality gate — no new baseline or strict debt
 Promotion gates: changed-file syntax/static, focused tests, import boundary,
   git diff --check, official full once on the final test/config candidate; no package/live
-Stop conditions: a runtime field conversion, Prompt Data schema change, public export,
-  root-shim change, behavior change, ignore, or a field owner outside this fixed family
-  is required
+Stop conditions: a schema migration, runtime dictionary conversion, public export,
+  root-shim change, behavior change, broad AiO refactor, ignore, or rejection of an
+  accepted legacy/future input is required
 Next task: re-audit the Prompt row and select only its next smallest remaining finding;
   do not start G-04A while any Phase F follow-up row remains
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02b Prompt field-family typed contract;
+   - first READY task: Issue #563 / F-02c canonical Prompt Data typed read/output contract;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -54,7 +54,9 @@ COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 PARKED    D-14 / Phase H root removal
 COMPLETE  #563 F-02a Autocomplete typed result contracts
-READY     #563 F-02b Prompt field-family typed contract
+COMPLETE  #563 F-02b Prompt field-family typed contract
+COMPLETE  #563 affected Prompt-row re-audit
+READY     #563 F-02c canonical Prompt Data typed read/output contract
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
@@ -69,27 +71,26 @@ The D-14 stop is correct:
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02b source map
+## Active F-02c source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-typed-boundary-f01-audit.md  # F-02b task card
+docs/architecture/python-typed-boundary-f01-audit.md  # F-02c task card
 Issue #563 latest checkpoint
-easyuse_anima/prompt/advanced.py, prompt/regional.py, and direct typed consumers
-direct Advanced/Regional Prompt Studio, AiO conditioning, node-owner, Pyright,
-and import fixtures
+easyuse_anima/prompt/contracts.py, prompt/data.py, prompt/advanced.py
+direct Prompt Data unpack/conditioning, AiO consumer, Pyright, and import fixtures
 ```
 
-F-02b adds the internal PromptField/AdvancedField/RegionalField structural family
-without changing runtime dictionaries, JSON/workflow migration, field order/defaults,
-Prompt/AiO/wildcard/translation/artist-mix behavior, Regional mask assignments, node
-results, or public exports. Preserve Extend's omitted `pin`; do not expand into Prompt
-Data, settings, or error-taxonomy work.
+F-02c types the canonical Prompt Data builder result and feature-side read mapping
+without converting runtime dictionaries or rejecting legacy/future workflow keys. It
+must preserve schema/version, exact nested values and order, fallback precedence,
+copy-on-update/override behavior, Prompt/AiO/artist-mix outputs, node identities, and
+public exports. Do not expand into settings migration or error-taxonomy work.
 
 ## Following queue
 
-After F-02b:
+After F-02c:
 
 1. re-audit the affected Prompt row;
 2. execute the next smallest F-02 while any Phase F finding remains;


### PR DESCRIPTION
## 목적과 변경 경계

Issue #563 / F-02b 병합 후 Prompt/Wildcard/Autocomplete row를 production 변경 없이 다시 감사합니다.

- Base: `4cf0c82ee459d37e67fa0b8d7b80cd162e111658`
- Head: `de80ede8b832849acf701c7f145d796f5e5bdfec`
- F-02b Prompt field family를 complete로 분류
- legacy/future Prompt Data JSON 입력은 workflow/node adapter의 intentional raw boundary로 분류
- canonical Prompt Data 생성 결과와 feature-side read mapping의 `dict[str, Any]` 누출만 exact F-02c로 선정
- settings migration과 common error taxonomy는 별도 later row로 유지
- G-04A / Issue #188은 계속 blocked

Production, test, tool, fixture 변경은 없습니다.

## 변경 문서

- `docs/architecture/python-typed-boundary-f01-audit.md`
- `docs/architecture/post-phase-e-maintenance-roadmap.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

## 검증

- PromptBuilderTests: 64 passed
- AIOConditioningMoveTests: 6 passed
- PromptDataConditioningMoveContractTests: 5 passed
- Pyright baseline owners: 11 passed
- PythonBackendAnalyzerTests: 18 passed
- CompletedPackageImportBoundaryTests: 6 passed
- `git diff --check`: passed

문서 전용 변경이며 test/tool/fixture/production 변경이 없으므로 새 official full은 실행하지 않았습니다. PR #569 final SHA의 official full(Python 1,438 tests, frontend 120 files, Pyright/import/diff)을 재사용합니다. Package/live는 미실행입니다.

## 다음 READY task

F-02c canonical Prompt Data typed read/output contract:

- 내부 canonical output/nested TypedDict와 feature-side read mapping
- Advanced v2 builder → Prompt Data helpers → 직접 Prompt/AiO/artist-mix consumers
- runtime dictionary, schema/version, nested order/value, fallback precedence, copy/update, legacy/future input acceptance, identity/export 불변
- settings/error/root/release 작업 금지

## 위험과 rollback

문서가 실제 owner scope를 과대 분류할 위험을 줄이기 위해 direct builder/read/helper/caller와 기존 deterministic fixtures만 사용했습니다. production 영향은 없고, 필요하면 이 squash commit만 되돌릴 수 있습니다.