### PR TITLE
docs: complete F-02c typed-boundary re-audit

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02c canonical Prompt Data typed read/output contract.
+  / F-02d settings typed migration contract.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -32,8 +32,10 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE affected-row re-audit
   -> COMPLETE F-02b Prompt field-family typed contract
   -> COMPLETE affected Prompt-row re-audit
-  -> READY F-02c canonical Prompt Data typed read/output contract
-  -> re-audit the affected Prompt row
+  -> COMPLETE F-02c canonical Prompt Data typed read/output contract
+  -> COMPLETE affected Prompt-row re-audit
+  -> READY F-02d settings typed migration contract
+  -> re-audit the affected settings row
   -> next smallest F-02 while a finding remains
   -> G-04A public API snapshot coverage audit
   -> optional G-04B gap

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02c canonical Prompt Data typed read/output contract.
+- Active first task: Issue #563 / F-02d settings typed migration contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -69,8 +69,10 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE affected-row re-audit
   -> COMPLETE F-02b Prompt field-family typed contract         #563 / PR #569
   -> COMPLETE affected Prompt-row re-audit
-  -> READY F-02c canonical Prompt Data typed read/output       #563
-  -> RE-AUDIT affected Prompt row
+  -> COMPLETE F-02c canonical Prompt Data typed read/output    #563 / PR #571
+  -> COMPLETE affected Prompt-row re-audit
+  -> READY F-02d settings typed migration contract             #563
+  -> RE-AUDIT affected settings row
   -> F-02      next smallest targeted gap while one remains
   -> G-04A    public API snapshot coverage audit              #188
   -> OPTIONAL G-04B  minimal missing public-surface gate
@@ -138,19 +140,20 @@ Exit:
 - gap: execute only the smallest F-02, re-audit the affected row, then select the
   next smallest remaining finding or start G-04A when Phase F closes.
 
-Audit result, updated after F-02b merged at
-`4cf0c82ee459d37e67fa0b8d7b80cd162e111658`:
+Audit result, updated after F-02c merged at
+`789c29075f6a0651bd2da5c9abe6d0619e7cf8b7`:
 
 - [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md)
   records the production-free six-area inventory and reuses the existing
   deterministic fixtures;
-- Autocomplete and Wildcard are complete after F-02a; the Prompt field family is
-  complete after F-02b;
+- Autocomplete and Wildcard are complete after F-02a; the Prompt field family and
+  canonical Prompt Data are complete after F-02b/F-02c;
 - legacy/future Prompt Data JSON remains intentionally raw only at the workflow and
   node adapter boundary;
-- only the smallest remaining Prompt leak, F-02c canonical Prompt Data typed
-  read/output contract, is selected as the next task card;
-- settings migration and common error taxonomy remain separate findings;
+- the Prompt/Wildcard/Autocomplete row is complete;
+- only the smaller remaining Phase F finding, F-02d settings typed migration contract,
+  is selected as the next task card;
+- common error taxonomy remains a separate later finding;
 - G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
 
 ## 4. G-04A — Public API snapshot coverage audit
@@ -366,37 +369,38 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #563 / F-02c only from latest origin/dev after the F-02b affected Prompt-row
-re-audit merges.
+Start Issue #563 / F-02d only from latest origin/dev after the F-02c affected Prompt-row
+completion re-audit merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document's F-01 result and validation sections
-- python-typed-boundary-f01-audit.md F-02c task card
+- python-typed-boundary-f01-audit.md F-02d task card
 - Issue #563 latest checkpoint
-- direct Prompt Data/Advanced/AiO/artist-mix owner source/tests and current
+- direct settings schema/repository/service/API owner source/tests and current
   Pyright/import fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Define internal canonical Prompt Data output and nested TypedDicts plus a typed
