### PR TITLE
[F-02f] Add common feature error categories

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ then only the active task section, owning Issue, direct source, and direct tests
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
 - First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02f common category inheritance.
+  / F-02g authoritative profile/translation API mappings.
 - After Phase F handoff, Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
   owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
@@ -37,8 +37,8 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE F-02d settings typed migration contract
   -> COMPLETE affected settings/profile/workflow-row re-audit
   -> COMPLETE F-02e common feature error taxonomy Contract
-  -> READY F-02f canonical categories and feature inheritance
-  -> F-02g authoritative profile/translation API mappings
+  -> COMPLETE F-02f canonical categories and feature inheritance
+  -> READY F-02g authoritative profile/translation API mappings
   -> F-02h error-row and Phase F completion audit
   -> G-04A public API snapshot coverage audit
   -> optional G-04B gap

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #563 / F-02f common category inheritance.
+- Active first task: Issue #563 / F-02g authoritative API mappings.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -74,8 +74,8 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE F-02d settings typed migration contract          #563 / PR #573
   -> COMPLETE affected settings/profile/workflow row re-audit
   -> COMPLETE F-02e common feature error taxonomy Contract     #563
-  -> READY F-02f canonical categories and feature inheritance  #563
-  -> F-02g    authoritative profile/translation API mappings   #563
+  -> COMPLETE F-02f canonical categories and feature inheritance #563
+  -> READY F-02g authoritative profile/translation API mappings  #563
   -> F-02h    affected error-row re-audit and Phase F close    #563
   -> G-04A    public API snapshot coverage audit              #188
   -> OPTIONAL G-04B  minimal missing public-surface gate
@@ -158,8 +158,9 @@ Audit result, updated after F-02d merged at
   the settings/profile/workflow row while profile future fields and raw host workflow
   lookup remain intentional migration/adapter boundaries;
 - common feature error taxonomy is the only remaining Phase F finding; F-02e fixes
-  its production-free executable contract and selects ordered F-02f inheritance,
-  F-02g API mapping, and F-02h completion-audit slices;
+  its production-free executable contract and F-02f completes the canonical categories
+  and additive inheritance; F-02g API mapping is READY before the F-02h completion
+  audit;
 - G-04A and Issue #188 remain blocked until all Phase F follow-up rows are closed.
 
 ## 4. G-04A — Public API snapshot coverage audit
@@ -375,34 +376,32 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #563 / F-02f only from latest origin/dev after the F-02e taxonomy Contract
-merges.
+Start Issue #563 / F-02g only from latest origin/dev after F-02f merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document's F-01 result and validation sections
-- python-feature-error-taxonomy-contract.md F-02f task card
-- python-typed-boundary-f01-audit.md F-02e decision
+- python-feature-error-taxonomy-contract.md F-02g task card
+- python-typed-boundary-f01-audit.md F-02f completion decision
 - Issue #563 latest checkpoint
 - direct profile, Autocomplete, Prompt knowledge, AiO migration, translation, and seed
   error owners/tests plus taxonomy, Pyright, import, package, and analyzer fixtures
 
 Do not read all historical D/E PRs and do not restart D-14 removal.
 
-Add `easyuse_anima/errors.py` with the seven documented categories and explicit module
-exports but no root export. Add category ancestry to every fixture-owned feature error
-in place while preserving its concrete class identity, feature-specific subclass
-graph, ValueError/RuntimeError/FileNotFoundError catches, constructor, attributes,
-messages, details, reason, export identity, and behavior. Do not perform the profile or
-translation API mapping cutover in this task.
+Make the canonical profile and translation API mappings authoritative without reading
+feature-owned HTTP status/code/message/details metadata. Preserve those attributes as
+compatibility mirrors, preserve exact payloads/correlation/redaction/catch order, and
+retain the arbitrary dynamic ProfileMutationError dependency seam. Do not change the
+feature exceptions, taxonomy, route/runtime lifecycle, or root exports.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run official full once on the final production/test/tool SHA.
 Package/live are not triggered.
 
-Push a dev-targeted Draft PR. After review and merge, run F-02g as a separate adapter
-cutover, then F-02h re-audits the error row and closes Phase F before #188 G-04A.
+Push a dev-targeted Draft PR. After review and merge, F-02h re-audits the error row and
+closes Phase F before #188 G-04A.
 
 Do not change profile/settings/workflow/AiO migration semantics, exception metadata,
 public/root exports, or API/node payloads. Do not remove root files, add deprecation

--- a/docs/architecture/python-feature-error-taxonomy-contract.md
+++ b/docs/architecture/python-feature-error-taxonomy-contract.md
@@ -3,17 +3,19 @@
 ## Status
 
 - Owner: Issue #563
-- Base: `e5e0329cd64afa9894d631f9b6baa6514a81ab48`
-- Task: F-02e
-- Class: Contract/gate
-- Production changes: none
+- Contract base: `e5e0329cd64afa9894d631f9b6baa6514a81ab48`
+- F-02f implementation base: `878a86f739a37a000a56b9e76ee2179aa86271f1`
+- Status: F-02e Contract complete; F-02f inheritance complete; F-02g READY
+- Current class: Adapter
+- Production changes: F-02f categories and additive inheritance only
 - Fixture: `tests/fixtures/python_feature_error_contract.v1.json`
 - Gate: `tests/test_python_feature_error_contract.py`
 
-This contract resolves the final Phase F finding without changing production
-inheritance, exceptions, API payloads, node behavior, or public exports. The fixture is
-the executable inventory; this document records the decisions and ordered
-implementation boundaries.
+This contract resolves the final Phase F finding in ordered slices. F-02f implemented
+the categories and additive inheritance without changing concrete exception identity,
+API payloads, node behavior, or public exports. The fixture is the executable
+inventory; this document records the decisions and the remaining adapter/audit
+boundaries.
 
 ## Canonical categories
 
@@ -121,6 +123,15 @@ One adapter cutover after F-02f:
 - do not change Autocomplete fallback, seed behavior, migration behavior, or node
   payloads.
 
+## F-02f completion
+
+F-02f is complete. `easyuse_anima/errors.py` owns the seven categories with an
+explicit module `__all__` and no root export. All 24 fixture-owned feature errors keep
+their original module, name, concrete object identity, feature-specific subclass
+relations, constructor/metadata/message behavior, and built-in exception catches while
+also inheriting the selected semantic category. Profile and translation adapters still
+read the compatibility metadata; that authority cutover remains exclusively F-02g.
+
 ### F-02h — Completion audit
 
 A production-free audit must reconcile every fixture-owned feature error, record zero
@@ -172,6 +183,46 @@ Promotion: official full exactly once on final production/test/tool SHA; no pack
 Stop: MRO conflict, public/root export change, concrete identity/catch change, API or
   feature behavior change, or canonical-to-root import is required
 Next: F-02g adapter authority cutover only
