### PR TITLE
test: define feature error taxonomy contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02e common feature error taxonomy contract.
+  / F-02f common category inheritance.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -36,8 +36,10 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE affected Prompt-row re-audit
   -> COMPLETE F-02d settings typed migration contract
   -> COMPLETE affected settings/profile/workflow-row re-audit
-  -> READY F-02e common feature error taxonomy Contract
-  -> contract-selected implementation and affected-row re-audit
+  -> COMPLETE F-02e common feature error taxonomy Contract
+  -> READY F-02f canonical categories and feature inheritance
+  -> F-02g authoritative profile/translation API mappings
+  -> F-02h error-row and Phase F completion audit
   -> G-04A public API snapshot coverage audit
   -> optional G-04B gap
   -> Wildcard pure-shim feasibility Contract
@@ -77,6 +79,9 @@ of architectural success by itself.
 - [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md):
   current Phase F typed-boundary inventory, classifications, G-04A handoff surface,
   and the selected smallest F-02 task card.
+- [`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md):
+  executable error inventory, canonical categories, preserved compatibility, adapter
+  authority decision, and ordered F-02f/F-02g/F-02h task boundaries.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 and Phase E execution record plus post-Phase-E D-14 verdict.
 - [`python-backend.md`](python-backend.md): target ownership, phase definitions, and

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02e common feature error taxonomy contract.
+- Active first task: Issue #563 / F-02f common category inheritance.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -73,9 +73,10 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE affected Prompt-row re-audit
   -> COMPLETE F-02d settings typed migration contract          #563 / PR #573
   -> COMPLETE affected settings/profile/workflow row re-audit
-  -> READY F-02e common feature error taxonomy Contract        #563
-  -> IMPLEMENT only the contract-selected error cutover
-  -> RE-AUDIT affected error row and close Phase F
+  -> COMPLETE F-02e common feature error taxonomy Contract     #563
+  -> READY F-02f canonical categories and feature inheritance  #563
+  -> F-02g    authoritative profile/translation API mappings   #563
+  -> F-02h    affected error-row re-audit and Phase F close    #563
   -> G-04A    public API snapshot coverage audit              #188
   -> OPTIONAL G-04B  minimal missing public-surface gate
   -> P-WC-01  wildcard pure-shim feasibility Contract         #186
@@ -156,8 +157,9 @@ Audit result, updated after F-02d merged at
 - typed v1 ordinary/long-text settings persistence plus pure legacy/raw reads close
   the settings/profile/workflow row while profile future fields and raw host workflow
   lookup remain intentional migration/adapter boundaries;
-- common feature error taxonomy is the only remaining Phase F finding, and F-02e
-  starts with a production-free executable contract before implementation;
+- common feature error taxonomy is the only remaining Phase F finding; F-02e fixes
+  its production-free executable contract and selects ordered F-02f inheritance,
+  F-02g API mapping, and F-02h completion-audit slices;
 - G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
 
 ## 4. G-04A — Public API snapshot coverage audit
@@ -373,37 +375,36 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #563 / F-02e only from latest origin/dev after the F-02d affected
-settings/profile/workflow-row completion re-audit merges.
+Start Issue #563 / F-02f only from latest origin/dev after the F-02e taxonomy Contract
+merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document's F-01 result and validation sections
-- python-typed-boundary-f01-audit.md F-02e task card
+- python-feature-error-taxonomy-contract.md F-02f task card
+- python-typed-boundary-f01-audit.md F-02e decision
 - Issue #563 latest checkpoint
-- direct profile, Autocomplete, Prompt knowledge, AiO migration, translation, seed,
-  API/node error owners/tests and current Pyright/import/package fixtures
+- direct profile, Autocomplete, Prompt knowledge, AiO migration, translation, and seed
+  error owners/tests plus taxonomy, Pyright, import, package, and analyzer fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Create a production-free executable contract for the documented `EasyUseAnimaError`
-categories. Inventory every current feature error, preserve its concrete identity and
-built-in exception compatibility, and freeze exact API/node status, code, message,
-details, redaction, and request-correlation mappings. A new narrow machine-readable
-fixture is allowed because the hierarchy does not yet exist and current fixtures
-cannot express category completeness. Do not change production inheritance or error
-behavior in this task.
+Add `easyuse_anima/errors.py` with the seven documented categories and explicit module
+exports but no root export. Add category ancestry to every fixture-owned feature error
+in place while preserving its concrete class identity, feature-specific subclass
+graph, ValueError/RuntimeError/FileNotFoundError catches, constructor, attributes,
+messages, details, reason, export identity, and behavior. Do not perform the profile or
+translation API mapping cutover in this task.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
-Run official full once on the final test/tool SHA.
+Run official full once on the final production/test/tool SHA.
 Package/live are not triggered.
 
-Push a dev-targeted Draft PR. After review and merge, execute only the contract-selected
-cohesive cutover or smallest ordered slices, re-audit the error row, and mark Phase F
-complete before #188 G-04A.
+Push a dev-targeted Draft PR. After review and merge, run F-02g as a separate adapter
+cutover, then F-02h re-audits the error row and closes Phase F before #188 G-04A.
 
-Do not change profile/settings/workflow/AiO migration semantics, public/root exports,
-or API payloads. Do not remove root files, add deprecation warnings/telemetry, publish
-a release, or perform Registry work.
+Do not change profile/settings/workflow/AiO migration semantics, exception metadata,
+public/root exports, or API/node payloads. Do not remove root files, add deprecation
+warnings/telemetry, publish a release, or perform Registry work.
 ```

--- a/docs/architecture/python-feature-error-taxonomy-contract.md
+++ b/docs/architecture/python-feature-error-taxonomy-contract.md
@@ -1,0 +1,188 @@
+# Python Feature Error Taxonomy Contract
+
+## Status
+
+- Owner: Issue #563
+- Base: `e5e0329cd64afa9894d631f9b6baa6514a81ab48`
+- Task: F-02e
+- Class: Contract/gate
+- Production changes: none
+- Fixture: `tests/fixtures/python_feature_error_contract.v1.json`
+- Gate: `tests/test_python_feature_error_contract.py`
+
+This contract resolves the final Phase F finding without changing production
+inheritance, exceptions, API payloads, node behavior, or public exports. The fixture is
+the executable inventory; this document records the decisions and ordered
+implementation boundaries.
+
+## Canonical categories
+
+The canonical owner will be `easyuse_anima/errors.py` with one explicit module
+`__all__` and no root-package export:
+
+```text
+EasyUseAnimaError
+|-- ValidationError
+|-- ConflictError
+|-- NotFoundError
+|-- CapabilityUnavailableError
+|-- UpstreamTimeoutError
+`-- StorageError
+```
+
+The category classes contain no HTTP status, API code, JSON details, ComfyUI UI
+payload, or feature-specific default message. They are semantic catch categories.
+Concrete exceptions remain defined in their current feature modules so their class
+object, `__module__`, `__name__`, feature-specific subclass relation, constructor, and
+export identity do not move.
+
+F-02f adds category ancestry with compatibility-preserving multiple inheritance.
+Every existing `ValueError`, `RuntimeError`, or `FileNotFoundError` catch must continue
+to match. Category classes therefore do not replace built-in ancestry.
+
+## Current inventory and target category
+
+| Feature family | Current concrete errors | Target category | Adapter disposition |
+| --- | --- | --- | --- |
+| Profile schema/storage | `ProfileContractError`, `InvalidProfileDataError` | `ValidationError` | contract failures convert before the API; stored-data failures keep the exact 422 mapping |
+| Profile mutation | `ProfileMutationError`; precondition, identity, and revision subclasses | conflict base; precondition adds `ValidationError`; identity/revision add `ConflictError` | exact 428/409 mappings remain API-owned targets |
+| Autocomplete index | `AutocompleteIndexUnavailable` | `CapabilityUnavailableError` | still converts to existing typed fallback diagnostics, not HTTP |
+| Prompt knowledge compatibility | `KnowledgeBaseNotFound` | `NotFoundError` | remains a `FileNotFoundError`-compatible import surface |
+| AiO generation migration | `AIOGenerationMigrationError` | `ValidationError` | still propagates with the same migration messages |
+| Seed request/identity | `SeedReservationContractError`, `SeedExecutionIdentityError` | `ValidationError` | current node/queue propagation remains |
+| Seed service | service base, conflict, and capacity errors | root, `ConflictError`, and `CapabilityUnavailableError` | current reservation behavior and catches remain |
+| Translation limits | limit base and marker count/size/total errors | `ValidationError` | exact 413 codes/messages remain |
+| Translation availability | provider unavailable, timeout, and busy | capability, upstream-timeout, and conflict categories | exact 503/504 mappings remain |
+| Translation general | base, cancelled, and upstream errors | `EasyUseAnimaError` | exact 500/499/502 mappings remain |
+
+`StorageError` has no current concrete assignment. It remains part of the documented
+taxonomy for a future real storage error; F-02f must not reclassify invalid profile
+data or invent a new storage behavior merely to populate every category.
+
+`ApiContractError` remains an API request-adapter error and does not inherit the
+feature taxonomy. `_InvalidAutocompleteIndex` remains private repair control flow and
+does not cross a feature boundary.
+
+## HTTP mapping authority and compatibility
+
+Current profile and translation adapters read status/code/message metadata directly
+from feature exceptions. F-02g makes API mapping tables or equivalent injected
+adapter callbacks authoritative by exact exception kind and preserved MRO fallback.
+The externally observable response remains unchanged:
+
+```text
+status
+code
+message
+optional details
+request_id
+X-Request-ID
+```
+
+The existing feature exception metadata is retained as a passive compatibility mirror
+during the current support window. Production API adapters must no longer use that
+mirror after F-02g. This preserves existing direct Python consumers and root aliases
+without leaving HTTP policy authoritative in feature behavior. Removing a mirror is a
+later compatibility/removal decision, not Phase F work.
+
+Profile mutation mapping retains the dynamic root monkeypatch seam. Canonical
+precondition, identity, and revision errors use exact adapter mappings; a deliberately
+patched compatibility error type may continue through the existing injected fallback.
+No raw unexpected `ValueError` gains a new mapping, and current redaction/order rules
+remain fixed.
+
+Translation adapters continue to map only `PromptTranslationError` instances. Custom
+limit messages remain semantic instance messages, while status and code are selected
+by the adapter. Cancellation remains a stable 499 response and request cancellation
+outside that exception family remains unnormalized.
+
+## Ordered implementation
+
+### F-02f — Category inheritance
+
+One additive Contract implementation:
+
+- add `easyuse_anima/errors.py` with the seven category classes and explicit
+  `__all__`;
+- add category ancestry to every fixture-owned feature exception in place;
+- preserve current built-in catches, feature-specific subclass relations,
+  constructors, attributes, messages, details, reasons, and exports;
+- add no root export and change no API/node adapter behavior.
+
+### F-02g — Authoritative API adapter mapping
+
+One adapter cutover after F-02f:
+
+- make profile and translation API mappings authoritative outside feature behavior;
+- preserve exact status/code/message/details, request correlation, redaction, catch
+  order, and dynamic profile dependency seams;
+- retain current exception metadata as compatibility mirrors, but prove production
+  mappers do not read it;
+- do not change Autocomplete fallback, seed behavior, migration behavior, or node
+  payloads.
+
+### F-02h — Completion audit
+
+A production-free audit must reconcile every fixture-owned feature error, record zero
+unmapped errors, mark the common error row and Phase F complete, and transition Issue
+#188 to G-04A READY. Production corrections require a separate task instead of being
+hidden in the audit.
+
+## F-02f task card
+
+```text
+Task ID: F-02f common category inheritance
+Owner Issue: #563
+Primary class: CONTRACT
+Base SHA: latest origin/dev after F-02e merges
+Goal: add the canonical feature-error categories and additive category inheritance to
+      every fixture-owned concrete feature error without changing behavior or identity.
+Allowed production:
+  easyuse_anima/errors.py
+  easyuse_anima/profiles/contract.py
+  easyuse_anima/profiles/repository.py
+  easyuse_anima/profiles/mutation.py
+  easyuse_anima/autocomplete/index.py
+  easyuse_anima/prompt/anima/knowledge.py
+  easyuse_anima/aio/generation_migrations.py
+  easyuse_anima/translation/contracts.py
+  easyuse_anima/seed/reservation.py
+  easyuse_anima/seed/execution_identity.py
+  easyuse_anima/seed/service.py
+Allowed tests/config/docs:
+  tests/test_python_feature_error_contract.py
+  tests/fixtures/python_feature_error_contract.v1.json
+  direct profile/Autocomplete/Prompt/AiO/translation/seed error owners
+  tests/test_python_package_skeleton.py
+  tests/test_pyright_baseline.py
+  tests/test_python_backend_analyzer.py
+  tests/fixtures/python_backend_baseline.json only as generated analyzer evidence
+  import-boundary owners and current queue/audit docs
+Forbidden: API mapper authority cutover, exception metadata/constructor/message change,
+  public root export, behavior/migration/storage changes, broad error cleanup, Any
+  cleanup, ignore addition
+Preserve: concrete class module/name/object identity, feature-specific base graph,
+  ValueError/RuntimeError/FileNotFoundError catches, all current exports and root
+  aliases, profile/translation HTTP payloads, profile dynamic seam, Autocomplete
+  diagnostics, AiO messages, seed behavior
+Focused: new taxonomy contract; direct profile, translation, Autocomplete, AiO, seed,
+  Prompt compatibility owners; package skeleton; Pyright; analyzer; import boundary;
+  changed-file syntax/static; git diff --check
+Promotion: official full exactly once on final production/test/tool SHA; no package/live
+Stop: MRO conflict, public/root export change, concrete identity/catch change, API or
+  feature behavior change, or canonical-to-root import is required
+Next: F-02g adapter authority cutover only
+```
+
+## Validation and stop policy
+
+F-02e runs the new contract owner, direct profile and translation API owners, direct
+Autocomplete/AiO/seed/Prompt owners, package/import/analyzer/Pyright gates,
+`git diff --check`, and official full once on its final test/fixture SHA. Package/live
+are not triggered.
+
+No additional PRO review is required for the inheritance contract: the documented
+hierarchy, exact built-in catches, identity rules, and API compatibility policy select
+one additive design. Stop and request focused architecture review only if F-02f proves
+an actual MRO/identity conflict or F-02g cannot preserve both adapter authority and the
+dynamic profile seam.

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -95,7 +95,7 @@ locking, and root identities remain unchanged. Profile future-field preservation
 raw ComfyUI workflow lookup remain intentional migration/adapter boundaries. The
 settings/profile/workflow row is therefore **complete**.
 
-## Selected next task: F-02e
+## F-02e selected contract task
 
 Common feature error taxonomy is the only remaining Phase F finding. The first unit is
 a production-free executable Contract so the shared categories, built-in exception
@@ -151,3 +151,33 @@ Next task: one cohesive implementation if the contract proves one safe inheritan
   and adapter cutover; otherwise the smallest ordered implementation slices; then
   re-audit the error row and mark Phase F complete before G-04A
 ```
+
+## F-02e contract decision and selected next task
+
+F-02e fixes the production-free executable contract in
+[`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md)
+and `tests/fixtures/python_feature_error_contract.v1.json`. The inventory covers all
+24 current feature errors across profile, Autocomplete, Prompt knowledge, AiO
+migration, translation, and seed owners. `ApiContractError` remains API-only and the
+private `_InvalidAutocompleteIndex` remains internal repair control flow.
+
+The contract selects the documented seven-category hierarchy in
+`easyuse_anima/errors.py`, no root exports, in-place concrete classes, and additive
+multiple inheritance that preserves every current `ValueError`, `RuntimeError`, and
+`FileNotFoundError` catch. HTTP mappings become API-authoritative in a later adapter
+slice; current exception metadata remains a passive compatibility mirror rather than
+being removed during Phase F.
+
+The ordered implementation is:
+
+```text
+READY F-02f canonical categories and additive feature inheritance
+  -> F-02g authoritative profile/translation API mappings
+  -> F-02h production-free error-row and Phase F completion audit
+  -> G-04A
+```
+
+F-02f is the next task. Its complete task card is in
+`python-feature-error-taxonomy-contract.md`. It must not perform the F-02g adapter
+cutover, change any exception constructor/attribute/message, add a root export, or
+change feature/API/node behavior.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02e common feature error taxonomy contract;
+   - first READY task: Issue #563 / F-02f common category inheritance;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -23,6 +23,7 @@ Read only the sections needed by the active task.
 6. Read a topic guide only when the active task touches it:
    - completed D/E execution record: `../architecture/backend-roadmap-resume-0.6.2.md`
    - F-01 typed-boundary audit: `../architecture/python-typed-boundary-f01-audit.md`
+   - feature error taxonomy: `../architecture/python-feature-error-taxonomy-contract.md`
    - runtime base/state inventory: `../architecture/python-runtime-base-contract.md`,
      `../architecture/python-runtime-state-inventory.md`
    - repository/filesystem runtime contract: `../architecture/python-runtime-e03-repository-filesystem-contract.md`
@@ -59,7 +60,10 @@ COMPLETE  #563 F-02c canonical Prompt Data typed read/output contract
 COMPLETE  #563 affected Prompt-row re-audit
 COMPLETE  #563 F-02d settings typed migration contract
 COMPLETE  #563 affected settings/profile/workflow-row re-audit
-READY     #563 F-02e common feature error taxonomy contract
+COMPLETE  #563 F-02e common feature error taxonomy contract
+READY     #563 F-02f canonical categories and feature inheritance
+NEXT      #563 F-02g authoritative profile/translation API mappings
+NEXT      #563 F-02h error-row and Phase F completion audit
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
@@ -74,28 +78,28 @@ The D-14 stop is correct:
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02e source map
+## Active F-02f source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-typed-boundary-f01-audit.md  # F-02e task card
+docs/architecture/python-feature-error-taxonomy-contract.md  # F-02f task card
 Issue #563 latest checkpoint
 direct feature error owners under profiles, autocomplete, prompt, aio, translation, seed
-direct API/node error mappers plus Pyright, package, analyzer, and import fixtures
+taxonomy fixture/test plus Pyright, package, analyzer, and import fixtures
 ```
 
-F-02e first defines a production-free executable contract for the documented
-`EasyUseAnimaError` hierarchy. It classifies every current feature error and freezes
-built-in exception compatibility plus exact API/node mapping before any inheritance or
-HTTP-metadata change. Do not combine production implementation with this contract.
+F-02f adds the documented categories and category ancestry in place. Preserve each
+concrete class object/module/name, existing feature-specific inheritance, built-in
+catch compatibility, constructor, attributes, exports, and behavior. Do not combine
+the F-02g profile/translation API mapping cutover into this task.
 
 ## Following queue
 
-After F-02e Contract:
+After F-02f:
 
-1. execute only the contract-selected cohesive cutover or smallest ordered slices;
-2. re-audit the common error row and record Phase F completion;
+1. execute F-02g as the separate authoritative API adapter mapping cutover;
+2. run F-02h to re-audit the common error row and record Phase F completion;
 3. after Phase F closes, run #188 G-04A against existing
    compatibility/node/API/package fixtures;
 4. audit Wildcard and API pure-shim feasibility without deleting root modules;

--- a/tests/fixtures/python_feature_error_contract.v1.json
+++ b/tests/fixtures/python_feature_error_contract.v1.json
@@ -1,0 +1,681 @@
+{
+  "base_sha": "e5e0329cd64afa9894d631f9b6baa6514a81ab48",
+  "canonical_taxonomy": {
+    "categories": [
+      {
+        "name": "EasyUseAnimaError",
+        "parent": "Exception"
+      },
+      {
+        "name": "ValidationError",
+        "parent": "EasyUseAnimaError"
+      },
+      {
+        "name": "ConflictError",
+        "parent": "EasyUseAnimaError"
+      },
+      {
+        "name": "NotFoundError",
+        "parent": "EasyUseAnimaError"
+      },
+      {
+        "name": "CapabilityUnavailableError",
+        "parent": "EasyUseAnimaError"
+      },
+      {
+        "name": "UpstreamTimeoutError",
+        "parent": "EasyUseAnimaError"
+      },
+      {
+        "name": "StorageError",
+        "parent": "EasyUseAnimaError"
+      }
+    ],
+    "module": "easyuse_anima/errors.py",
+    "module_exports": [
+      "EasyUseAnimaError",
+      "ValidationError",
+      "ConflictError",
+      "NotFoundError",
+      "CapabilityUnavailableError",
+      "UpstreamTimeoutError",
+      "StorageError"
+    ],
+    "root_exports": []
+  },
+  "classification": "Contract",
+  "current_authority": {
+    "canonical_module_exists": false,
+    "profile_mapper_reads": [
+      "mutation_error.status",
+      "mutation_error.code",
+      "mutation_error.message",
+      "mutation_error.details"
+    ],
+    "profile_mapper_source": "easyuse_anima/api/responses.py",
+    "translation_mapper_reads": [
+      "exc.status",
+      "exc.code",
+      "exc.message"
+    ],
+    "translation_mapper_source": "easyuse_anima/api/routes/translation.py"
+  },
+  "direct_test_owners": [
+    "tests.test_api_contract.ApiProfileErrorResponseTests",
+    "tests.test_prompt_translation_api.PromptTranslationApiTests",
+    "tests.test_autocomplete_service.AutocompleteServiceTests",
+    "tests.test_prompt_corrector.AutocompleteDatasetTests",
+    "tests.test_aio_generation_migrations.AIOGenerationMigrationTests",
+    "tests.test_seed_reservation_contract.SeedReservationContractTests",
+    "tests.test_seed_reservation_service.SeedReservationServiceTests",
+    "tests.test_seed_execution_identity.SeedExecutionIdentityTests",
+    "tests.test_profile_contract.ProfileContractTests"
+  ],
+  "evidence": [
+    "docs/architecture/python-backend.md",
+    "docs/architecture/python-feature-error-taxonomy-contract.md",
+    "docs/architecture/python-typed-boundary-f01-audit.md",
+    "easyuse_anima/api/errors.py",
+    "easyuse_anima/api/responses.py",
+    "easyuse_anima/api/routes/translation.py",
+    "easyuse_anima/profiles/contract.py",
+    "easyuse_anima/profiles/repository.py",
+    "easyuse_anima/profiles/mutation.py",
+    "easyuse_anima/autocomplete/index.py",
+    "easyuse_anima/prompt/anima/knowledge.py",
+    "easyuse_anima/aio/generation_migrations.py",
+    "easyuse_anima/translation/contracts.py",
+    "easyuse_anima/seed/reservation.py",
+    "easyuse_anima/seed/execution_identity.py",
+    "easyuse_anima/seed/service.py"
+  ],
+  "excluded_errors": [
+    {
+      "name": "ApiContractError",
+      "reason": "API request-adapter error; HTTP metadata remains adapter-owned.",
+      "source": "easyuse_anima/api/errors.py"
+    },
+    {
+      "name": "_InvalidAutocompleteIndex",
+      "reason": "Private index repair control flow; never crosses the feature boundary.",
+      "source": "easyuse_anima/autocomplete/index.py"
+    }
+  ],
+  "feature_errors": [
+    {
+      "adapter": "converted-before-adapter",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.profiles.contract",
+      "name": "ProfileContractError",
+      "source": "easyuse_anima/profiles/contract.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.profiles.repository",
+      "name": "InvalidProfileDataError",
+      "source": "easyuse_anima/profiles/repository.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.profiles.mutation",
+      "name": "ProfileMutationError",
+      "source": "easyuse_anima/profiles/mutation.py",
+      "target_category": "ConflictError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ProfileMutationError"
+      ],
+      "module": "easyuse_anima.profiles.mutation",
+      "name": "ProfilePreconditionRequiredError",
+      "source": "easyuse_anima/profiles/mutation.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ProfileMutationError"
+      ],
+      "module": "easyuse_anima.profiles.mutation",
+      "name": "ProfileIdentityMismatchError",
+      "source": "easyuse_anima/profiles/mutation.py",
+      "target_category": "ConflictError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ProfileMutationError"
+      ],
+      "module": "easyuse_anima.profiles.mutation",
+      "name": "ProfileRevisionConflictError",
+      "source": "easyuse_anima/profiles/mutation.py",
+      "target_category": "ConflictError"
+    },
+    {
+      "adapter": "fallback-diagnostics",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "RuntimeError"
+      ],
+      "module": "easyuse_anima.autocomplete.index",
+      "name": "AutocompleteIndexUnavailable",
+      "source": "easyuse_anima/autocomplete/index.py",
+      "target_category": "CapabilityUnavailableError"
+    },
+    {
+      "adapter": "compatibility-only",
+      "builtin_compatibility": [
+        "FileNotFoundError"
+      ],
+      "current_direct_bases": [
+        "FileNotFoundError"
+      ],
+      "module": "easyuse_anima.prompt.anima.knowledge",
+      "name": "KnowledgeBaseNotFound",
+      "source": "easyuse_anima/prompt/anima/knowledge.py",
+      "target_category": "NotFoundError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.aio.generation_migrations",
+      "name": "AIOGenerationMigrationError",
+      "source": "easyuse_anima/aio/generation_migrations.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "RuntimeError"
+      ],
+      "module": "easyuse_anima.seed.service",
+      "name": "SeedReservationServiceError",
+      "source": "easyuse_anima/seed/service.py",
+      "target_category": "EasyUseAnimaError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "SeedReservationServiceError"
+      ],
+      "module": "easyuse_anima.seed.service",
+      "name": "SeedReservationConflictError",
+      "source": "easyuse_anima/seed/service.py",
+      "target_category": "ConflictError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "SeedReservationServiceError"
+      ],
+      "module": "easyuse_anima.seed.service",
+      "name": "SeedReservationCapacityError",
+      "source": "easyuse_anima/seed/service.py",
+      "target_category": "CapabilityUnavailableError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.seed.execution_identity",
+      "name": "SeedExecutionIdentityError",
+      "source": "easyuse_anima/seed/execution_identity.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "propagate",
+      "builtin_compatibility": [
+        "ValueError"
+      ],
+      "current_direct_bases": [
+        "ValueError"
+      ],
+      "module": "easyuse_anima.seed.reservation",
+      "name": "SeedReservationContractError",
+      "source": "easyuse_anima/seed/reservation.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "RuntimeError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "PromptTranslationError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "EasyUseAnimaError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "PromptTranslationLimitError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationLimitError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationMarkerCountError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationLimitError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationMarkerSizeError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationLimitError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationTotalSizeError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "ValidationError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationProviderUnavailableError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "CapabilityUnavailableError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationTimeoutError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "UpstreamTimeoutError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationCancelledError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "EasyUseAnimaError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationBusyError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "ConflictError"
+    },
+    {
+      "adapter": "http",
+      "builtin_compatibility": [
+        "RuntimeError"
+      ],
+      "current_direct_bases": [
+        "PromptTranslationError"
+      ],
+      "module": "easyuse_anima.translation.contracts",
+      "name": "TranslationUpstreamError",
+      "source": "easyuse_anima/translation/contracts.py",
+      "target_category": "EasyUseAnimaError"
+    }
+  ],
+  "http_mappings": [
+    {
+      "code": "profile_revision_conflict",
+      "constructor": {
+        "kwargs": {
+          "code": "profile_revision_conflict",
+          "details": {
+            "profile": "profile"
+          },
+          "message": "Profile revision does not match",
+          "status": 409
+        }
+      },
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Profile revision does not match",
+      "details": {
+        "profile": "profile"
+      },
+      "mapping_policy": "dynamic-compatibility",
+      "name": "ProfileMutationError",
+      "owner": "easyuse_anima.api.responses.build_profile_error_response",
+      "status": 409,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "profile_precondition_required",
+      "constructor": {
+        "args": [
+          [
+            "profile_id",
+            "revision"
+          ]
+        ]
+      },
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Profile precondition is required",
+      "details": {
+        "fields": [
+          "profile_id",
+          "revision"
+        ],
+        "profile": "profile"
+      },
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "ProfilePreconditionRequiredError",
+      "owner": "easyuse_anima.api.responses.build_profile_error_response",
+      "status": 428,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "profile_identity_mismatch",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Profile identity does not match",
+      "details": {
+        "profile": "profile"
+      },
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "ProfileIdentityMismatchError",
+      "owner": "easyuse_anima.api.responses.build_profile_error_response",
+      "status": 409,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "profile_revision_conflict",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Profile revision does not match",
+      "details": {
+        "profile": "profile"
+      },
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "ProfileRevisionConflictError",
+      "owner": "easyuse_anima.api.responses.build_profile_error_response",
+      "status": 409,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "invalid_profile_data",
+      "current_metadata_owner": "api-adapter",
+      "default_message": "Profile data is invalid",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "InvalidProfileDataError",
+      "owner": "easyuse_anima.api.responses.build_profile_error_response",
+      "status": 422,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_error",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Prompt translation failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "PromptTranslationError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 500,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_error",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Prompt translation failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "PromptTranslationLimitError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 413,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_marker_count_exceeded",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Prompt translation failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationMarkerCountError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 413,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_marker_too_long",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Prompt translation failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationMarkerSizeError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 413,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_marker_characters_exceeded",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "Prompt translation failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationTotalSizeError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 413,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_provider_unavailable",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "The selected translation provider is unavailable.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationProviderUnavailableError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 503,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_timeout",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "The translation provider timed out.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationTimeoutError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 504,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_cancelled",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "The translation request was cancelled.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationCancelledError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 499,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_busy",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "A prompt translation request is already in progress.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationBusyError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 503,
+      "target_authority": "api-adapter"
+    },
+    {
+      "code": "translation_upstream_error",
+      "constructor": {},
+      "current_metadata_owner": "feature-compatibility",
+      "default_message": "The translation provider request failed.",
+      "details": null,
+      "mapping_policy": "fixed-by-exception-kind",
+      "name": "TranslationUpstreamError",
+      "owner": "easyuse_anima.api.routes.translation",
+      "status": 502,
+      "target_authority": "api-adapter"
+    }
+  ],
+  "implementation_sequence": [
+    {
+      "classification": "CONTRACT",
+      "id": "F-02f",
+      "scope": "Add the canonical categories and category inheritance while preserving every concrete class identity, feature-specific base relationship, built-in catch, export, constructor, attribute, and behavior."
+    },
+    {
+      "classification": "ADAPTER",
+      "id": "F-02g",
+      "scope": "Make API-owned mappings authoritative for profile and translation errors while preserving exact HTTP payloads, dynamic profile seams, and current exception metadata as passive compatibility mirrors."
+    },
+    {
+      "classification": "CONTRACT",
+      "id": "F-02h",
+      "scope": "Re-audit the common error row, record zero unmapped feature errors, close Phase F, and hand off to G-04A."
+    }
+  ],
+  "inventory_modules": [
+    "easyuse_anima/api/errors.py",
+    "easyuse_anima/profiles/contract.py",
+    "easyuse_anima/profiles/repository.py",
+    "easyuse_anima/profiles/mutation.py",
+    "easyuse_anima/autocomplete/index.py",
+    "easyuse_anima/prompt/anima/knowledge.py",
+    "easyuse_anima/aio/generation_migrations.py",
+    "easyuse_anima/translation/contracts.py",
+    "easyuse_anima/seed/reservation.py",
+    "easyuse_anima/seed/execution_identity.py",
+    "easyuse_anima/seed/service.py"
+  ],
+  "preserved_invariants": [
+    "concrete-class-module-name-and-identity",
+    "existing-feature-specific-subclass-relations",
+    "ValueError-RuntimeError-FileNotFoundError-catch-compatibility",
+    "canonical-and-compatibility-exports",
+    "exception-constructors-messages-details-and-reasons",
+    "profile-dynamic-monkeypatch-seam",
+    "profile-and-translation-status-code-message-details-payloads",
+    "request-id-correlation-and-redaction",
+    "autocomplete-fallback-diagnostics",
+    "aio-migration-failure-messages",
+    "seed-conflict-capacity-and-contract-behavior"
+  ],
+  "production_changes": 0,
+  "schema_version": 1,
+  "stop_conditions": [
+    "public-or-root-export-change",
+    "concrete-exception-identity-change",
+    "built-in-catch-compatibility-change",
+    "api-payload-or-correlation-change",
+    "profile-dynamic-seam-change",
+    "feature-behavior-or-migration-change",
+    "root-shim-import-from-canonical-code"
+  ]
+}

