### PR TITLE
feat: add typed settings persistence migration

### DIFF
--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -104,6 +104,7 @@ Allowed production files:
   easyuse_anima/api/routes/long_text_settings.py only for direct result annotations
 Allowed test/config files:
   tests/test_prompt_corrector.py only SettingsTests
+  tests/test_autocomplete_locale_settings.py only persisted initialization shape
   tests/test_api_contract.py only ApiSettingsRouteTests and
     ApiLongTextSettingsRouteTests
   tests/test_pyright_baseline.py

--- a/easyuse_anima/api/routes/long_text_settings.py
+++ b/easyuse_anima/api/routes/long_text_settings.py
@@ -9,14 +9,14 @@ def build_long_text_settings_payloads(
 ):
     """Build long-text payload helpers with runtime-resolved dependencies."""
 
-    def _get_long_text_settings_payload_sync() -> dict:
+    def _get_long_text_settings_payload_sync() -> dict[str, object]:
         return {
             "status": "ok",
             "values": load_long_text_settings(),
             "settings": public_settings(),
         }
 
-    def _save_long_text_settings_payload_sync(values: dict) -> dict:
+    def _save_long_text_settings_payload_sync(values: dict) -> dict[str, object]:
         return {
             "status": "ok",
             "values": save_long_text_settings(values),

--- a/easyuse_anima/api/routes/settings.py
+++ b/easyuse_anima/api/routes/settings.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 def build_settings_payloads(*, public_settings, save_setting):
     """Build settings payload helpers with runtime-resolved dependencies."""
 
-    def _get_settings_payload_sync() -> dict:
+    def _get_settings_payload_sync() -> dict[str, object]:
         return public_settings()
 
-    def _save_setting_payload_sync(key: str, value) -> dict:
+    def _save_setting_payload_sync(key: str, value) -> dict[str, object]:
         save_setting(key, value)
         return {"status": "ok", **public_settings()}
 

--- a/easyuse_anima/settings/repository.py
+++ b/easyuse_anima/settings/repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -20,6 +20,8 @@ from .schema import (
     DEFAULT_SETTINGS,
     LONG_TEXT_SETTING_ALIASES,
     LONG_TEXT_SETTING_KEYS,
+    _SettingsDocumentV1,
+    _SettingsValues,
 )
 
 SETTINGS_FILE = USER_DATA_DIR / "settings.json"
@@ -53,20 +55,57 @@ def _current_settings_repository() -> _SettingsRepository:
     )
 
 
-def _read_json_file(path: Path) -> dict:
+def _read_json_file(path: Path) -> dict[str, object]:
     repository = _current_settings_repository()
     try:
         data = repository.store(path).read(default={})
     except (OSError, json.JSONDecodeError):
         return {}
-    return data if isinstance(data, dict) else {}
+    return cast(dict[str, object], data) if isinstance(data, dict) else {}
 
 
-def _normalize_long_text_settings(data: dict) -> dict:
+def _detect_settings_document_version(data: object) -> int:
+    if not isinstance(data, dict):
+        return 0
+    return (
+        1
+        if data.get("version") == 1 and isinstance(data.get("values"), dict)
+        else 0
+    )
+
+
+def _settings_document(values: Mapping[str, object]) -> _SettingsDocumentV1:
+    return {"version": 1, "values": dict(values)}
+
+
+def _migrate_settings_document(data: object) -> _SettingsDocumentV1:
+    if not isinstance(data, dict):
+        return _settings_document({})
+    if _detect_settings_document_version(data) == 1:
+        values = cast(dict[str, object], data["values"])
+    else:
+        values = cast(dict[str, object], data)
+    return _settings_document(values)
+
+
+def _normalize_settings_values(data: object) -> _SettingsValues:
+    if not isinstance(data, dict):
+        return {}
+    normalized: _SettingsValues = {}
+    for key in DEFAULT_SETTINGS:
+        if key in data:
+            value = data[key]
+            normalized[key] = "" if value is None else str(value)
+    return normalized
+
+
+def _normalize_long_text_settings(data: object) -> _SettingsValues:
+    if not isinstance(data, dict):
+        return {}
     values = data.get("values", data)
     if not isinstance(values, dict):
         return {}
-    normalized = {}
+    normalized: _SettingsValues = {}
     for key, value in values.items():
         internal_key = LONG_TEXT_SETTING_ALIASES.get(str(key), str(key))
         if internal_key in LONG_TEXT_SETTING_KEYS:
@@ -74,32 +113,34 @@ def _normalize_long_text_settings(data: dict) -> dict:
     return normalized
 
 
-def load_long_text_settings() -> dict:
+def _migrate_long_text_settings_document(data: object) -> _SettingsDocumentV1:
+    return _settings_document(_normalize_long_text_settings(data))
+
+
+def load_long_text_settings() -> _SettingsValues:
     repository = _current_settings_repository()