+```
+
+## F-02g task card
+
+```text
+Task ID: F-02g authoritative profile/translation API mappings
+Owner Issue: #563
+Primary class: ADAPTER
+Base SHA: latest origin/dev after F-02f merges
+Goal: make canonical API adapters authoritative for every fixture-owned profile and
+      translation HTTP mapping without changing any response or feature behavior.
+Allowed production:
+  api.py
+  easyuse_anima/bootstrap.py
+  easyuse_anima/api/responses.py
+  easyuse_anima/api/routes/translation.py
+Allowed tests/config/docs:
+  tests/test_python_feature_error_contract.py
+  tests/fixtures/python_feature_error_contract.v1.json
+  tests/test_api_contract.py
+  tests/test_prompt_translation_api.py
+  tests/test_python_translation_runtime_contract.py
+  direct bootstrap/package/Pyright/analyzer/import owners
+  tests/fixtures/python_backend_baseline.json only as generated analyzer evidence
+  current queue/audit docs
+Forbidden: feature exception or category changes, exception metadata removal, root
+  alias/export changes, route/runtime lifecycle changes, Autocomplete/seed/migration/
+  node behavior changes, broad error cleanup, Any cleanup, ignore addition
+Preserve: exact profile/translation status/code/message/details, request correlation,
+  redaction and catch order, arbitrary dynamic ProfileMutationError dependency seam,
+  concrete exception identity and compatibility metadata, translation worker identity,
+  route identity/order/signature/registration, repeated initialize behavior
+Focused: taxonomy authority contract; direct profile error response and Prompt
+  translation API/runtime owners; bootstrap/package; Pyright; analyzer; import boundary;
+  changed-file syntax/static; git diff --check
+Promotion: official full exactly once on final production/test/tool SHA; no package/live
+Stop: preserving the dynamic profile seam requires feature-owned HTTP authority,
+  a canonical adapter must import root api.py, exception metadata/payload/identity must
+  change, or route/runtime lifecycle behavior must change
+Next: F-02h production-free completion audit only
 ```
 
 ## Validation and stop policy

--- a/docs/architecture/python-typed-boundary-f01-audit.md
+++ b/docs/architecture/python-typed-boundary-f01-audit.md
@@ -171,13 +171,14 @@ being removed during Phase F.
 The ordered implementation is:
 
 ```text
-READY F-02f canonical categories and additive feature inheritance
-  -> F-02g authoritative profile/translation API mappings
+COMPLETE F-02f canonical categories and additive feature inheritance
+  -> READY F-02g authoritative profile/translation API mappings
   -> F-02h production-free error-row and Phase F completion audit
   -> G-04A
 ```
 
-F-02f is the next task. Its complete task card is in
-`python-feature-error-taxonomy-contract.md`. It must not perform the F-02g adapter
-cutover, change any exception constructor/attribute/message, add a root export, or
-change feature/API/node behavior.
+F-02f is complete: the canonical categories and additive ancestry now preserve every
+recorded identity, built-in catch, export, constructor, metadata, message, and direct
+behavior. F-02g is the next task. Its complete task card is in
+`python-feature-error-taxonomy-contract.md`; it owns only the profile/translation API
+mapping authority cutover and must not change feature errors or payloads.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02f common category inheritance;
+   - first READY task: Issue #563 / F-02g authoritative API mappings;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -61,8 +61,8 @@ COMPLETE  #563 affected Prompt-row re-audit
 COMPLETE  #563 F-02d settings typed migration contract
 COMPLETE  #563 affected settings/profile/workflow-row re-audit
 COMPLETE  #563 F-02e common feature error taxonomy contract
-READY     #563 F-02f canonical categories and feature inheritance
-NEXT      #563 F-02g authoritative profile/translation API mappings
+COMPLETE  #563 F-02f canonical categories and feature inheritance
+READY     #563 F-02g authoritative profile/translation API mappings
 NEXT      #563 F-02h error-row and Phase F completion audit
 BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
 LATER     G-05 size ratchet / G-06 test ownership
@@ -78,34 +78,34 @@ The D-14 stop is correct:
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02f source map
+## Active F-02g source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-feature-error-taxonomy-contract.md  # F-02f task card
+docs/architecture/python-feature-error-taxonomy-contract.md  # F-02g task card
 Issue #563 latest checkpoint
-direct feature error owners under profiles, autocomplete, prompt, aio, translation, seed
-taxonomy fixture/test plus Pyright, package, analyzer, and import fixtures
+api.py dynamic profile dependency composition
+easyuse_anima/api/responses.py and api/routes/translation.py mapping owners
+bootstrap translation composition plus taxonomy/API/runtime tests
 ```
 
-F-02f adds the documented categories and category ancestry in place. Preserve each
-concrete class object/module/name, existing feature-specific inheritance, built-in
-catch compatibility, constructor, attributes, exports, and behavior. Do not combine
-the F-02g profile/translation API mapping cutover into this task.
+F-02g moves profile and translation HTTP authority into canonical API adapters while
+preserving exact payloads, correlation, redaction, catch order, compatibility metadata,
+and the dynamic profile dependency seam. It does not change feature exceptions,
+taxonomy, root exports, or runtime lifecycle.
 
 ## Following queue
 
-After F-02f:
+After F-02g:
 
-1. execute F-02g as the separate authoritative API adapter mapping cutover;
-2. run F-02h to re-audit the common error row and record Phase F completion;
-3. after Phase F closes, run #188 G-04A against existing
+1. run F-02h to re-audit the common error row and record Phase F completion;
+2. after Phase F closes, run #188 G-04A against existing
    compatibility/node/API/package fixtures;
-4. audit Wildcard and API pure-shim feasibility without deleting root modules;
-5. add G-05 changed-path size growth and G-06 test-ownership gates;
-6. let the next ordinary release containing final shims become release N;
-7. re-audit D-14 only after an event-gate changes.
+3. audit Wildcard and API pure-shim feasibility without deleting root modules;
+4. add G-05 changed-path size growth and G-06 test-ownership gates;
+5. let the next ordinary release containing final shims become release N;
+6. re-audit D-14 only after an event-gate changes.
 
 No dedicated release, outbound telemetry, import-time deprecation warning, or public
 root removal is authorized by this queue.

--- a/easyuse_anima/aio/generation_migrations.py
+++ b/easyuse_anima/aio/generation_migrations.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import TypeAlias, cast
 
+from ..errors import ValidationError
 from .generation_values import freeze_object, thaw_object
 
 AIO_GENERATION_SETTINGS_SCHEMA = "easyuse_anima_aio_generation_settings"
@@ -27,7 +28,7 @@ AIOGenerationMigrationFunction: TypeAlias = Callable[
 ]
 
 
-class AIOGenerationMigrationError(ValueError):
+class AIOGenerationMigrationError(ValidationError, ValueError):
     """A pure generation-settings version contract could not be satisfied."""
 
 

--- a/easyuse_anima/autocomplete/index.py
+++ b/easyuse_anima/autocomplete/index.py
@@ -10,11 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from ..errors import CapabilityUnavailableError
 from ..infrastructure.filesystem.paths import (
     PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR,
 )
 from ..infrastructure.filesystem.paths import USER_DATA_DIR