-feature-side read mapping. Apply them from the Advanced v2 builder through Prompt Data
-helpers and direct Prompt/AiO/artist-mix consumers without changing runtime
-dictionaries, schema/version, nested key order/values, fallback precedence,
-copy-on-update behavior, input/workflow acceptance, identities, or public exports.
-Keep legacy and future JSON raw only at the adapter boundary. Reuse direct Prompt Data,
-AiO conditioning/generation, node-owner, Pyright, and import tests; update only a direct
-generated analyzer baseline if the canonical type surface requires it.
+Define typed normalized ordinary/long-text settings values and versioned v1 persisted
+documents. Add pure detection/migration from accepted v0 raw mappings to v1 and apply
+the contract through repository/service/API adapters without changing public payloads,
+defaults, aliases, Comfy overlay precedence, first-run autocomplete initialization,
+atomic locking, file-I/O dispatch, identities, or root exports. Preserve raw v0
+settings reads and raw/v1 long-text reads. Reuse direct settings, settings/long-text
+API, Pyright, analyzer, and import tests; add no new fixture unless current deterministic
+tests cannot express the migration contract.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run official full once on the final production/test/tool SHA.
 Package/live are not triggered.
 
-Push a dev-targeted Draft PR. After review and merge, re-audit the Prompt row and
-execute only its next smallest F-02 while a finding remains; otherwise continue the
-remaining Phase F rows before #188 G-04A.
+Push a dev-targeted Draft PR. After review and merge, re-audit the settings row and
+execute only its smallest residual if one remains; otherwise select common feature
+error taxonomy before #188 G-04A.
 