-    return _normalize_long_text_settings(
+    document = _migrate_long_text_settings_document(
         _read_json_file(repository.long_text_settings_file)
     )
+    return cast(_SettingsValues, document["values"])
 
 
-def save_long_text_settings(values: dict) -> dict:
+def save_long_text_settings(values: object) -> _SettingsValues:
     repository = _current_settings_repository()
     if not isinstance(values, dict):
         values = {}
     updates = _normalize_long_text_settings(values)
-    saved: dict = {}
+    saved: _SettingsValues = {}
 
-    def merge(current) -> dict:
-        settings = _normalize_long_text_settings(
-            current if isinstance(current, dict) else {}
-        )
+    def merge(current: object) -> _SettingsDocumentV1:
+        settings = _normalize_long_text_settings(current)
         settings.update(updates)
         saved.update(settings)
-        return {
-            "version": 1,
-            "values": {
+        return _settings_document(
+            {
                 key: settings.get(key, "") for key in sorted(LONG_TEXT_SETTING_KEYS)
-            },
-        }
+            }
+        )
 
     repository.store(repository.long_text_settings_file).update(
         merge,
@@ -130,7 +171,7 @@ def _comfy_settings_candidates() -> list[Path]:
     return candidates
 
 
-def _load_comfy_settings() -> dict:
+def _load_comfy_settings() -> dict[str, object]:
     for path in _comfy_settings_candidates():
         data = _read_json_file(path)
         if data:
@@ -138,7 +179,7 @@ def _load_comfy_settings() -> dict:
     return {}
 
 
-def _is_korean_locale(value) -> bool:
+def _is_korean_locale(value: object) -> bool:
     locale = str(value or "").strip().casefold()
     return (
         locale == "ko"
@@ -148,13 +189,16 @@ def _is_korean_locale(value) -> bool:
     )
 
 
-def _initial_autocomplete_source(comfy_settings: dict) -> str:
+def _initial_autocomplete_source(comfy_settings: Mapping[str, object]) -> str:
     if _is_korean_locale(comfy_settings.get(_COMFY_LOCALE_KEY)):
         return _KOREAN_AUTOCOMPLETE_SOURCE
     return DEFAULT_SETTINGS[_AUTOCOMPLETE_SOURCE_KEY]
 
 
-def _initialize_autocomplete_source(data: dict, comfy_settings: dict) -> dict:
+def _initialize_autocomplete_source(
+    data: _SettingsValues,
+    comfy_settings: Mapping[str, object],
+) -> _SettingsValues:
     if (
         _AUTOCOMPLETE_SOURCE_KEY in data
         or _COMFY_AUTOCOMPLETE_SOURCE_KEY in comfy_settings
@@ -165,14 +209,12 @@ def _initialize_autocomplete_source(data: dict, comfy_settings: dict) -> dict:
     initialized = dict(data)
     initialized[_AUTOCOMPLETE_SOURCE_KEY] = source
 
-    def merge(current) -> dict:
-        if not isinstance(current, dict):
-            return initialized
-        if _AUTOCOMPLETE_SOURCE_KEY in current:
-            return current
-        current = dict(current)
-        current[_AUTOCOMPLETE_SOURCE_KEY] = source
-        return current
+    def merge(current: object) -> _SettingsDocumentV1:
+        document = _migrate_settings_document(current)
+        current_values = document["values"]
+        if _AUTOCOMPLETE_SOURCE_KEY not in current_values:
+            current_values[_AUTOCOMPLETE_SOURCE_KEY] = source
+        return document
 
     repository = _current_settings_repository()
     try:
@@ -183,10 +225,11 @@ def _initialize_autocomplete_source(data: dict, comfy_settings: dict) -> dict:
         )
     except OSError:
         return initialized
-    return persisted if isinstance(persisted, dict) else initialized
+    document = _migrate_settings_document(persisted)
+    return _normalize_settings_values(document["values"])
 
 
-def _stringify_setting_value(value) -> str:
+def _stringify_setting_value(value: object) -> str:
     if value is None:
         return ""
     if isinstance(value, bool):
@@ -195,13 +238,13 @@ def _stringify_setting_value(value) -> str:
 
 
 def _apply_prompt_studio_color_settings(
-    settings: dict,
-    comfy_settings: dict,
+    settings: _SettingsValues,
+    comfy_settings: Mapping[str, object],
 ) -> None:
     if "EasyUseAnima.Prompt.HighlightColors" in comfy_settings:
         return
 
-    colors = {}
+    colors: dict[str, str] = {}
     current = settings.get("prompt_studio.colors", "")
     if current:
         try:
@@ -225,9 +268,9 @@ def _apply_prompt_studio_color_settings(
 
 
 def _apply_comfy_settings(
-    settings: dict,
-    comfy_settings: dict | None = None,
-) -> dict:
+    settings: _SettingsValues,
+    comfy_settings: Mapping[str, object] | None = None,
+) -> _SettingsValues:
     comfy_settings = (
         _load_comfy_settings()
         if comfy_settings is None
@@ -242,27 +285,27 @@ def _apply_comfy_settings(
     return settings
 
 
-def _apply_long_text_settings(settings: dict) -> dict:
+def _apply_long_text_settings(settings: _SettingsValues) -> _SettingsValues:
     settings.update(load_long_text_settings())
     return settings
 
 
-def get_settings() -> dict:
+def get_settings() -> _SettingsValues:
     repository = _current_settings_repository()
-    data = _read_json_file(repository.settings_file)
+    document = _migrate_settings_document(
+        _read_json_file(repository.settings_file)
+    )
+    data = _normalize_settings_values(document["values"])
     comfy_settings = _load_comfy_settings()
     data = _initialize_autocomplete_source(data, comfy_settings)
-    settings = dict(DEFAULT_SETTINGS)
-    for key in DEFAULT_SETTINGS:
-        if key in data:
-            value = data[key]
-            settings[key] = "" if value is None else str(value)
+    settings: _SettingsValues = dict(DEFAULT_SETTINGS)
+    settings.update(data)
     return _apply_long_text_settings(
         _apply_comfy_settings(settings, comfy_settings)
     )
 
 
-def save_setting(key: str, value) -> dict:
+def save_setting(key: str, value: object) -> _SettingsValues:
     if key not in DEFAULT_SETTINGS:
         raise KeyError(f"Unknown setting: {key}")
     repository = _current_settings_repository()
@@ -270,7 +313,7 @@ def save_setting(key: str, value) -> dict:
     with store.locked():
         settings = get_settings()
         settings[key] = _stringify_setting_value(value)
-        store.write(settings, trailing_newline=True)
+        store.write(_settings_document(settings), trailing_newline=True)
     return settings
 
 

--- a/easyuse_anima/settings/repository.py
+++ b/easyuse_anima/settings/repository.py
@@ -67,9 +67,12 @@ def _read_json_file(path: Path) -> dict[str, object]:
 def _detect_settings_document_version(data: object) -> int:
     if not isinstance(data, dict):
         return 0
+    version = data.get("version")
     return (
         1
-        if data.get("version") == 1 and isinstance(data.get("values"), dict)
+        if type(version) is int
+        and version == 1
+        and isinstance(data.get("values"), dict)
         else 0
     )
 

--- a/easyuse_anima/settings/schema.py
+++ b/easyuse_anima/settings/schema.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Literal, TypeAlias, TypedDict
+
 from ..translation.contracts import (
     DEFAULT_PROMPT_TRANSLATION_SOURCE,
     DEFAULT_PROMPT_TRANSLATION_TARGET,
     PROMPT_TRANSLATION_PROVIDER_OFF,
 )
 
-DEFAULT_SETTINGS = {
+_SettingsValues: TypeAlias = dict[str, str]
+_SettingsRead: TypeAlias = Mapping[str, str]
+
+
+class _SettingsDocumentV1(TypedDict):
+    version: Literal[1]
+    values: dict[str, object]
+
+
+DEFAULT_SETTINGS: _SettingsValues = {
     "prompt.metadata_filter_words": "",
     "autocomplete.source": "dbr_danbooru_2025_09_01",
     "autocomplete.limit": "20",
@@ -68,29 +80,29 @@ DEFAULT_SETTINGS = {
     "naia.tag_implication_compression": "skip",
 }
 
-AUTOCOMPLETE_MODES = {
+AUTOCOMPLETE_MODES: set[str] = {
     "off",
     "easyuse_nodes",
     "compatible_global",
 }
 
-AUTOCOMPLETE_COMMIT_KEYS = {
+AUTOCOMPLETE_COMMIT_KEYS: set[str] = {
     "enter",
     "tab",
 }
 
-AUTOCOMPLETE_COMMIT_MODES = {
+AUTOCOMPLETE_COMMIT_MODES: set[str] = {
     "smart",
     "insert",
     "replace",
 }
 
-NAIA_RESOLUTION_MODES = {
+NAIA_RESOLUTION_MODES: set[str] = {
     "scale",
     "bucket",
 }
 
-NAIA_RESOLUTION_BUCKETS = {
+NAIA_RESOLUTION_BUCKETS: set[str] = {
     "512",
     "768",
     "896",
@@ -99,7 +111,7 @@ NAIA_RESOLUTION_BUCKETS = {
     "1536",
 }
 
-NAIA_PREPROCESSING_KEYS = [
+NAIA_PREPROCESSING_KEYS: list[str] = [
     "remove_author",
     "remove_work_title",
     "remove_character_name",
@@ -117,7 +129,7 @@ NAIA_PREPROCESSING_KEYS = [
     "tag_implication_compression",
 ]
 
-PROMPT_STUDIO_COLOR_KEYS = [
+PROMPT_STUDIO_COLOR_KEYS: list[str] = [
     "quality",
     "safety",
     "year",
@@ -135,7 +147,7 @@ PROMPT_STUDIO_COLOR_KEYS = [
     "unknown",
 ]
 
-COMFY_SETTING_KEYS = {
+COMFY_SETTING_KEYS: dict[str, str] = {
     "EasyUseAnima.Prompt.MetadataFilter": "prompt.metadata_filter_words",
     "EasyUseAnima.Prompt.AutocompleteSource": "autocomplete.source",
     "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
@@ -186,19 +198,19 @@ COMFY_SETTING_KEYS = {
     },
 }
 
-COMFY_COLOR_SETTING_KEYS = {
+COMFY_COLOR_SETTING_KEYS: dict[str, str] = {
     f"EasyUseAnima.Prompt.HighlightColor.{key}": key
     for key in PROMPT_STUDIO_COLOR_KEYS
 }
 
-LONG_TEXT_SETTING_KEYS = {
+LONG_TEXT_SETTING_KEYS: set[str] = {
     "prompt.metadata_filter_words",
     "naia.pre_prompt",
     "naia.post_prompt",
     "naia.auto_hide",
 }
 
-LONG_TEXT_SETTING_ALIASES = {
+LONG_TEXT_SETTING_ALIASES: dict[str, str] = {
     "metadata_filter": "prompt.metadata_filter_words",
     "metadataFilter": "prompt.metadata_filter_words",
     "EasyUseAnima.Prompt.MetadataFilter": "prompt.metadata_filter_words",

--- a/easyuse_anima/settings/service.py
+++ b/easyuse_anima/settings/service.py
@@ -18,10 +18,14 @@ from .schema import (
     NAIA_PREPROCESSING_KEYS,
     NAIA_RESOLUTION_BUCKETS,
     NAIA_RESOLUTION_MODES,
+    _SettingsRead,
 )
 
+_PublicSettingsValue = str | int | float
+_PublicSettings = dict[str, _PublicSettingsValue]
 
-def public_settings() -> dict:
+
+def public_settings() -> _PublicSettings:
     settings = get_settings()
     return {
         "prompt.metadata_filter_words": settings.get(
@@ -155,7 +159,7 @@ def resolve_autocomplete_source() -> str:
     )
 
 
-def resolve_autocomplete_limit(settings: dict | None = None) -> int:
+def resolve_autocomplete_limit(settings: _SettingsRead | None = None) -> int:
     settings = settings or get_settings()
     try:
         value = int(
@@ -169,7 +173,7 @@ def resolve_autocomplete_limit(settings: dict | None = None) -> int:
     return max(1, min(100, value))
 
 
-def resolve_autocomplete_mode(settings: dict | None = None) -> str:
+def resolve_autocomplete_mode(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get("autocomplete.mode", DEFAULT_SETTINGS["autocomplete.mode"])
@@ -180,7 +184,9 @@ def resolve_autocomplete_mode(settings: dict | None = None) -> str:
     return DEFAULT_SETTINGS["autocomplete.mode"]
 
 
-def _resolve_autocomplete_artist_prefix(settings: dict | None = None) -> str:
+def _resolve_autocomplete_artist_prefix(
+    settings: _SettingsRead | None = None,
+) -> str:
     settings = settings or get_settings()
     default = DEFAULT_SETTINGS["autocomplete.artist_prefix"]
     value = str(settings.get("autocomplete.artist_prefix", default) or "").strip()
@@ -194,7 +200,7 @@ def _resolve_autocomplete_artist_prefix(settings: dict | None = None) -> str:
     return value
 
 
-def resolve_autocomplete_commit_key(settings: dict | None = None) -> str:
+def resolve_autocomplete_commit_key(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get(
@@ -208,7 +214,7 @@ def resolve_autocomplete_commit_key(settings: dict | None = None) -> str:
     return DEFAULT_SETTINGS["autocomplete.commit_key"]
 
 
-def resolve_autocomplete_commit_mode(settings: dict | None = None) -> str:
+def resolve_autocomplete_commit_mode(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get(
@@ -223,7 +229,7 @@ def resolve_autocomplete_commit_mode(settings: dict | None = None) -> str:
 
 
 def _resolve_lora_preset_strength_step(
-    settings: dict,
+    settings: _SettingsRead,
     key: str,
     max_value: float,
 ) -> float:
@@ -235,7 +241,7 @@ def _resolve_lora_preset_strength_step(
 
 
 def resolve_lora_preset_strength_button_step(
-    settings: dict | None = None,
+    settings: _SettingsRead | None = None,
 ) -> float:
     settings = settings or get_settings()
     return _resolve_lora_preset_strength_step(
@@ -246,7 +252,7 @@ def resolve_lora_preset_strength_button_step(
 
 
 def resolve_lora_preset_strength_drag_step(
-    settings: dict | None = None,
+    settings: _SettingsRead | None = None,
 ) -> float:
     settings = settings or get_settings()
     return _resolve_lora_preset_strength_step(
@@ -257,7 +263,7 @@ def resolve_lora_preset_strength_drag_step(
 
 
 def resolve_lora_preset_strength_drag_pixels(
-    settings: dict | None = None,
+    settings: _SettingsRead | None = None,
 ) -> int:
     settings = settings or get_settings()
     try:
@@ -274,7 +280,7 @@ def resolve_lora_preset_strength_drag_pixels(
     return max(1, min(100, value))
 
 
-def resolve_lora_preset_menu_mode(settings: dict | None = None) -> str:
+def resolve_lora_preset_menu_mode(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get(
@@ -288,7 +294,9 @@ def resolve_lora_preset_menu_mode(settings: dict | None = None) -> str:
     return DEFAULT_SETTINGS["lora_preset.menu_mode"]
 
 
-def resolve_prompt_studio_font_family(settings: dict | None = None) -> str:
+def resolve_prompt_studio_font_family(
+    settings: _SettingsRead | None = None,
+) -> str:
     settings = settings or get_settings()
     value = str(settings.get("prompt_studio.font_family", "") or "")
     for token in (";", "{", "}", "\r", "\n"):
@@ -296,7 +304,7 @@ def resolve_prompt_studio_font_family(settings: dict | None = None) -> str:
     return value.strip()[:160]
 
 
-def resolve_prompt_studio_font_size(settings: dict | None = None) -> int:
+def resolve_prompt_studio_font_size(settings: _SettingsRead | None = None) -> int:
     settings = settings or get_settings()
     try:
         value = int(
@@ -312,7 +320,9 @@ def resolve_prompt_studio_font_size(settings: dict | None = None) -> int:
     return max(8, min(24, value))
 
 
-def resolve_prompt_translation_provider(settings: dict | None = None) -> str:
+def resolve_prompt_translation_provider(
+    settings: _SettingsRead | None = None,
+) -> str:
     settings = settings or get_settings()
     return normalize_prompt_translation_provider(
         settings.get(
@@ -322,7 +332,9 @@ def resolve_prompt_translation_provider(settings: dict | None = None) -> str:
     )
 
 
-def resolve_prompt_translation_source(settings: dict | None = None) -> str:
+def resolve_prompt_translation_source(
+    settings: _SettingsRead | None = None,
+) -> str:
     settings = settings or get_settings()
     return normalize_prompt_translation_language(
         settings.get(
@@ -333,7 +345,9 @@ def resolve_prompt_translation_source(settings: dict | None = None) -> str:
     )
 
 
-def resolve_prompt_translation_target(settings: dict | None = None) -> str:
+def resolve_prompt_translation_target(
+    settings: _SettingsRead | None = None,
+) -> str:
     settings = settings or get_settings()
     return normalize_prompt_translation_language(
         settings.get(
@@ -345,7 +359,7 @@ def resolve_prompt_translation_target(settings: dict | None = None) -> str:
 
 
 def resolve_prompt_translation_settings(
-    settings: dict | None = None,
+    settings: _SettingsRead | None = None,
 ) -> PromptTranslationSettings:
     settings = settings or get_settings()
     return PromptTranslationSettings(
@@ -355,7 +369,7 @@ def resolve_prompt_translation_settings(
     )
 
 
-def _resolve_settings_bool(settings: dict, key: str) -> bool:
+def _resolve_settings_bool(settings: _SettingsRead, key: str) -> bool:
     return str(settings.get(key, DEFAULT_SETTINGS[key])).strip().lower() in {
         "true",
         "1",
@@ -365,7 +379,7 @@ def _resolve_settings_bool(settings: dict, key: str) -> bool:
     }
 
 
-def resolve_naia_port(settings: dict | None = None) -> int:
+def resolve_naia_port(settings: _SettingsRead | None = None) -> int:
     settings = settings or get_settings()
     try:
         value = int(settings.get("naia.port", DEFAULT_SETTINGS["naia.port"]))
@@ -374,7 +388,7 @@ def resolve_naia_port(settings: dict | None = None) -> int:
     return max(1, min(65535, value))
 
 
-def resolve_naia_resolution_mode(settings: dict | None = None) -> str:
+def resolve_naia_resolution_mode(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get(
@@ -390,7 +404,7 @@ def resolve_naia_resolution_mode(settings: dict | None = None) -> str:
     return DEFAULT_SETTINGS["naia.resolution_mode"]
 
 
-def resolve_naia_resolution_bucket(settings: dict | None = None) -> str:
+def resolve_naia_resolution_bucket(settings: _SettingsRead | None = None) -> str:
     settings = settings or get_settings()
     value = str(
         settings.get(
@@ -406,7 +420,7 @@ def resolve_naia_resolution_bucket(settings: dict | None = None) -> str:
     )
 
 
-def resolve_naia_resolution_scale(settings: dict | None = None) -> float:
+def resolve_naia_resolution_scale(settings: _SettingsRead | None = None) -> float:
     settings = settings or get_settings()
     try:
         value = float(
@@ -421,7 +435,7 @@ def resolve_naia_resolution_scale(settings: dict | None = None) -> float:
 
 
 def resolve_naia_resolution_max_long_edge(
-    settings: dict | None = None,
+    settings: _SettingsRead | None = None,
 ) -> int:
     settings = settings or get_settings()
     try:
@@ -443,7 +457,7 @@ def resolve_naia_resolution_max_long_edge(
 def resolve_naia_settings() -> dict:
     settings = get_settings()
     use_naia_settings = _resolve_settings_bool(settings, "naia.use_naia_settings")
-    preprocessing = {}
+    preprocessing: dict[str, str] = {}
     for key in NAIA_PREPROCESSING_KEYS:
         value = settings.get(
             f"naia.{key}",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -32717,6 +32717,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/repository.py"
+      },
+      {
+        "alias": null,
         "bound_name": "dataclass",
         "branch_context": [],
         "classification": "external",
@@ -32912,6 +32929,42 @@
       },
       {
         "alias": null,
+        "bound_name": "_SettingsDocumentV1",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".schema:_SettingsDocumentV1",
+        "kind": "static_from",
+        "line": 17,
+        "name": "_SettingsDocumentV1",
+        "optional": false,
+        "requested": ".schema",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/repository.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_SettingsValues",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".schema:_SettingsValues",
+        "kind": "static_from",
+        "line": 17,
+        "name": "_SettingsValues",
+        "optional": false,
+        "requested": ".schema",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/repository.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
         "bound_name": "folder_paths",
         "branch_context": [
           {
@@ -32919,7 +32972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 114
+            "line": 155
           }
         ],
         "classification": "external",
@@ -32927,7 +32980,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 115,
+        "line": 156,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -32954,6 +33007,74 @@
       },
       {
         "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Literal",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Literal",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Literal",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypedDict",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypedDict",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypedDict",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
         "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "branch_context": [],
         "classification": "internal",
@@ -32961,7 +33082,7 @@
         "conditional": false,
         "imported": "..translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
-        "line": 5,
+        "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "optional": false,
         "requested": "..translation.contracts",
@@ -32979,7 +33100,7 @@
         "conditional": false,
         "imported": "..translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
-        "line": 5,
+        "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
         "optional": false,
         "requested": "..translation.contracts",
@@ -32997,7 +33118,7 @@
         "conditional": false,
         "imported": "..translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
-        "line": 5,
+        "line": 8,
         "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
         "optional": false,
         "requested": "..translation.contracts",
@@ -33250,6 +33371,24 @@
         "kind": "static_from",
         "line": 13,
         "name": "NAIA_RESOLUTION_MODES",
+        "optional": false,
+        "requested": ".schema",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/service.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_SettingsRead",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".schema:_SettingsRead",
+        "kind": "static_from",
+        "line": 13,
+        "name": "_SettingsRead",
         "optional": false,
         "requested": ".schema",
         "role": "ordinary",
@@ -70370,7 +70509,7 @@
         "is_package": false,
         "loc": 63,
         "module": "easyuse_anima.api.routes.long_text_settings",
-        "normalized_git_blob_sha1": "26e85ca17eed3e39798eca30e11b13c156a0cb4a",
+        "normalized_git_blob_sha1": "6243033451ff6a532b1ee0f4d2825b268c87f6a1",
         "path": "easyuse_anima/api/routes/long_text_settings.py",
         "top_level": {
           "class_count": 0,
@@ -70454,7 +70593,7 @@
         "is_package": false,
         "loc": 55,
         "module": "easyuse_anima.api.routes.settings",
-        "normalized_git_blob_sha1": "6b3b68f8929056619472d02cadf4889688526b91",
+        "normalized_git_blob_sha1": "86d3953f2f78ba58bfad7cdfa9f9ec398f0c3504",
         "path": "easyuse_anima/api/routes/settings.py",
         "top_level": {
           "class_count": 0,
@@ -71436,38 +71575,38 @@
       },
       {
         "is_package": false,
-        "loc": 284,
+        "loc": 327,
         "module": "easyuse_anima.settings.repository",
-        "normalized_git_blob_sha1": "25044507a6d2eea4a73efa84af152556e207d756",
+        "normalized_git_blob_sha1": "8b0fbfb069972afc24d90299e23e86bf123b3c50",
         "path": "easyuse_anima/settings/repository.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 16,
+          "function_count": 21,
           "global_count": 7
         }
       },
       {
         "is_package": false,
-        "loc": 230,
+        "loc": 242,
         "module": "easyuse_anima.settings.schema",
-        "normalized_git_blob_sha1": "1a0a9046f9e6c1d7dd79b594854b6b899c7d1278",
+        "normalized_git_blob_sha1": "ae54460b69f504937f22fee99c2149685ed0562d",
         "path": "easyuse_anima/settings/schema.py",
         "top_level": {
-          "class_count": 0,
+          "class_count": 1,
           "function_count": 0,
-          "global_count": 13
+          "global_count": 15
         }
       },
       {
         "is_package": false,
-        "loc": 494,
+        "loc": 508,
         "module": "easyuse_anima.settings.service",
-        "normalized_git_blob_sha1": "19963faaba9203febba90cad7c71d06b3341c8c7",
+        "normalized_git_blob_sha1": "203b71739e0a951dd08f3442fdb3904bc24e6935",
         "path": "easyuse_anima/settings/service.py",
         "top_level": {
           "class_count": 0,
           "function_count": 26,
-          "global_count": 1
+          "global_count": 3
         }
       },
       {
@@ -90514,6 +90653,17 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/settings/repository.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 8,
@@ -90550,14 +90700,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 114
+            "line": 155
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 115,
+        "line": 156,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"
@@ -90569,6 +90719,50 @@
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Literal",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypedDict",
+        "kind": "static_from",
+        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/settings/schema.py"
@@ -92431,14 +92625,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 114
+            "line": 155
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 115,
+        "line": 156,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"
@@ -94675,7 +94869,7 @@
         "column": 1,
         "context": "decorator:_SettingsRepository",
         "kind": "import_time_call",
-        "line": 33,
+        "line": 35,
         "module": "easyuse_anima/settings/repository.py",
         "scope": "<module>"
       },
@@ -95201,67 +95395,67 @@
       },
       {
         "kind": "set",
-        "line": 77,
+        "line": 89,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_COMMIT_KEYS"
       },
       {
         "kind": "set",
-        "line": 82,
+        "line": 94,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_COMMIT_MODES"
       },
       {
         "kind": "set",
-        "line": 71,
+        "line": 83,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_MODES"
       },
       {
         "kind": "dict",
-        "line": 138,
+        "line": 150,
         "module": "easyuse_anima/settings/schema.py",
         "name": "COMFY_SETTING_KEYS"
       },
       {
         "kind": "dict",
-        "line": 11,
+        "line": 23,
         "module": "easyuse_anima/settings/schema.py",
         "name": "DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 201,
+        "line": 213,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_ALIASES"
       },
       {
         "kind": "set",
-        "line": 194,
+        "line": 206,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_KEYS"
       },
       {
         "kind": "list",
-        "line": 102,
+        "line": 114,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_PREPROCESSING_KEYS"
       },
       {
         "kind": "set",
-        "line": 93,
+        "line": 105,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_BUCKETS"
       },
       {
         "kind": "set",
-        "line": 88,
+        "line": 100,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_MODES"
       },
       {
         "kind": "list",
-        "line": 120,
+        "line": 132,
         "module": "easyuse_anima/settings/schema.py",
         "name": "PROMPT_STUDIO_COLOR_KEYS"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -32972,7 +32972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 155
+            "line": 158
           }
         ],
         "classification": "external",
@@ -32980,7 +32980,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 156,
+        "line": 159,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -71575,9 +71575,9 @@
       },
       {
         "is_package": false,
-        "loc": 327,
+        "loc": 330,
         "module": "easyuse_anima.settings.repository",
-        "normalized_git_blob_sha1": "8b0fbfb069972afc24d90299e23e86bf123b3c50",
+        "normalized_git_blob_sha1": "d991f7fded7cc686644ad6b17919dd56a853d30b",
         "path": "easyuse_anima/settings/repository.py",
         "top_level": {
           "class_count": 1,
@@ -90700,14 +90700,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 155
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 156,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"
@@ -92625,14 +92625,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 155
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 156,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"

--- a/tests/test_autocomplete_locale_settings.py
+++ b/tests/test_autocomplete_locale_settings.py
@@ -58,7 +58,10 @@ class AutocompleteLocaleSettingsTests(unittest.TestCase):
         self.assertEqual(settings["autocomplete.source"], DANBOORU_SOURCE)
         self.assertEqual(
             json.loads(settings_file.read_text(encoding="utf-8")),
-            {"autocomplete.source": DANBOORU_SOURCE},
+            {
+                "version": 1,
+                "values": {"autocomplete.source": DANBOORU_SOURCE},
+            },
         )
 
         cases = (
@@ -81,7 +84,10 @@ class AutocompleteLocaleSettingsTests(unittest.TestCase):
                 self.assertEqual(settings["autocomplete.source"], expected)
                 self.assertEqual(
                     persisted,
-                    {"autocomplete.source": expected},
+                    {
+                        "version": 1,
+                        "values": {"autocomplete.source": expected},
+                    },
                 )
 
     def test_explicit_internal_sources_are_preserved(self):
@@ -197,7 +203,10 @@ class AutocompleteLocaleSettingsTests(unittest.TestCase):
         self.assertEqual(second["autocomplete.source"], KOREAN_SOURCE)
         self.assertEqual(
             json.loads(settings_file.read_text(encoding="utf-8")),
-            {"autocomplete.source": KOREAN_SOURCE},
+            {
+                "version": 1,
+                "values": {"autocomplete.source": KOREAN_SOURCE},
+            },
         )
 
     def test_persistence_failure_keeps_locale_derived_runtime_value(self):

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3017,6 +3017,112 @@ class SettingsTests(unittest.TestCase):
             self.assertIs(store, store_factory.return_value)
             store_factory.assert_called_once_with(settings_file, backup=False)
 
+    def test_settings_document_migration_is_pure_and_versioned(self):
+        legacy = {
+            "autocomplete.source": "localsmile_kr_wiki",
+            "autocomplete.limit": 7,
+            "prompt_studio.font_family": None,
+            "autocomplete.append_separator": True,
+            "future.unknown": {"kept": True},
+        }
+        original = json.loads(json.dumps(legacy))
+
+        self.assertEqual(
+            settings_repository._detect_settings_document_version(legacy),
+            0,
+        )
+        migrated = settings_repository._migrate_settings_document(legacy)
+
+        self.assertEqual(legacy, original)
+        self.assertEqual(migrated, {"version": 1, "values": legacy})
+        self.assertIsNot(migrated["values"], legacy)
+        self.assertEqual(
+            settings_repository._detect_settings_document_version(migrated),
+            1,
+        )
+        self.assertEqual(
+            settings_repository._normalize_settings_values(migrated["values"]),
+            {
+                "autocomplete.source": "localsmile_kr_wiki",
+                "autocomplete.limit": "7",
+                "prompt_studio.font_family": "",
+                "autocomplete.append_separator": "True",
+            },
+        )
+        self.assertEqual(
+            settings_repository._migrate_settings_document(migrated),
+            migrated,
+        )
+
+    def test_get_settings_accepts_legacy_and_v1_documents_without_rewrite(self):
+        legacy = {
+            "autocomplete.source": "localsmile_kr_wiki",
+            "autocomplete.limit": 17,
+            "future.unknown": {"kept": True},
+        }
+        cases = (legacy, {"version": 1, "values": legacy})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            settings_file = root / "settings.json"
+            long_text_settings_file = root / "long_text_settings.json"
+            with (
+                patch.object(settings_repository, "SETTINGS_FILE", settings_file),
+                patch.object(
+                    settings_repository,
+                    "LONG_TEXT_SETTINGS_FILE",
+                    long_text_settings_file,
+                ),
+                patch.object(
+                    settings_repository,
+                    "_load_comfy_settings",
+                    return_value={},
+                ),
+            ):
+                for document in cases:
+                    with self.subTest(document=document):
+                        settings_file.write_text(
+                            json.dumps(document),
+                            encoding="utf-8",
+                        )
+                        settings = settings_repository.get_settings()
+
+                        self.assertEqual(
+                            settings["autocomplete.source"],
+                            "localsmile_kr_wiki",
+                        )
+                        self.assertEqual(settings["autocomplete.limit"], "17")
+                        self.assertEqual(
+                            json.loads(settings_file.read_text(encoding="utf-8")),
+                            document,
+                        )
+
+    def test_long_text_document_migration_accepts_raw_and_v1_aliases(self):
+        raw = {
+            "metadataFilter": "artist, copyright",
+            "naia.pre_prompt": None,
+            "future.unknown": {"ignored": True},
+        }
+        expected_values = {
+            "prompt.metadata_filter_words": "artist, copyright",
+            "naia.pre_prompt": "",
+        }
+
+        for document in (raw, {"version": 1, "values": raw}):
+            original = json.loads(json.dumps(document))
+            with self.subTest(document=document):
+                migrated = (
+                    settings_repository._migrate_long_text_settings_document(
+                        document
+                    )
+                )
+
+                self.assertEqual(document, original)
+                self.assertEqual(
+                    migrated,
+                    {"version": 1, "values": expected_values},
+                )
+
     def test_save_setting_round_trips_false_zero_empty_string_and_null(self):
         with tempfile.TemporaryDirectory() as tmp:
             settings_file = Path(tmp) / "settings.json"
@@ -3048,7 +3154,8 @@ class SettingsTests(unittest.TestCase):
                         reloaded = settings_repository.get_settings()
 
                         self.assertEqual(saved[key], expected)
-                        self.assertEqual(persisted[key], expected)
+                        self.assertEqual(persisted["version"], 1)
+                        self.assertEqual(persisted["values"][key], expected)
                         self.assertEqual(reloaded[key], expected)
 
     def test_parallel_save_setting_updates_do_not_lose_different_keys(self):
@@ -3121,8 +3228,12 @@ class SettingsTests(unittest.TestCase):
             self.assertFalse(second.is_alive())
             self.assertEqual(errors, [])
             persisted = json.loads(settings_file.read_text(encoding="utf-8"))
-            self.assertEqual(persisted["autocomplete.limit"], "33")
-            self.assertEqual(persisted["prompt_studio.font_family"], "Inter")
+            self.assertEqual(persisted["version"], 1)
+            self.assertEqual(persisted["values"]["autocomplete.limit"], "33")
+            self.assertEqual(
+                persisted["values"]["prompt_studio.font_family"],
+                "Inter",
+            )
         finally:
             release_first.set()
             shutil.rmtree(root, ignore_errors=True)
@@ -3199,6 +3310,7 @@ class SettingsTests(unittest.TestCase):
             self.assertFalse(second.is_alive())
             self.assertEqual(errors, [])
             persisted = json.loads(long_text_settings_file.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["version"], 1)
             self.assertEqual(persisted["values"]["prompt.metadata_filter_words"], "metadata")
             self.assertEqual(persisted["values"]["naia.pre_prompt"], "prefix")
         finally:

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3053,6 +3053,27 @@ class SettingsTests(unittest.TestCase):
             settings_repository._migrate_settings_document(migrated),
             migrated,
         )
+        for invalid_version in (True, 1.0, "1"):
+            with self.subTest(invalid_version=invalid_version):
+                invalid = {
+                    "version": invalid_version,
+                    "values": {"autocomplete.limit": 99},
+                }
+                self.assertEqual(
+                    settings_repository._detect_settings_document_version(
+                        invalid
+                    ),
+                    0,
+                )
+                invalid_document = (
+                    settings_repository._migrate_settings_document(invalid)
+                )
+                self.assertEqual(
+                    settings_repository._normalize_settings_values(
+                        invalid_document["values"]
+                    ),
+                    {},
+                )
 
     def test_get_settings_accepts_legacy_and_v1_documents_without_rewrite(self):
         legacy = {


### PR DESCRIPTION
## 목적과 변경 경계

Issue #563 / F-02d로 ordinary settings와 long-text settings의 내부 normalized value와 persisted document 계약을 타입으로 고정하고, 기존 v0 raw mapping을 읽는 pure migration을 추가합니다.

- Base: `471a8c732c40a3bd243a1ddb27ee804dede3e29c`
- Head: `ced8f03820961132d3a62179558c24901ab02891`
- Primary class: CONTRACT + MIGRATION
- Ref: #563

## 주요 변경

- 내부 settings read/value를 `Mapping[str, str]` / `dict[str, str]`로 고정
- persisted document를 `{"version": 1, "values": {...}}`로 타입화
- legacy flat ordinary settings와 raw/v1 long-text settings를 mutation 없이 읽는 migration 추가
- 정확한 정수 `1`만 v1으로 감지하고 boolean/float/string version은 기존 invalid fallback 유지
- 새 ordinary/long-text write와 first-run autocomplete source 초기화를 v1 envelope로 저장
- unknown key read/preservation, defaults, aliases, Comfy overlay 및 long-text precedence 유지
- public/API payload, route helper/handler identity, root `__all__`, lock/update 순서 유지
- 실제 source graph에서 analyzer baseline 재생성
- first-run persisted shape를 직접 소유하는 locale test를 task card 허용 범위에 명시

## 변경 파일

- `easyuse_anima/settings/schema.py`
- `easyuse_anima/settings/repository.py`
- `easyuse_anima/settings/service.py`
- settings / long-text API route annotations
- Settings 및 autocomplete locale direct tests
- analyzer generated baseline과 F-02d task card 보정

## 검증

Focused:

- SettingsTests: 29 passed
- AutocompleteLocaleSettingsTests: 7 passed
- ApiSettingsRouteTests: 8 passed
- ApiLongTextSettingsRouteTests: 5 passed
- Pyright baseline contract: 11 passed
- backend analyzer: 18 passed
- import boundary: 16 passed
- changed production Ruff: passed
- changed Python syntax: passed
- Python quality: Pyright 158 files / 기존 14 errors 무증가, import boundary passed
- `git diff --check`: passed

Promotion:

- official full, final SHA `ced8f03`에서 1회: Python 1,442 passed; frontend 120 files passed; Pyright/import/diff gates passed
- package/live: 미실행(패키지 closure와 host-visible behavior 변경 없음)

## 위험과 rollback

첫 write 후 settings 파일이 v1 envelope로 저장됩니다. 기존 flat settings와 raw/v1 long-text는 계속 읽으며, public/API 결과는 동일합니다. 문제가 있으면 이 PR의 squash commit을 revert하면 되고 기존 파일 backup은 AtomicJsonStore 정책대로 유지됩니다.

## Next

검토 후 squash merge하고 settings/profile/workflow 행만 production-free 재감사합니다. Settings 행이 complete이면 common feature error taxonomy를 다음 최소 F-02로 선택합니다. G-04A, root shim, release/Registry는 아직 시작하지 않습니다.