-
 
 AUTOCOMPLETE_INDEX_SCHEMA_VERSION = 1
 __all__ = (
@@ -73,7 +73,7 @@ class AutocompleteIndexResult:
     diagnostics: AutocompleteIndexDiagnostics
 
 
-class AutocompleteIndexUnavailable(RuntimeError):
+class AutocompleteIndexUnavailable(CapabilityUnavailableError, RuntimeError):
     def __init__(self, reason: str) -> None:
         super().__init__(reason)
         self.reason = reason

--- a/easyuse_anima/errors.py
+++ b/easyuse_anima/errors.py
@@ -1,0 +1,42 @@
+"""Shared semantic error categories for feature and adapter boundaries."""
+
+from __future__ import annotations
+
+
+class EasyUseAnimaError(Exception):
+    """Base class for errors raised by EasyUse Anima feature code."""
+
+
+class ValidationError(EasyUseAnimaError):
+    """A feature input or persisted contract is invalid."""
+
+
+class ConflictError(EasyUseAnimaError):
+    """A requested operation conflicts with retained feature state."""
+
+
+class NotFoundError(EasyUseAnimaError):
+    """A required feature-owned resource is absent."""
+
+
+class CapabilityUnavailableError(EasyUseAnimaError):
+    """A requested feature capability is currently unavailable."""
+
+
+class UpstreamTimeoutError(EasyUseAnimaError):
+    """An upstream dependency did not settle within its time budget."""
+
+
+class StorageError(EasyUseAnimaError):
+    """A feature-owned storage operation failed."""
+
+
+__all__ = (
+    "EasyUseAnimaError",
+    "ValidationError",
+    "ConflictError",
+    "NotFoundError",
+    "CapabilityUnavailableError",
+    "UpstreamTimeoutError",
+    "StorageError",
+)

--- a/easyuse_anima/profiles/contract.py
+++ b/easyuse_anima/profiles/contract.py
@@ -4,6 +4,7 @@ import uuid
 from collections.abc import Mapping
 from typing import Any, cast
 
+from ..errors import ValidationError
 
 PROFILE_ENVELOPE_VERSION = 2
 PROFILE_KIND_AIO = "aio"
@@ -14,7 +15,7 @@ _PROFILE_KINDS = frozenset({PROFILE_KIND_AIO, PROFILE_KIND_LORA})
 _ENVELOPE_FIELDS = frozenset({"version", "profile_id", "revision", "name"})
 
 
-class ProfileContractError(ValueError):
+class ProfileContractError(ValidationError, ValueError):
     """A stored profile does not satisfy the supported envelope taxonomy."""
 
 

--- a/easyuse_anima/profiles/mutation.py
+++ b/easyuse_anima/profiles/mutation.py
@@ -8,10 +8,11 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from ..errors import ConflictError, ValidationError
 from .contract import read_profile_metadata
 
 
-class ProfileMutationError(ValueError):
+class ProfileMutationError(ConflictError, ValueError):
     """A public optimistic-concurrency failure with a stable API mapping."""
 
     status: int
@@ -33,7 +34,7 @@ class ProfileMutationError(ValueError):
         self.details = dict(details) if details is not None else None
 
 
-class ProfilePreconditionRequiredError(ProfileMutationError):
+class ProfilePreconditionRequiredError(ProfileMutationError, ValidationError):
     def __init__(self, fields: tuple[str, ...], *, profile: str = "profile") -> None:
         super().__init__(
             status=428,

--- a/easyuse_anima/profiles/repository.py
+++ b/easyuse_anima/profiles/repository.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..errors import ValidationError
 from ..infrastructure.filesystem.atomic_json import (
     AtomicJsonStore,
     create_atomic_json_store,
@@ -33,7 +34,7 @@ WINDOWS_RESERVED_FILE_BASENAMES = {
 }
 
 
-class InvalidProfileDataError(ValueError):
+class InvalidProfileDataError(ValidationError, ValueError):
     pass
 
 

--- a/easyuse_anima/prompt/anima/knowledge.py
+++ b/easyuse_anima/prompt/anima/knowledge.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ...errors import NotFoundError
 from ...infrastructure.filesystem.paths import PACKAGE_DATA_DIR
 from .models import TagInfo
 from .normalize import lookup_key
 from .ordering import TagSection, builtin_tag_section
 
 
-class KnowledgeBaseNotFound(FileNotFoundError):
+class KnowledgeBaseNotFound(NotFoundError, FileNotFoundError):
     """Compatibility exception for older callers."""
 
 

--- a/easyuse_anima/seed/execution_identity.py
+++ b/easyuse_anima/seed/execution_identity.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TypeAlias, cast
 
+from ..errors import ValidationError
+
 SEED_EXECUTION_IDENTITY_VERSION = 1
 
 _REQUEST_NAMESPACE = (
@@ -25,7 +27,7 @@ _ExecutionContextLoader: TypeAlias = Callable[[], object]
 _RequestIdFactory: TypeAlias = Callable[[], str]
 
 
-class SeedExecutionIdentityError(ValueError):
+class SeedExecutionIdentityError(ValidationError, ValueError):
     """A seed execution identity component is invalid."""
 
 

--- a/easyuse_anima/seed/reservation.py
+++ b/easyuse_anima/seed/reservation.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal, Protocol, TypeAlias, cast
 
+from ..errors import ValidationError
+
 SEED_RESERVATION_REQUEST_SCHEMA = "easyuse_anima_seed_reservation_request"
 SEED_RESERVATION_CONTRACT_VERSION = 2
 SEED_MAX_UINT64 = 0xFFFFFFFFFFFFFFFF
@@ -83,7 +85,7 @@ _LEGACY_SELECTION_BY_SEED: Mapping[int, SeedSelection] = {
 }
 
 
-class SeedReservationContractError(ValueError):
+class SeedReservationContractError(ValidationError, ValueError):
     """A seed reservation request or result violates the versioned contract."""
 
 

--- a/easyuse_anima/seed/service.py
+++ b/easyuse_anima/seed/service.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TypeAlias
 
+from ..errors import CapabilityUnavailableError, ConflictError, EasyUseAnimaError
 from .reservation import (
     SEED_CONTROL_FIXED,
     SEED_OVERFLOW_CLAMP,
@@ -34,15 +35,18 @@ _RandomSeed: TypeAlias = Callable[[int], int]
 _ReservationIdFactory: TypeAlias = Callable[[], str]
 
 
-class SeedReservationServiceError(RuntimeError):
+class SeedReservationServiceError(EasyUseAnimaError, RuntimeError):
     """The process-local reservation service cannot complete an operation."""
 
 
-class SeedReservationConflictError(SeedReservationServiceError):
+class SeedReservationConflictError(SeedReservationServiceError, ConflictError):
     """A request identity or stream domain conflicts with retained state."""
 
 
-class SeedReservationCapacityError(SeedReservationServiceError):
+class SeedReservationCapacityError(
+    SeedReservationServiceError,
+    CapabilityUnavailableError,
+):
     """A configured bounded state store has no safe capacity."""
 
 

--- a/easyuse_anima/translation/contracts.py
+++ b/easyuse_anima/translation/contracts.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from ..errors import (
+    CapabilityUnavailableError,
+    ConflictError,
+    EasyUseAnimaError,
+    UpstreamTimeoutError,
+    ValidationError,
+)
+
 PROMPT_TRANSLATION_PROVIDER_OFF = "off"
 PROMPT_TRANSLATION_PROVIDER_GOOGLE = "google"
 PROMPT_TRANSLATION_PROVIDERS = {
@@ -31,7 +39,7 @@ class PromptTranslationSettings:
     target: str = DEFAULT_PROMPT_TRANSLATION_TARGET
 
 
-class PromptTranslationError(RuntimeError):
+class PromptTranslationError(EasyUseAnimaError, RuntimeError):
     code = "translation_error"
     status = 500
     default_message = "Prompt translation failed."
@@ -41,7 +49,7 @@ class PromptTranslationError(RuntimeError):
         self.message = message or self.default_message
 
 
-class PromptTranslationLimitError(PromptTranslationError):
+class PromptTranslationLimitError(PromptTranslationError, ValidationError):
     status = 413
 
 
@@ -57,13 +65,16 @@ class TranslationTotalSizeError(PromptTranslationLimitError):
     code = "translation_marker_characters_exceeded"
 
 
-class TranslationProviderUnavailableError(PromptTranslationError):
+class TranslationProviderUnavailableError(
+    PromptTranslationError,
+    CapabilityUnavailableError,
+):
     code = "translation_provider_unavailable"
     status = 503
     default_message = "The selected translation provider is unavailable."
 
 
-class TranslationTimeoutError(PromptTranslationError):
+class TranslationTimeoutError(PromptTranslationError, UpstreamTimeoutError):
     code = "translation_timeout"
     status = 504
     default_message = "The translation provider timed out."
@@ -75,7 +86,7 @@ class TranslationCancelledError(PromptTranslationError):
     default_message = "The translation request was cancelled."
 
 
-class TranslationBusyError(PromptTranslationError):
+class TranslationBusyError(PromptTranslationError, ConflictError):
     code = "translation_busy"
     status = 503
     default_message = "A prompt translation request is already in progress."

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8496,6 +8496,24 @@
       },
       {
         "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_migrations.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "freeze_object",
         "branch_context": [],
         "classification": "internal",
@@ -8503,7 +8521,7 @@
         "conditional": false,
         "imported": ".generation_values:freeze_object",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "freeze_object",
         "optional": false,
         "requested": ".generation_values",
@@ -8521,7 +8539,7 @@
         "conditional": false,
         "imported": ".generation_values:thaw_object",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "thaw_object",
         "optional": false,
         "requested": ".generation_values",
@@ -17041,6 +17059,24 @@
         "source": "easyuse_anima/autocomplete/index.py"
       },
       {
+        "alias": null,
+        "bound_name": "CapabilityUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:CapabilityUnavailableError",
+        "kind": "static_from",
+        "line": 13,
+        "name": "CapabilityUnavailableError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/autocomplete/index.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
         "alias": "STORAGE_PACKAGE_DATA_DIR",
         "bound_name": "STORAGE_PACKAGE_DATA_DIR",
         "branch_context": [],
@@ -17049,7 +17085,7 @@
         "conditional": false,
         "imported": "..infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 13,
+        "line": 14,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "..infrastructure.filesystem.paths",
@@ -17067,7 +17103,7 @@
         "conditional": false,
         "imported": "..infrastructure.filesystem.paths:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "..infrastructure.filesystem.paths",
@@ -18785,6 +18821,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/errors.py"
       },
       {
         "alias": null,
@@ -27039,6 +27092,24 @@
       },
       {
         "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 7,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/contract.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -27634,6 +27705,42 @@
       },
       {
         "alias": null,
+        "bound_name": "ConflictError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ConflictError",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ConflictError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "read_profile_metadata",
         "branch_context": [],
         "classification": "internal",
@@ -27641,7 +27748,7 @@
         "conditional": false,
         "imported": ".contract:read_profile_metadata",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "read_profile_metadata",
         "optional": false,
         "requested": ".contract",
@@ -27754,6 +27861,24 @@
       },
       {
         "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/repository.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AtomicJsonStore",
         "branch_context": [],
         "classification": "internal",
@@ -27761,7 +27886,7 @@
         "conditional": false,
         "imported": "..infrastructure.filesystem.atomic_json:AtomicJsonStore",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "..infrastructure.filesystem.atomic_json",
@@ -27779,7 +27904,7 @@
         "conditional": false,
         "imported": "..infrastructure.filesystem.atomic_json:create_atomic_json_store",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "create_atomic_json_store",
         "optional": false,
         "requested": "..infrastructure.filesystem.atomic_json",
@@ -27797,7 +27922,7 @@
         "conditional": false,
         "imported": ".contract:ProfileContractError",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ProfileContractError",
         "optional": false,
         "requested": ".contract",
@@ -27815,7 +27940,7 @@
         "conditional": false,
         "imported": ".contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "interpret_profile_document",
         "optional": false,
         "requested": ".contract",
@@ -27833,7 +27958,7 @@
         "conditional": false,
         "imported": ".contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "legacy_profile_id",
         "optional": false,
         "requested": ".contract",
@@ -27851,7 +27976,7 @@
         "conditional": false,
         "imported": ".contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "normalize_profile_filename_identity",
         "optional": false,
         "requested": ".contract",
@@ -27869,7 +27994,7 @@
         "conditional": false,
         "imported": ".mutation:DirectoryMutationCoordinator",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "DirectoryMutationCoordinator",
         "optional": false,
         "requested": ".mutation",
@@ -29218,6 +29343,24 @@
       },
       {
         "alias": null,
+        "bound_name": "NotFoundError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "...errors:NotFoundError",
+        "kind": "static_from",
+        "line": 7,
+        "name": "NotFoundError",
+        "optional": false,
+        "requested": "...errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/anima/knowledge.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PACKAGE_DATA_DIR",
         "branch_context": [],
         "classification": "internal",
@@ -29225,7 +29368,7 @@
         "conditional": false,
         "imported": "...infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "...infrastructure.filesystem.paths",
@@ -29243,7 +29386,7 @@
         "conditional": false,
         "imported": ".models:TagInfo",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "TagInfo",
         "optional": false,
         "requested": ".models",
@@ -29261,7 +29404,7 @@
         "conditional": false,
         "imported": ".normalize:lookup_key",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "lookup_key",
         "optional": false,
         "requested": ".normalize",
@@ -29279,7 +29422,7 @@
         "conditional": false,
         "imported": ".ordering:TagSection",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "TagSection",
         "optional": false,
         "requested": ".ordering",
@@ -29297,7 +29440,7 @@
         "conditional": false,
         "imported": ".ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "builtin_tag_section",
         "optional": false,
         "requested": ".ordering",
@@ -31862,6 +32005,24 @@
       },
       {
         "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 13,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -32209,6 +32370,24 @@
       },
       {
         "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 10,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -32379,6 +32558,60 @@
       },
       {
         "alias": null,
+        "bound_name": "CapabilityUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:CapabilityUnavailableError",
+        "kind": "static_from",
+        "line": 14,
+        "name": "CapabilityUnavailableError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/service.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ConflictError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ConflictError",
+        "kind": "static_from",
+        "line": 14,
+        "name": "ConflictError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/service.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EasyUseAnimaError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:EasyUseAnimaError",
+        "kind": "static_from",
+        "line": 14,
+        "name": "EasyUseAnimaError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/service.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
         "bound_name": "SEED_CONTROL_FIXED",
         "branch_context": [],
         "classification": "internal",
@@ -32386,7 +32619,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".reservation",
@@ -32404,7 +32637,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_OVERFLOW_CLAMP",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_OVERFLOW_CLAMP",
         "optional": false,
         "requested": ".reservation",
@@ -32422,7 +32655,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_OVERFLOW_WRAP",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_OVERFLOW_WRAP",
         "optional": false,
         "requested": ".reservation",
@@ -32440,7 +32673,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_RESERVATION_CONTRACT_VERSION",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_RESERVATION_CONTRACT_VERSION",
         "optional": false,
         "requested": ".reservation",
@@ -32458,7 +32691,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SELECTION_CONCRETE",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SELECTION_CONCRETE",
         "optional": false,
         "requested": ".reservation",
@@ -32476,7 +32709,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SELECTION_DECREMENT",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SELECTION_DECREMENT",
         "optional": false,
         "requested": ".reservation",
@@ -32494,7 +32727,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SELECTION_INCREMENT",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SELECTION_INCREMENT",
         "optional": false,
         "requested": ".reservation",
@@ -32512,7 +32745,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SELECTION_RANDOMIZE",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SELECTION_RANDOMIZE",
         "optional": false,
         "requested": ".reservation",
@@ -32530,7 +32763,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SETTLEMENTS",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SETTLEMENTS",
         "optional": false,
         "requested": ".reservation",
@@ -32548,7 +32781,7 @@
         "conditional": false,
         "imported": ".reservation:SEED_SETTLEMENT_ACCEPTED",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SEED_SETTLEMENT_ACCEPTED",
         "optional": false,
         "requested": ".reservation",
@@ -32566,7 +32799,7 @@
         "conditional": false,
         "imported": ".reservation:SeedOverflowPolicy",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SeedOverflowPolicy",
         "optional": false,
         "requested": ".reservation",
@@ -32584,7 +32817,7 @@
         "conditional": false,
         "imported": ".reservation:SeedReservation",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SeedReservation",
         "optional": false,
         "requested": ".reservation",
@@ -32602,7 +32835,7 @@
         "conditional": false,
         "imported": ".reservation:SeedReservationContractError",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SeedReservationContractError",
         "optional": false,
         "requested": ".reservation",
@@ -32620,7 +32853,7 @@
         "conditional": false,
         "imported": ".reservation:SeedReservationRequest",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SeedReservationRequest",
         "optional": false,
         "requested": ".reservation",
@@ -32638,7 +32871,7 @@
         "conditional": false,
         "imported": ".reservation:SeedReservationSettlement",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "SeedReservationSettlement",
         "optional": false,
         "requested": ".reservation",
@@ -33446,6 +33679,96 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "CapabilityUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:CapabilityUnavailableError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "CapabilityUnavailableError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ConflictError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ConflictError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "ConflictError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EasyUseAnimaError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:EasyUseAnimaError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "EasyUseAnimaError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "UpstreamTimeoutError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:UpstreamTimeoutError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "UpstreamTimeoutError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py",
+        "target": "easyuse_anima/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ValidationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..errors:ValidationError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "ValidationError",
+        "optional": false,
+        "requested": "..errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py",
+        "target": "easyuse_anima/errors.py"
       },
       {
         "alias": null,
@@ -66922,6 +67245,10 @@
         "to": "easyuse_anima/aio/generation_values.py"
       },
       {
+        "from": "easyuse_anima/aio/generation_migrations.py",
+        "to": "easyuse_anima/errors.py"
+      },
+      {
         "from": "easyuse_anima/aio/generation_normalization.py",
         "to": "easyuse_anima/aio/generation_defaults.py"
       },
@@ -67368,6 +67695,10 @@
       {
         "from": "easyuse_anima/autocomplete/dataset.py",
         "to": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
+        "from": "easyuse_anima/autocomplete/index.py",
+        "to": "easyuse_anima/errors.py"
       },
       {
         "from": "easyuse_anima/autocomplete/index.py",
@@ -67974,6 +68305,10 @@
         "to": "easyuse_anima/profiles/repository.py"
       },
       {
+        "from": "easyuse_anima/profiles/contract.py",
+        "to": "easyuse_anima/errors.py"
+      },
+      {
         "from": "easyuse_anima/profiles/lora.py",
         "to": "easyuse_anima/infrastructure/filesystem/atomic_json.py"
       },
@@ -67995,7 +68330,15 @@
       },
       {
         "from": "easyuse_anima/profiles/mutation.py",
+        "to": "easyuse_anima/errors.py"
+      },
+      {
+        "from": "easyuse_anima/profiles/mutation.py",
         "to": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "from": "easyuse_anima/profiles/repository.py",
+        "to": "easyuse_anima/errors.py"
       },
       {
         "from": "easyuse_anima/profiles/repository.py",
@@ -68092,6 +68435,10 @@
       {
         "from": "easyuse_anima/prompt/anima/correction.py",
         "to": "easyuse_anima/prompt/anima/parser.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/anima/knowledge.py",
+        "to": "easyuse_anima/errors.py"
       },
       {
         "from": "easyuse_anima/prompt/anima/knowledge.py",
@@ -68290,8 +68637,20 @@
         "to": "easyuse_anima/wildcard/seed.py"
       },
       {
+        "from": "easyuse_anima/seed/execution_identity.py",
+        "to": "easyuse_anima/errors.py"
+      },
+      {
         "from": "easyuse_anima/seed/execution_session.py",
         "to": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "from": "easyuse_anima/seed/reservation.py",
+        "to": "easyuse_anima/errors.py"
+      },
+      {
+        "from": "easyuse_anima/seed/service.py",
+        "to": "easyuse_anima/errors.py"
       },
       {
         "from": "easyuse_anima/seed/service.py",
@@ -68324,6 +68683,10 @@
       {
         "from": "easyuse_anima/settings/service.py",
         "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/translation/contracts.py",
+        "to": "easyuse_anima/errors.py"
       },
       {
         "from": "easyuse_anima/translation/ports.py",
@@ -69248,6 +69611,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/errors.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/image/__init__.py"
         ]
       },
@@ -69807,7 +70176,7 @@
     ]
   },
   "inventory": {
-    "module_count": 175,
+    "module_count": 176,
     "modules": [
       {
         "is_package": true,
@@ -70087,9 +70456,9 @@
       },
       {
         "is_package": false,
-        "loc": 244,
+        "loc": 245,
         "module": "easyuse_anima.aio.generation_migrations",
-        "normalized_git_blob_sha1": "d13d009205b63f37f36c5a37e489cd3924042ede",
+        "normalized_git_blob_sha1": "1d0cd29d8937e58e95383e89fd7540ed02d4c5c4",
         "path": "easyuse_anima/aio/generation_migrations.py",
         "top_level": {
           "class_count": 3,
@@ -70689,7 +71058,7 @@
         "is_package": false,
         "loc": 684,
         "module": "easyuse_anima.autocomplete.index",
-        "normalized_git_blob_sha1": "d16540946907a69522ccc027dfc13eaafd6f4b41",
+        "normalized_git_blob_sha1": "fa5f5b8ce47e3c4f4f64a017beae8ecb7c350954",
         "path": "easyuse_anima/autocomplete/index.py",
         "top_level": {
           "class_count": 8,
@@ -70778,6 +71147,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 5,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 42,
+        "module": "easyuse_anima.errors",
+        "normalized_git_blob_sha1": "1d56d0f371b698329361069804cc7c826d30e64c",
+        "path": "easyuse_anima/errors.py",
+        "top_level": {
+          "class_count": 7,
+          "function_count": 0,
           "global_count": 1
         }
       },
@@ -71227,9 +71608,9 @@
       },
       {
         "is_package": false,
-        "loc": 191,
+        "loc": 192,
         "module": "easyuse_anima.profiles.contract",
-        "normalized_git_blob_sha1": "9e2b528291c85e34a207d2d77395c607102978b2",
+        "normalized_git_blob_sha1": "6a6e6899abdba5bc74e0afbae0aaf28c09ea7bd7",
         "path": "easyuse_anima/profiles/contract.py",
         "top_level": {
           "class_count": 1,
@@ -71251,9 +71632,9 @@
       },
       {
         "is_package": false,
-        "loc": 150,
+        "loc": 151,
         "module": "easyuse_anima.profiles.mutation",
-        "normalized_git_blob_sha1": "71cb4340b6eec8c1a25e8f4ee311e97bc7ae89b2",
+        "normalized_git_blob_sha1": "d22dc126f4b1b5ff04c49e21ed7ad57a79654672",
         "path": "easyuse_anima/profiles/mutation.py",
         "top_level": {
           "class_count": 5,
@@ -71263,9 +71644,9 @@
       },
       {
         "is_package": false,
-        "loc": 111,
+        "loc": 112,
         "module": "easyuse_anima.profiles.repository",
-        "normalized_git_blob_sha1": "ee5775d083714330156fb417157e8cb91725cdea",
+        "normalized_git_blob_sha1": "c8fc846e51d98da409f7cb0469f94a8ecfc8b3ee",
         "path": "easyuse_anima/profiles/repository.py",
         "top_level": {
           "class_count": 2,
@@ -71323,9 +71704,9 @@
       },
       {
         "is_package": false,
-        "loc": 46,
+        "loc": 47,
         "module": "easyuse_anima.prompt.anima.knowledge",
-        "normalized_git_blob_sha1": "98cb99d4f8920f4e11aea2a397852c9022265ceb",
+        "normalized_git_blob_sha1": "2c667cd958c2b892decac7ef0be668856d6f2a21",
         "path": "easyuse_anima/prompt/anima/knowledge.py",
         "top_level": {
           "class_count": 2,
@@ -71515,9 +71896,9 @@
       },
       {
         "is_package": false,
-        "loc": 212,
+        "loc": 214,
         "module": "easyuse_anima.seed.execution_identity",
-        "normalized_git_blob_sha1": "4f09455dd43382096ea3e87946f793c16bdba870",
+        "normalized_git_blob_sha1": "6c1ae95e6f6bb899e37287cf28650cadf7c1db8d",
         "path": "easyuse_anima/seed/execution_identity.py",
         "top_level": {
           "class_count": 3,
@@ -71539,9 +71920,9 @@
       },
       {
         "is_package": false,
-        "loc": 349,
+        "loc": 351,
         "module": "easyuse_anima.seed.reservation",
-        "normalized_git_blob_sha1": "6b3d2d9a96a3969b26088471c9f0ba1fba45806b",
+        "normalized_git_blob_sha1": "f2e72b8aeb35950607545cb4b13c95ed24499536",
         "path": "easyuse_anima/seed/reservation.py",
         "top_level": {
           "class_count": 4,
@@ -71551,9 +71932,9 @@
       },
       {
         "is_package": false,
-        "loc": 501,
+        "loc": 505,
         "module": "easyuse_anima.seed.service",
-        "normalized_git_blob_sha1": "b8ef428d579f3f65984d505a7937f33153c94161",
+        "normalized_git_blob_sha1": "6203014bbd6305a767de3570d31a70218306344f",
         "path": "easyuse_anima/seed/service.py",
         "top_level": {
           "class_count": 7,
@@ -71623,9 +72004,9 @@
       },
       {
         "is_package": false,
-        "loc": 135,
+        "loc": 146,
         "module": "easyuse_anima.translation.contracts",
-        "normalized_git_blob_sha1": "4655be5fb22056d89fef34216a30067eccacad12",
+        "normalized_git_blob_sha1": "d48643fe74a034e1498cb5f661ac07c2aea37803",
         "path": "easyuse_anima/translation/contracts.py",
         "top_level": {
           "class_count": 12,
@@ -87625,6 +88006,17 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/errors.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/image/detailer.py"
       },
       {
@@ -92778,6 +93170,7 @@
       "easyuse_anima/common/__init__.py",
       "easyuse_anima/common/serialization.py",
       "easyuse_anima/common/values.py",
+      "easyuse_anima/errors.py",
       "easyuse_anima/image/__init__.py",
       "easyuse_anima/image/detailer.py",
       "easyuse_anima/image/geometry.py",
@@ -92955,6 +93348,7 @@
       "easyuse_anima/common/__init__.py",
       "easyuse_anima/common/serialization.py",
       "easyuse_anima/common/values.py",
+      "easyuse_anima/errors.py",
       "easyuse_anima/image/__init__.py",
       "easyuse_anima/image/detailer.py",
       "easyuse_anima/image/geometry.py",
@@ -93663,7 +94057,7 @@
         "column": 1,
         "context": "decorator:AIOGenerationMigrationStep",
         "kind": "import_time_call",
-        "line": 63,
+        "line": 64,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93672,7 +94066,7 @@
         "column": 1,
         "context": "decorator:AIOGenerationMigrationRegistry",
         "kind": "import_time_call",
-        "line": 86,
+        "line": 87,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93681,7 +94075,7 @@
         "column": 4,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 178,
+        "line": 179,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93690,7 +94084,7 @@
         "column": 4,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 178,
+        "line": 179,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93699,7 +94093,7 @@
         "column": 4,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 178,
+        "line": 179,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93708,7 +94102,7 @@
         "column": 4,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 178,
+        "line": 179,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93717,7 +94111,7 @@
         "column": 8,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 180,
+        "line": 181,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93726,7 +94120,7 @@
         "column": 8,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 185,
+        "line": 186,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -93735,7 +94129,7 @@
         "column": 8,
         "context": "assign:AIO_GENERATION_MIGRATION_REGISTRY",
         "kind": "import_time_call",
-        "line": 190,
+        "line": 191,
         "module": "easyuse_anima/aio/generation_migrations.py",
         "scope": "<module>"
       },
@@ -94437,7 +94831,7 @@
         "column": 23,
         "context": "assign:PROFILE_ID_NAMESPACE",
         "kind": "import_time_call",
-        "line": 11,
+        "line": 12,
         "module": "easyuse_anima/profiles/contract.py",
         "scope": "<module>"
       },
@@ -94446,7 +94840,7 @@
         "column": 17,
         "context": "assign:_PROFILE_KINDS",
         "kind": "import_time_call",
-        "line": 13,
+        "line": 14,
         "module": "easyuse_anima/profiles/contract.py",
         "scope": "<module>"
       },
@@ -94455,7 +94849,7 @@
         "column": 19,
         "context": "assign:_ENVELOPE_FIELDS",
         "kind": "import_time_call",
-        "line": 14,
+        "line": 15,
         "module": "easyuse_anima/profiles/contract.py",
         "scope": "<module>"
       },
@@ -94464,7 +94858,7 @@
         "column": 31,
         "context": "assign:PROFILE_MUTATION_COORDINATOR",
         "kind": "import_time_call",
-        "line": 147,
+        "line": 148,
         "module": "easyuse_anima/profiles/mutation.py",
         "scope": "<module>"
       },
@@ -94473,16 +94867,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 23,
-        "module": "easyuse_anima/profiles/repository.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "range",
-        "column": 33,
-        "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
-        "kind": "import_time_call",
-        "line": 29,
+        "line": 24,
         "module": "easyuse_anima/profiles/repository.py",
         "scope": "<module>"
       },
@@ -94496,11 +94881,20 @@
         "scope": "<module>"
       },
       {
+        "callee": "range",
+        "column": 33,
+        "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
+        "kind": "import_time_call",
+        "line": 31,
+        "module": "easyuse_anima/profiles/repository.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "dataclass",
         "column": 1,
         "context": "decorator:_ProfileRepository",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 41,
         "module": "easyuse_anima/profiles/repository.py",
         "scope": "<module>"
       },
@@ -94761,7 +95155,7 @@
         "column": 1,
         "context": "decorator:SeedExecutionContext",
         "kind": "import_time_call",
-        "line": 73,
+        "line": 75,
         "module": "easyuse_anima/seed/execution_identity.py",
         "scope": "<module>"
       },
@@ -94770,7 +95164,7 @@
         "column": 1,
         "context": "decorator:SeedExecutionIdentity",
         "kind": "import_time_call",
-        "line": 100,
+        "line": 102,
         "module": "easyuse_anima/seed/execution_identity.py",
         "scope": "<module>"
       },
@@ -94779,7 +95173,7 @@
         "column": 18,
         "context": "assign:SEED_SELECTIONS",
         "kind": "import_time_call",
-        "line": 18,
+        "line": 20,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94788,7 +95182,7 @@
         "column": 16,
         "context": "assign:SEED_CONTROLS",
         "kind": "import_time_call",
-        "line": 28,
+        "line": 30,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94797,7 +95191,7 @@
         "column": 25,
         "context": "assign:SEED_OVERFLOW_POLICIES",
         "kind": "import_time_call",
-        "line": 39,
+        "line": 41,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94806,7 +95200,7 @@
         "column": 19,
         "context": "assign:SEED_SETTLEMENTS",
         "kind": "import_time_call",
-        "line": 49,
+        "line": 51,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94815,7 +95209,7 @@
         "column": 1,
         "context": "decorator:SeedReservationRequest",
         "kind": "import_time_call",
-        "line": 131,
+        "line": 133,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94824,7 +95218,7 @@
         "column": 1,
         "context": "decorator:SeedReservation",
         "kind": "import_time_call",
-        "line": 207,
+        "line": 209,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -94833,7 +95227,7 @@
         "column": 1,
         "context": "decorator:_ReservationRecord",
         "kind": "import_time_call",
-        "line": 89,
+        "line": 93,
         "module": "easyuse_anima/seed/service.py",
         "scope": "<module>"
       },
@@ -94842,7 +95236,7 @@
         "column": 1,
         "context": "decorator:_StreamState",
         "kind": "import_time_call",
-        "line": 101,
+        "line": 105,
         "module": "easyuse_anima/seed/service.py",
         "scope": "<module>"
       },
@@ -94851,7 +95245,7 @@
         "column": 46,
         "context": "assign:reservations",
         "kind": "import_time_call",
-        "line": 109,
+        "line": 113,
         "module": "easyuse_anima/seed/service.py",
         "scope": "_StreamState"
       },
@@ -94860,7 +95254,7 @@
         "column": 1,
         "context": "decorator:_AcceptedRecord",
         "kind": "import_time_call",
-        "line": 114,
+        "line": 118,
         "module": "easyuse_anima/seed/service.py",
         "scope": "<module>"
       },
@@ -94878,7 +95272,7 @@
         "column": 1,
         "context": "decorator:PromptTranslationSettings",
         "kind": "import_time_call",
-        "line": 27,
+        "line": 35,
         "module": "easyuse_anima/translation/contracts.py",
         "scope": "<module>"
       },
@@ -95281,7 +95675,7 @@
       },
       {
         "kind": "set",
-        "line": 24,
+        "line": 25,
         "module": "easyuse_anima/profiles/repository.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
@@ -95389,7 +95783,7 @@
       },
       {
         "kind": "dict",
-        "line": 79,
+        "line": 81,
         "module": "easyuse_anima/seed/reservation.py",
         "name": "_LEGACY_SELECTION_BY_SEED"
       },