-Do not remove root files, add deprecation warnings/telemetry, publish a release, or
-perform Registry work.
+Do not change profile/workflow/AiO migrations or common error taxonomy. Do not remove
+root files, add deprecation warnings/telemetry, publish a release, or perform Registry
+work.
 ```

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -3,14 +3,14 @@
 ## Status
 
 - Owner: Issue #563
-- Base: `4cf0c82ee459d37e67fa0b8d7b80cd162e111658`
+- Base: `789c29075f6a0651bd2da5c9abe6d0619e7cf8b7`
 - Class: Contract/gate
 - Production changes: none
 - Result: Phase F remains open; G-04A is not READY
 
 This audit reuses the current Pyright, import-boundary, API, profile, workflow,
 Autocomplete, Wildcard, and AiO schema/migration evidence. The Prompt/Wildcard/
-Autocomplete row was re-audited after F-02b merged as PR #569. It adds no second
+Autocomplete row was re-audited after F-02c merged as PR #571. It adds no second
 machine-readable inventory because the current deterministic fixtures and direct
 owner tests can express every finding below.
 
@@ -20,7 +20,7 @@ owner tests can express every finding below.
 | --- | --- | --- | --- |
 | Settings, profile, and workflow schema/migration | Profile v2 identity/revision and pure read migration are owned by `easyuse_anima/profiles/contract.py`; the strict Pyright owner is fixed by `tests/fixtures/pyright_baseline.json`. Settings persistence/projection is owned by `easyuse_anima/settings/schema.py`, `repository.py`, and `service.py`. Read-only ComfyUI workflow lookup is owned by `easyuse_anima/workflow.py`. Direct evidence is in `tests/test_profile_contract.py`, `tests/test_lora_profiles.py`, `tests/test_aio_profiles.py`, `tests/test_api_contract.py`, and `tests/test_node_contracts.py`. | Profile payload mappings preserve legacy and future fields at the persisted JSON migration boundary. `_get_workflow_node` accepts dynamic host `extra_pnginfo` and returns a raw workflow node only at the ComfyUI adapter boundary. | **exact F-02 follow-up required.** Profile and workflow boundaries are complete or intentional, but ordinary settings have no version detection, pure migration sequence, or typed post-normalization model. Long-text settings write a v1 envelope, yet their normalized value and the settings service still cross feature code as unparameterized dictionaries. |
 | API request/result/error | `easyuse_anima/api/requests.py` validates JSON-object bodies and produces typed scalar fields; `easyuse_anima/api/errors.py` owns `ApiContractError`; `easyuse_anima/api/responses.py` owns the stable error envelope and request correlation. `tests/test_api_contract_compatibility.py` and the direct route classes in `tests/test_api_contract.py` freeze the behavior. | Request bodies and success/error dictionaries exist at the JSON serialization adapter. Profile and settings sub-objects remain mappings only while they are validated or handed to their persisted-schema boundary. | **intentional adapter/migration boundary.** Malformed/body/schema/conflict/not-found mappings and request-id correlation are typed or tested before feature calls; raw response dictionaries do not become feature-service state. |
-| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. `easyuse_anima/prompt/contracts.py` now owns the shared `PromptField`, `AdvancedField`, and `RegionalField` family used by Prompt, Regional, AiO-conditioning, wildcard, translation, and artist-mix consumers. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are owned by `easyuse_anima/autocomplete/contracts.py`. Direct evidence is in `tests/test_prompt_corrector.py`, `tests/test_prompt_studio_regional.py`, `tests/test_aio_conditioning.py`, `tests/test_wildcards.py`, `tests/test_autocomplete_service.py`, and the existing runtime fixtures. | Prompt Data JSON accepts old layouts, malformed nested values, and future keys at the workflow/node adapter boundary. The legacy Extend adapter intentionally omits optional `pin`, and legacy Regional fallback may omit optional `pin`/`collapsed`; Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **exact F-02 follow-up required.** Wildcard, Autocomplete, core ANIMA correction results, and the Prompt field family are complete. Canonical Prompt Data is still built as `dict[str, Any]`, normalized to `dict[str, Any]`, and read across Prompt/AiO/artist-mix feature code through untyped nested/output mappings. F-02c must type the canonical builder result and feature-side read mapping while leaving legacy/future JSON acceptance at the adapter boundary. |
+| Prompt, Wildcard, and Autocomplete | Prompt correction owns `TagInfo`, `TagToken`, `ParsedPrompt`, and `CorrectionResult` in `easyuse_anima/prompt/anima/models.py`. `easyuse_anima/prompt/contracts.py` owns the `PromptField` family plus canonical `PromptData` nested/output contracts and the feature-side `PromptDataRead` mapping. Wildcard owns `WildcardOption`, `WildcardExpansionBudget`, and `WildcardExpansionResult` in `easyuse_anima/wildcard/models.py`. Autocomplete source/status/search/classification payloads are owned by `easyuse_anima/autocomplete/contracts.py`. Direct evidence is in the Prompt, Regional, AiO-conditioning, Wildcard, Autocomplete, Pyright, and analyzer owner tests. | Prompt Data JSON accepts old layouts, malformed nested values, and future keys at the workflow/node adapter boundary. The legacy Extend adapter intentionally omits optional `pin`, and legacy Regional fallback may omit optional `pin`/`collapsed`; Wildcard and Autocomplete payload dictionaries are serialized by API adapters after typed feature results. | **complete.** F-02a through F-02c type the Autocomplete results, shared Prompt field family, canonical Prompt Data output, and feature-side read mapping. Raw workflow/node JSON stays at the intentional adapter/migration boundary and no untyped Prompt feature-state leak remains. |
 | AiO config/request/state/result | `AIOGenerationConfig` and its section dataclasses are owned by `easyuse_anima/aio/generation_settings.py` and adjacent strict generation modules. `GenerationRequest`, `GenerationState`, and `GenerationStage` are owned by `easyuse_anima/aio/generation_pipeline.py`; version detection and pure v1-to-v4 migration are owned by `generation_migrations.py`. Evidence is in the v1-v4 schema/surface fixtures and `tests/test_aio_schema_contract.py`, `tests/test_aio_generation_settings.py`, and `tests/test_aio_generation_migrations.py`. | `Mapping[str, object]` is retained only for JSON freeze/thaw, unknown-field preservation, host capability maps, prompt/workflow context, and final ComfyUI result serialization. Tensor/model values remain `object` at host boundaries. | **complete.** Normalized settings enter the generation pipeline as a typed config and typed request/state objects; strict per-file Pyright directives cover the generation contract modules. |
 | Node adapter raw input/output conversion | `easyuse_anima/nodes/aio_nodes.py`, `prompt_nodes.py`, and `wildcard_nodes.py` convert ComfyUI inputs into the typed AiO, Prompt, and Wildcard owners before feature work. `tests/test_node_contracts.py` and the 0.5.2 node/workflow fixtures freeze the public socket and result shapes. | Dynamic ComfyUI objects, tensor/model values, workflow metadata, input dictionaries, UI dictionaries, and output tuples are host adapter values. | **intentional adapter/migration boundary.** Their dynamic shape is not feature-service typing debt and no broad `Any` removal is justified. |
 | Common feature error taxonomy and adapter mappings | Existing concrete errors include `ProfileContractError`, `ProfileMutationError`, `InvalidProfileDataError`, `AutocompleteIndexUnavailable`, `KnowledgeBaseNotFound`, `AIOGenerationMigrationError`, and API-only `ApiContractError`. Their current behavior is covered by profile, Autocomplete, AiO migration, and API tests. | `ApiContractError` is allowed to carry HTTP status/code because it is an API request-adapter error. Node adapters may translate feature errors to the existing host-visible `RuntimeError` or UI status at the final adapter. | **exact F-02 follow-up required.** The documented `EasyUseAnimaError` category hierarchy does not exist, feature errors have no shared category base, and `ProfileMutationError` currently owns HTTP status alongside feature conflict meaning. Category-to-API/node mapping is therefore not a common tested contract. |
@@ -71,68 +71,69 @@ triggered. The shared Prompt field family now crosses Advanced, Regional, AiO,
 wildcard, translation, and artist-mix consumers without changing runtime
 dictionaries. The legacy optional-key forms remain intentional workflow adapters.
 
-## Selected next task: F-02c
+## F-02c completion re-audit
 
-Only the remaining canonical Prompt Data leak is selected now. Settings migration
-and common error taxonomy remain separate findings and are not silently combined
-into this task.
+F-02c merged as PR #571 at `789c29075f6a0651bd2da5c9abe6d0619e7cf8b7`.
+Its final candidate passed 1,439 Python tests, 120-file frontend validation,
+Pyright/import-boundary checks, and `git diff --check`; package/live were not
+triggered. Canonical Prompt Data builders and feature-side reads now use the shared
+typed contracts. Legacy, future, and malformed workflow/node JSON remains raw only at
+the intentional adapter boundary. The Prompt/Wildcard/Autocomplete row is therefore
+**complete**.
+
+## Selected next task: F-02d
+
+Settings typed migration is the smaller of the two remaining Phase F findings. Common
+feature error taxonomy remains separate and is not silently combined into this task.
 
 ```text