--- a/tests/test_python_feature_error_contract.py
+++ b/tests/test_python_feature_error_contract.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib
+import json
+import unittest
+from functools import cache
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_feature_error_contract.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-feature-error-taxonomy-contract.md"
+)
+
+
+@cache
+def _tree(source: str) -> ast.Module:
+    path = ROOT / source
+    return ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+
+
+def _class_def(source: str, name: str) -> ast.ClassDef:
+    for statement in _tree(source).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == name:
+            return statement
+    raise AssertionError(f"{source} has no class {name}")
+
+
+def _base_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_base_name(node.value)}.{node.attr}"
+    raise AssertionError(f"Unsupported class base: {ast.dump(node)}")
+
+
+def _test_owner(target: str) -> tuple[str, str]:
+    module, _, class_name = target.rpartition(".")
+    if not module.startswith("tests.") or not class_name:
+        raise AssertionError(f"Invalid test owner: {target}")
+    return f"{module.replace('.', '/')}.py", class_name
+
+
+class PythonFeatureErrorContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_schema_scope_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "base_sha",
+                "canonical_taxonomy",
+                "classification",
+                "current_authority",
+                "direct_test_owners",
+                "evidence",
+                "excluded_errors",
+                "feature_errors",
+                "http_mappings",
+                "implementation_sequence",
+                "inventory_modules",
+                "preserved_invariants",
+                "production_changes",
+                "schema_version",
+                "stop_conditions",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(self.fixture["classification"], "Contract")
+        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(
+            self.fixture["base_sha"],
+            "e5e0329cd64afa9894d631f9b6baa6514a81ab48",
+        )
+        self.assertTrue(CONTRACT_DOC.is_file())
+        for source in self.fixture["evidence"]:
+            self.assertTrue((ROOT / source).is_file(), source)
+
+    def test_canonical_taxonomy_matches_the_documented_hierarchy(self):
+        taxonomy = self.fixture["canonical_taxonomy"]
+        categories = taxonomy["categories"]
+        self.assertEqual(taxonomy["module"], "easyuse_anima/errors.py")
+        self.assertEqual(taxonomy["root_exports"], [])
+        self.assertEqual(
+            [item["name"] for item in categories],
+            [
+                "EasyUseAnimaError",
+                "ValidationError",
+                "ConflictError",
+                "NotFoundError",
+                "CapabilityUnavailableError",
+                "UpstreamTimeoutError",
+                "StorageError",
+            ],
+        )
+        self.assertEqual(
+            taxonomy["module_exports"],
+            [item["name"] for item in categories],
+        )
+        self.assertEqual(categories[0]["parent"], "Exception")
+        self.assertEqual(
+            {item["parent"] for item in categories[1:]},
+            {"EasyUseAnimaError"},
+        )
+
+    def test_inventory_covers_every_current_feature_and_adapter_error(self):
+        discovered = set()
+        for source in self.fixture["inventory_modules"]:
+            for statement in _tree(source).body:
+                if isinstance(statement, ast.ClassDef) and (
+                    statement.name.endswith(("Error", "Unavailable", "NotFound"))
+                    or statement.name.startswith("_Invalid")
+                ):
+                    discovered.add((source, statement.name))
+
+        contracted = {
+            (item["source"], item["name"])
+            for item in self.fixture["feature_errors"]
+        }
+        excluded = {
+            (item["source"], item["name"])
+            for item in self.fixture["excluded_errors"]
+        }
+        self.assertEqual(discovered, contracted | excluded)
+        self.assertFalse(contracted & excluded)
+
+    def test_current_bases_and_builtin_catches_are_preserved_inputs(self):
+        category_names = {
+            item["name"]
+            for item in self.fixture["canonical_taxonomy"]["categories"]
+        }
+        for item in self.fixture["feature_errors"]:
+            with self.subTest(error=item["name"]):
+                class_def = _class_def(item["source"], item["name"])
+                self.assertEqual(
+                    [_base_name(base) for base in class_def.bases],
+                    item["current_direct_bases"],
+                )
+                error_type = getattr(
+                    importlib.import_module(item["module"]),
+                    item["name"],
+                )
+                for builtin_name in item["builtin_compatibility"]:
+                    builtin_type = getattr(builtins, builtin_name)
+                    self.assertTrue(
+                        issubclass(error_type, builtin_type),
+                        f"{item['name']} no longer catches as {builtin_name}",
+                    )
+                self.assertIn(item["target_category"], category_names)
+
+    def test_http_mapping_is_exhaustive_and_current_payloads_are_frozen(self):
+        http_errors = {
+            item["name"]
+            for item in self.fixture["feature_errors"]
+            if item["adapter"] == "http"
+        }
+        mappings = {
+            item["name"]: item for item in self.fixture["http_mappings"]
+        }
+        self.assertEqual(set(mappings), http_errors)
+
+        feature_errors = {
+            item["name"]: item for item in self.fixture["feature_errors"]
+        }
+        for name, mapping in mappings.items():
+            with self.subTest(error=name):
+                self.assertEqual(mapping["target_authority"], "api-adapter")
+                self.assertTrue(mapping["owner"].startswith("easyuse_anima.api."))
+                if mapping["current_metadata_owner"] == "api-adapter":
+                    continue
+                error = feature_errors[name]
+                error_type = getattr(
+                    importlib.import_module(error["module"]),
+                    name,
+                )
+                constructor = mapping.get("constructor", {})
+                instance = error_type(
+                    *constructor.get("args", []),
+                    **constructor.get("kwargs", {}),
+                )
+                self.assertEqual(instance.status, mapping["status"])
+                self.assertEqual(instance.code, mapping["code"])
+                self.assertEqual(instance.message, mapping["default_message"])
+                self.assertEqual(
+                    getattr(instance, "details", None),
+                    mapping["details"],
+                )
+
+    def test_current_http_authority_is_recorded_before_the_adapter_cutover(self):
+        authority = self.fixture["current_authority"]
+        self.assertEqual(
+            (ROOT / self.fixture["canonical_taxonomy"]["module"]).is_file(),
+            authority["canonical_module_exists"],
+        )
+        for prefix in ("profile", "translation"):
+            source = (ROOT / authority[f"{prefix}_mapper_source"]).read_text(
+                encoding="utf-8"
+            )
+            for expression in authority[f"{prefix}_mapper_reads"]:
+                self.assertIn(expression, source)
+
+    def test_direct_test_owners_and_ordered_implementation_exist(self):
+        for target in self.fixture["direct_test_owners"]:
+            with self.subTest(target=target):
+                source, class_name = _test_owner(target)
+                _class_def(source, class_name)
+
+        sequence = self.fixture["implementation_sequence"]
+        self.assertEqual(
+            [item["id"] for item in sequence],
+            ["F-02f", "F-02g", "F-02h"],
+        )
+        self.assertEqual(
+            [item["classification"] for item in sequence],
+            ["CONTRACT", "ADAPTER", "CONTRACT"],
+        )
+        for item in sequence:
+            self.assertTrue(item["scope"].strip())
+
+    def test_contract_forbids_silent_compatibility_loss(self):
+        self.assertEqual(
+            set(self.fixture["stop_conditions"]),
+            {
+                "public-or-root-export-change",
+                "concrete-exception-identity-change",
+                "built-in-catch-compatibility-change",
+                "api-payload-or-correlation-change",
+                "profile-dynamic-seam-change",
+                "feature-behavior-or-migration-change",
+                "root-shim-import-from-canonical-code",
+            },
+        )
+        self.assertIn(
+            "profile-and-translation-status-code-message-details-payloads",
+            self.fixture["preserved_invariants"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Phase F의 마지막 finding인 common feature error taxonomy를 production 변경 없이 executable Contract로 고정합니다. 현재 feature error 24개, 명시적 제외 2개, built-in catch 호환성, profile/translation HTTP mapping과 구현 순서를 machine-readable fixture/test로 소유합니다.

## Base -> Head

- Base: `e5e0329cd64afa9894d631f9b6baa6514a81ab48`
- Head: `27d1a9923f927976012606045f504ab3257ad64c`

## 주요 파일

- `docs/architecture/python-feature-error-taxonomy-contract.md`
- `tests/fixtures/python_feature_error_contract.v1.json`
- `tests/test_python_feature_error_contract.py`
- Phase F audit/roadmap와 architecture/development entrypoint

## 계약 결정

- canonical `easyuse_anima/errors.py`: root + 6 semantic categories, explicit module export, root export 없음
- concrete error는 현재 feature module에서 identity/module/name 유지
- ValueError/RuntimeError/FileNotFoundError catch를 additive multiple inheritance로 보존
- ApiContractError는 API-only, _InvalidAutocompleteIndex는 private control flow
- profile/translation HTTP mapping은 F-02g에서 API-authoritative로 전환
- 현재 status/code/message/details metadata는 passive compatibility mirror로 유지
- ordered queue: F-02f inheritance -> F-02g adapter mapping -> F-02h Phase F audit

## 검증

Focused 163 pass:
- taxonomy contract 8
- profile API 3 / translation API 12
- Autocomplete 37
- AiO migration 8
- seed contract/service/identity 47
- profile contract 9 / API compatibility 3
- package 1 / Pyright 11 / analyzer 18 / import-boundary 6

Final SHA official full 정확히 1회:
- Python 1,450 pass
- frontend 120 files pass
- Pyright 158 files / 기존 14 errors / 신규 증가 없음
- import-boundary 11 groups / 0 violations
- git diff gate pass
- package/live 미실행: production/package/runtime surface 변경 없음

## 위험과 rollback

Production 동작은 바뀌지 않습니다. 주요 잔여 위험은 F-02f 실제 MRO와 F-02g dynamic profile seam이며 각 task의 stop condition으로 고정했습니다. rollback은 이 Contract 커밋의 revert입니다.

## 다음 작업

Issue #563 / F-02f common category inheritance. API mapping cutover는 F-02g까지 금지하며 #188 G-04A는 F-02h 이후에만 READY입니다.