@@ -95461,7 +95855,7 @@
       },
       {
         "kind": "set",
-        "line": 10,
+        "line": 18,
         "module": "easyuse_anima/translation/contracts.py",
         "name": "PROMPT_TRANSLATION_PROVIDERS"
       },

--- a/tests/fixtures/python_feature_error_contract.v1.json
+++ b/tests/fixtures/python_feature_error_contract.v1.json
@@ -1,5 +1,5 @@
 {
-  "base_sha": "e5e0329cd64afa9894d631f9b6baa6514a81ab48",
+  "base_sha": "878a86f739a37a000a56b9e76ee2179aa86271f1",
   "canonical_taxonomy": {
     "categories": [
       {
@@ -45,7 +45,7 @@
   },
   "classification": "Contract",
   "current_authority": {
-    "canonical_module_exists": false,
+    "canonical_module_exists": true,
     "profile_mapper_reads": [
       "mutation_error.status",
       "mutation_error.code",
@@ -75,6 +75,7 @@
     "docs/architecture/python-backend.md",
     "docs/architecture/python-feature-error-taxonomy-contract.md",
     "docs/architecture/python-typed-boundary-f01-audit.md",
+    "easyuse_anima/errors.py",
     "easyuse_anima/api/errors.py",
     "easyuse_anima/api/responses.py",
     "easyuse_anima/api/routes/translation.py",
@@ -108,6 +109,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ValidationError",
         "ValueError"
       ],
       "module": "easyuse_anima.profiles.contract",
@@ -121,6 +123,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ValidationError",
         "ValueError"
       ],
       "module": "easyuse_anima.profiles.repository",
@@ -134,6 +137,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ConflictError",
         "ValueError"
       ],
       "module": "easyuse_anima.profiles.mutation",
@@ -147,7 +151,8 @@
         "ValueError"
       ],
       "current_direct_bases": [
-        "ProfileMutationError"
+        "ProfileMutationError",
+        "ValidationError"
       ],
       "module": "easyuse_anima.profiles.mutation",
       "name": "ProfilePreconditionRequiredError",
@@ -186,6 +191,7 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
+        "CapabilityUnavailableError",
         "RuntimeError"
       ],
       "module": "easyuse_anima.autocomplete.index",