-Task ID: F-02c canonical Prompt Data typed read/output contract
+Task ID: F-02d settings typed migration contract
 Owner Issue: #563
-Primary class: CONTRACT
+Primary class: CONTRACT + MIGRATION
 Base SHA: latest origin/dev after this completion re-audit merges
-Goal: define internal canonical Prompt Data output and nested TypedDicts plus a typed
-      feature-side read mapping; apply them from the Advanced v2 builder through
-      Prompt Data helpers and direct Prompt/AiO/artist-mix consumers without changing
-      a runtime dictionary, rejecting legacy/future keys, or treating adapter input as
-      already canonical.
-Prerequisites: merged F-02b and this affected Prompt-row completion re-audit
+Goal: define typed normalized ordinary/long-text settings values and versioned v1
+      persisted documents; add pure detection/migration from accepted v0 raw mappings
+      to v1; apply the contract through repository/service/API adapters while
+      preserving the existing public payloads.
+Prerequisites: merged F-02c and this affected Prompt-row completion re-audit
 Allowed production files:
-  easyuse_anima/prompt/contracts.py
-  easyuse_anima/prompt/data.py
-  easyuse_anima/prompt/advanced.py
-  easyuse_anima/prompt/artist_mix.py only for direct Prompt Data read annotations
-  easyuse_anima/aio/conditioning.py only for direct Prompt Data read annotations
-  easyuse_anima/aio/legacy_generation.py only for direct Prompt Data annotations
-  easyuse_anima/nodes/prompt_advanced_nodes.py only for direct builder/result annotations
-  easyuse_anima/nodes/prompt_data_nodes.py only for direct adapter annotations
-  easyuse_anima/nodes/aio_nodes.py only for direct Prompt Data copy/update annotations
+  easyuse_anima/settings/schema.py
+  easyuse_anima/settings/repository.py
+  easyuse_anima/settings/service.py
+  easyuse_anima/api/routes/settings.py only for direct result annotations
+  easyuse_anima/api/routes/long_text_settings.py only for direct result annotations
 Allowed test/config files:
-  tests/test_prompt_corrector.py
-  tests/test_aio_conditioning.py
-  tests/test_aio_legacy_generation.py
-  tests/test_aio_nodes.py
-  tests/test_node_contracts.py
+  tests/test_prompt_corrector.py only SettingsTests
+  tests/test_api_contract.py only ApiSettingsRouteTests and
+    ApiLongTextSettingsRouteTests
   tests/test_pyright_baseline.py
   tests/test_python_backend_analyzer.py
   tests/fixtures/python_backend_baseline.json only for generated analyzer evidence
   pyrightconfig.json and tests/fixtures/pyright_baseline.json only if the exact
-  touched owners are strict-clean and are deliberately enrolled without new debt
-Forbidden changes: Prompt Data schema/version or nested keys/order/defaults/values,
-  validation/migration policy, runtime conversion, field-family changes,
-  Prompt/AiO/artist-mix behavior, node sockets/results, root/canonical exports,
-  broad Any cleanup, ignore additions, settings/error work
-Preserved invariants: `str | dict | None` and malformed JSON acceptance, unknown-key
-  preservation, outputs-before-top-level-before-legacy-fallback read precedence,
-  copy-on-update nested ownership, override alias writes, JSON-safe snapshots,
-  exact canonical builder dictionaries, Prompt/AiO/artist-mix outputs, monkeypatch
-  seams, node/public identities
+    touched owners are strict-clean and deliberately enrolled without new debt
+  no new schema fixture unless the current deterministic tests cannot express the
+    migration contract
+Forbidden changes: public settings/API shapes, accepted keys/defaults, resolver
+  semantics, profile/workflow/AiO migrations, common error taxonomy, root exports,
+  broad Any cleanup, ignore additions
+Preserved invariants: raw v0 settings and raw/v1 long-text reads; invalid/non-object/
+  OSError fallback behavior; alias normalization and current unknown-key behavior;
+  Comfy overlay precedence, colors, locale, and autocomplete first-run behavior;
+  sorted long-text write order; atomic locking/concurrent updates; root aliases and
+  route handler identity
 Focused tests and purpose:
-  tests.test_prompt_corrector.PromptBuilderTests — canonical output, fallbacks,
-    overrides, fields, wildcard, NAIA, artist mix, and serialization stay exact
-  tests.test_aio_conditioning.AIOConditioningMoveTests — AiO reads the same Prompt Data
-  tests.test_aio_legacy_generation.AIOGeneratorLegacyMoveTests — generation reads and
-    dispatch remain exact
-  tests.test_aio_nodes.AIONodeContractTests — input-context copies preserve shape
-  tests.test_node_contracts.PromptDataConditioningMoveContractTests and
-    PromptAdvancedMoveContractTests — owner/signature/identity stay exact
-  tests.test_pyright_baseline plus the current quality gate — no new baseline or strict debt
+  tests.test_prompt_corrector.SettingsTests — defaults, legacy reads, migration,
+    aliases, overlays, initialization, and atomic writes remain exact
+  tests.test_api_contract.ApiSettingsRouteTests — settings API payload/error/identity
+  tests.test_api_contract.ApiLongTextSettingsRouteTests — long-text payload/order/error
+  tests.test_pyright_baseline plus the current quality gate — no new debt
+  tests.test_python_backend_analyzer and import-boundary owners — dependency surface
 Promotion gates: changed-file syntax/static, focused tests, import boundary,
-  git diff --check, official full once on the final test/config candidate; no package/live
-Stop conditions: a schema migration, runtime dictionary conversion, public export,
-  root-shim change, behavior change, broad AiO refactor, ignore, or rejection of an
-  accepted legacy/future input is required
-Next task: re-audit the Prompt row and select only its next smallest remaining finding;
-  do not start G-04A while any Phase F follow-up row remains
+  git diff --check, official full once on the final production/test/tool SHA;
+  no package/live
+Stop conditions: a public/API payload change, incompatible persisted-data rewrite,
+  import-time I/O, lock/order change, root export, or profile/workflow/error-taxonomy
+  change is required
+Next task: re-audit the settings row; if complete, select common feature error taxonomy,
+  otherwise select only the smallest residual; G-04A remains blocked
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02c canonical Prompt Data typed read/output contract;
+   - first READY task: Issue #563 / F-02d settings typed migration contract;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -55,8 +55,9 @@ COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 PARKED    D-14 / Phase H root removal
 COMPLETE  #563 F-02a Autocomplete typed result contracts
 COMPLETE  #563 F-02b Prompt field-family typed contract