@@ -199,6 +205,7 @@
         "FileNotFoundError"
       ],
       "current_direct_bases": [
+        "NotFoundError",
         "FileNotFoundError"
       ],
       "module": "easyuse_anima.prompt.anima.knowledge",
@@ -212,6 +219,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ValidationError",
         "ValueError"
       ],
       "module": "easyuse_anima.aio.generation_migrations",
@@ -225,6 +233,7 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
+        "EasyUseAnimaError",
         "RuntimeError"
       ],
       "module": "easyuse_anima.seed.service",
@@ -238,7 +247,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "SeedReservationServiceError"
+        "SeedReservationServiceError",
+        "ConflictError"
       ],
       "module": "easyuse_anima.seed.service",
       "name": "SeedReservationConflictError",
@@ -251,7 +261,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "SeedReservationServiceError"
+        "SeedReservationServiceError",
+        "CapabilityUnavailableError"
       ],
       "module": "easyuse_anima.seed.service",
       "name": "SeedReservationCapacityError",
@@ -264,6 +275,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ValidationError",
         "ValueError"
       ],
       "module": "easyuse_anima.seed.execution_identity",
@@ -277,6 +289,7 @@
         "ValueError"
       ],
       "current_direct_bases": [
+        "ValidationError",
         "ValueError"
       ],
       "module": "easyuse_anima.seed.reservation",
@@ -290,6 +303,7 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
+        "EasyUseAnimaError",
         "RuntimeError"
       ],
       "module": "easyuse_anima.translation.contracts",
@@ -303,7 +317,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "PromptTranslationError"
+        "PromptTranslationError",
+        "ValidationError"
       ],
       "module": "easyuse_anima.translation.contracts",
       "name": "PromptTranslationLimitError",
@@ -355,7 +370,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "PromptTranslationError"
+        "PromptTranslationError",
+        "CapabilityUnavailableError"
       ],
       "module": "easyuse_anima.translation.contracts",
       "name": "TranslationProviderUnavailableError",
@@ -368,7 +384,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "PromptTranslationError"
+        "PromptTranslationError",
+        "UpstreamTimeoutError"
       ],
       "module": "easyuse_anima.translation.contracts",
       "name": "TranslationTimeoutError",
@@ -394,7 +411,8 @@
         "RuntimeError"
       ],
       "current_direct_bases": [
-        "PromptTranslationError"
+        "PromptTranslationError",
+        "ConflictError"
       ],
       "module": "easyuse_anima.translation.contracts",
       "name": "TranslationBusyError",
@@ -667,7 +685,7 @@
     "aio-migration-failure-messages",
     "seed-conflict-capacity-and-contract-behavior"
   ],