+COMPLETE  #563 F-02c canonical Prompt Data typed read/output contract
 COMPLETE  #563 affected Prompt-row re-audit
-READY     #563 F-02c canonical Prompt Data typed read/output contract
+READY     #563 F-02d settings typed migration contract
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
@@ -71,28 +72,28 @@ The D-14 stop is correct:
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02c source map
+## Active F-02d source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-typed-boundary-f01-audit.md  # F-02c task card
+docs/architecture/python-typed-boundary-f01-audit.md  # F-02d task card
 Issue #563 latest checkpoint
-easyuse_anima/prompt/contracts.py, prompt/data.py, prompt/advanced.py
-direct Prompt Data unpack/conditioning, AiO consumer, Pyright, and import fixtures
+easyuse_anima/settings/schema.py, repository.py, service.py
+direct SettingsTests, settings/long-text API routes, Pyright, and import fixtures
 ```
 
-F-02c types the canonical Prompt Data builder result and feature-side read mapping
-without converting runtime dictionaries or rejecting legacy/future workflow keys. It
-must preserve schema/version, exact nested values and order, fallback precedence,
-copy-on-update/override behavior, Prompt/AiO/artist-mix outputs, node identities, and
-public exports. Do not expand into settings migration or error-taxonomy work.
+F-02d gives ordinary and long-text settings one typed normalized model and one pure
+v0/raw-to-v1 persisted-document migration. It preserves existing defaults, aliases,
+Comfy overlay precedence, first-run autocomplete initialization, atomic locking,
+public/API payloads, and root identities. Do not expand into profile/workflow migration
+or common error-taxonomy work.
 
 ## Following queue
 
-After F-02c:
+After F-02d:
 
-1. re-audit the affected Prompt row;
+1. re-audit the affected settings row;
 2. execute the next smallest F-02 while any Phase F finding remains;
 3. only after Phase F closes, run #188 G-04A against existing
    compatibility/node/API/package fixtures;


### PR DESCRIPTION
## 목적과 변경 경계

F-02c 병합 후 Prompt/Wildcard/Autocomplete typed-boundary 행을 production 변경 없이 재감사하고, 남은 두 finding 중 더 작은 F-02d settings typed migration을 다음 READY task로 고정합니다.

- Base: `789c29075f6a0651bd2da5c9abe6d0619e7cf8b7`
- Head: `d616de1`
- Production 변경: 없음
- Ref: #563

## 주요 변경

- F-02c PR #571과 최종 검증 증거를 completion audit에 반영
- Prompt/Wildcard/Autocomplete 행을 `complete`로 분류
- raw legacy/future/malformed Prompt Data JSON은 workflow/node adapter 경계로 유지
- F-02d settings typed migration의 허용 파일, 보존 계약, focused gate, stop condition 고정
- roadmap/development index의 READY 순서를 F-02d로 전환

## 검증

- `PromptBuilderTests`: 65 passed
- Wildcard runtime contract: 10 passed
- Autocomplete runtime contract: 12 passed
- Pyright baseline: 11 passed
- backend analyzer: 18 passed
- import boundary: 16 passed
- `git diff --check`: passed
- official full: PR #571 final SHA의 1,439 Python / 120 frontend 성공 증거 재사용
- package/live: 미실행(트리거 없음)

## 위험과 rollback

문서 및 queue checkpoint만 변경하므로 runtime 위험은 없습니다. 되돌릴 경우 이 PR의 squash commit만 revert하면 됩니다.

## Next

병합 후 최신 `origin/dev`에서 F-02d settings typed migration을 수행하고, 이어서 settings 행만 재감사합니다. Common error taxonomy, G-04A, root shim, release/Registry는 아직 시작하지 않습니다.