-  "production_changes": 0,
+  "production_changes": 11,
   "schema_version": 1,
   "stop_conditions": [
     "public-or-root-export-change",

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 175)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 175)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 175)
+        self.assertEqual(report["inventory"]["module_count"], 176)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 176)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 176)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_feature_error_contract.py
+++ b/tests/test_python_feature_error_contract.py
@@ -79,10 +79,10 @@ class PythonFeatureErrorContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(self.fixture["production_changes"], 11)
         self.assertEqual(
             self.fixture["base_sha"],
-            "e5e0329cd64afa9894d631f9b6baa6514a81ab48",
+            "878a86f739a37a000a56b9e76ee2179aa86271f1",
         )
         self.assertTrue(CONTRACT_DOC.is_file())
         for source in self.fixture["evidence"]:
@@ -108,6 +108,11 @@ class PythonFeatureErrorContractTests(unittest.TestCase):
         self.assertEqual(
             taxonomy["module_exports"],
             [item["name"] for item in categories],
+        )
+        taxonomy_module = importlib.import_module("easyuse_anima.errors")
+        self.assertEqual(
+            list(taxonomy_module.__all__),
+            taxonomy["module_exports"],
         )
         self.assertEqual(categories[0]["parent"], "Exception")
         self.assertEqual(
@@ -141,6 +146,7 @@ class PythonFeatureErrorContractTests(unittest.TestCase):
             item["name"]
             for item in self.fixture["canonical_taxonomy"]["categories"]
         }
+        taxonomy_module = importlib.import_module("easyuse_anima.errors")
         for item in self.fixture["feature_errors"]:
             with self.subTest(error=item["name"]):
                 class_def = _class_def(item["source"], item["name"])
@@ -159,6 +165,13 @@ class PythonFeatureErrorContractTests(unittest.TestCase):
                         f"{item['name']} no longer catches as {builtin_name}",
                     )
                 self.assertIn(item["target_category"], category_names)
+                self.assertTrue(
+                    issubclass(
+                        error_type,
+                        getattr(taxonomy_module, item["target_category"]),
+                    ),
+                    f"{item['name']} lacks {item['target_category']}",
+                )
 
     def test_http_mapping_is_exhaustive_and_current_payloads_are_frozen(self):
         http_errors = {

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_MODULES = (
     "easyuse_anima",
     "easyuse_anima.bootstrap",
+    "easyuse_anima.errors",
     "easyuse_anima.workflow",
     "easyuse_anima.aio",
     "easyuse_anima.aio.conditioning",
@@ -212,6 +213,15 @@ print(json.dumps({{
         expected_all[PACKAGE_MODULES.index("easyuse_anima.bootstrap")] = [
             "initialize",
             "shutdown",
+        ]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.errors")] = [
+            "EasyUseAnimaError",
+            "ValidationError",
+            "ConflictError",
+            "NotFoundError",
+            "CapabilityUnavailableError",
+            "UpstreamTimeoutError",
+            "StorageError",
         ]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.api.errors")] = [
             "ApiContractError"


### PR DESCRIPTION
## 목적과 변경 경계

Issue #563의 F-02f를 구현합니다. 공통 feature error category를 추가하고 기존 concrete exception에 additive inheritance만 부여합니다.

Base: `878a86f739a37a000a56b9e76ee2179aa86271f1`
Head: `b79885326e3a69af931d3f72288cac718857f214`

## 주요 변경

- `easyuse_anima/errors.py`: 7개 canonical category와 explicit `__all__`
- profile, Autocomplete, Prompt knowledge, AiO migration, translation, seed 예외의 category ancestry
- concrete class module/name/object identity, 기존 feature subclass graph와 built-in catch 호환 유지
- taxonomy/package/analyzer executable contract 갱신
- F-02f COMPLETE, F-02g authoritative API mapping READY로 roadmap checkpoint 전환

## 보존 계약

- exception constructor, metadata, message, details, reason
- profile/translation HTTP payload와 dynamic profile monkeypatch seam
- root aliases와 public/root exports
- route/runtime lifecycle 및 feature behavior

F-02g API mapping cutover는 포함하지 않습니다.

## 검증

Focused:
- taxonomy 8
- profile API 3 / translation API 12 / translation runtime contract 7
- Autocomplete 37 / Prompt compatibility 51
- profile contract/storage 64
- AiO migration 8
- seed contract/service/identity 47
- package 1 / Pyright 11 / analyzer 18 / import-boundary 16
- changed-file Python syntax, JSON, Ruff 신규 오류 없음, git diff check

Final SHA official full 1회:
- Python unittest 1,450 PASS
- frontend 120 files PASS
- Pyright 159 files, 기존 14 errors 증가 없음
- import boundary 11 groups, 0 violations
- git diff check PASS

Package/live는 이 경계에서 촉발되지 않아 미실행했습니다.

## 위험과 rollback

변경은 additive inheritance라 rollback은 이 PR revert로 한정됩니다. API mapping authority는 기존 상태이며 F-02g에서 별도 전환합니다.

## Next

F-02g authoritative profile/translation API mappings, 이후 F-02h completion audit.

Refs #563