### PR TITLE
docs: G-04 공개 API snapshot coverage 감사 완료

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,11 +16,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   production-import, release-window, consumer, rollback, or breaking-change gates.
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
   owns the current queue.
-- First READY task: Issue [#563](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/563)
-  / F-02g authoritative profile/translation API mappings.
-- After Phase F handoff, Issue
-  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
-  owns G-04 public API snapshot, G-05 size/complexity ratchet, and G-06 test ownership.
+- Phase F and Issue
+  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-04 public
+  API snapshot coverage are complete; existing deterministic owners required no G-04B
+  fixture. Issue #188 continues to own G-05 size/complexity ratchet and G-06 test
+  ownership.
+- First READY task: Issue
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186) / P-WC-01
+  wildcard pure-shim feasibility Contract.
 - Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
   remains the retained compatibility ledger. It owns pre-retirement feasibility and
   later D-14 decisions, not an immediately executable deletion task.
@@ -38,11 +41,11 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE affected settings/profile/workflow-row re-audit
   -> COMPLETE F-02e common feature error taxonomy Contract
   -> COMPLETE F-02f canonical categories and feature inheritance
-  -> READY F-02g authoritative profile/translation API mappings
-  -> F-02h error-row and Phase F completion audit
-  -> G-04A public API snapshot coverage audit
-  -> optional G-04B gap
-  -> Wildcard pure-shim feasibility Contract
+  -> COMPLETE F-02g authoritative profile/translation API mappings
+  -> COMPLETE F-02h error-row and Phase F completion audit
+  -> COMPLETE G-04A public API snapshot coverage audit
+  -> NOT REQUIRED G-04B gap
+  -> READY Wildcard pure-shim feasibility Contract
   -> API production-facade feasibility Contract
   -> approved internal-consumer Moves only
   -> G-05 size ratchet
@@ -79,6 +82,9 @@ of architectural success by itself.
 - [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md):
   current Phase F typed-boundary inventory, classifications, G-04A handoff surface,
   and the selected smallest F-02 task card.
+- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
+  completed public-surface owner map, root-name classifications, archive-closure
+  evidence, and the no-G-04B decision.
 - [`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md):
   executable error inventory, canonical categories, preserved compatibility, adapter
   authority decision, and ordered F-02f/F-02g/F-02h task boundaries.

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #188 / G-04A public API snapshot coverage audit.
+- Active first task: Issue #186 / P-WC-01 wildcard pure-shim feasibility Contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -53,7 +53,7 @@ ADR-002 result when evidence is absent or ambiguous.
 
 ### Remaining global roadmap work
 
-- G-04 public API snapshot completion is not recorded.
+- G-04 public API snapshot coverage is complete; no G-04B gate was required.
 - G-05 size/complexity growth ratchet is not implemented as a blocking incremental gate.
 - G-06 canonical test ownership is not completed.
 - `api.py` and `wildcard_engine.py` have not reached a proven pure-shim form that can
@@ -76,9 +76,9 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE F-02f canonical categories and feature inheritance #563
   -> COMPLETE F-02g authoritative profile/translation API mappings #563 / PR #577
   -> COMPLETE F-02h affected error-row re-audit and Phase F close #563
-  -> READY G-04A public API snapshot coverage audit            #188
-  -> OPTIONAL G-04B  minimal missing public-surface gate
-  -> P-WC-01  wildcard pure-shim feasibility Contract         #186
+  -> COMPLETE G-04A public API snapshot coverage audit         #188
+  -> NOT REQUIRED G-04B minimal missing public-surface gate
+  -> READY P-WC-01 wildcard pure-shim feasibility Contract     #186
   -> OPTIONAL P-WC-02  internal consumer/facade Move
   -> P-API-01 API production-facade feasibility Contract      #186
   -> OPTIONAL P-API-02 canonical production-entry Move
@@ -199,6 +199,18 @@ Exit:
 
 - existing gates already complete G-04: record completion without a synthetic rewrite;
 - gaps exist: create one bounded G-04B Contract/tool PR.
+
+Audit result:
+
+- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md) maps every
+  required surface to its existing deterministic owner;
+- the three permanent root entrypoint names, 18 supported mapped-node identities,
+  explicit root/canonical `__all__`, F-01 schema/result/error boundaries, and shipped
+  archive closure are already covered;
+- private/transitional bindings remain excluded or compatibility-ledger-owned, and no
+  unsupported name is promoted;
+- G-04A is complete without a synthetic fixture, so G-04B is not required;
+- the next READY task is Issue #186 / P-WC-01.
 
 ## 5. Pre-retirement preparation without removal
 
@@ -374,32 +386,31 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #188 / G-04A only from latest origin/dev after F-02h merges.
+Start Issue #186 / P-WC-01 only from latest origin/dev after G-04A merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- this document's G-04A and validation sections
-- python-typed-boundary-f01-audit.md G-04A handoff surface
-- Issue #188 latest checkpoint
-- python_compatibility_surface.v1.json and its direct owner
-- node/workflow, API/schema, package-skeleton, and Registry archive-closure contracts
+- this document's P-WC-01 and validation sections
+- Issue #186 latest P-WC-01 checkpoint
+- wildcard_engine.py and its direct api.py/nodes.py/canonical callers
+- direct wildcard compatibility, identity, determinism, package, and import owners
 
-Do not read all historical D/E PRs and do not restart D-14 removal.
+Do not read all historical D/E PRs and do not start D-14 removal.
 
-Audit the existing supported public surface against the current compatibility,
-node/workflow, API/schema, package, and archive-closure fixtures. Map existing evidence
-instead of creating a duplicate manifest. Classify each required public surface as
-covered, intentionally private/compatibility-only, or the smallest exact G-04B gap.
-Do not remove or deprecate a public/root symbol during the audit.
+Audit whether root wildcard_engine.py can become a pure compatibility shim while
+preserving call-time snapshot/source/build seams, deterministic NumPy seed, expansion
+budget, errors, object identity, and flat-import compatibility. Produce only a
+production-free FEASIBLE or RETAIN contract with exact evidence and a bounded Move
+card when feasible. Do not implement the Move in P-WC-01.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
-Run official full once on the final test/tool SHA when the audit changes an executable
-gate or fixture.
+Run official full once on the final test/tool SHA when the contract changes an
+executable gate or fixture.
 Package/live are not triggered.
 
-Push a dev-targeted Draft PR. If coverage is complete, close G-04A and select the next
-roadmap task. If a gap exists, emit only the smallest G-04B Contract/gate card.
+Push a dev-targeted Draft PR. If FEASIBLE, select only the bounded P-WC-02 Move. If
+RETAIN, record the exact blocker and next evidence trigger before selecting P-API-01.
 
 Do not change production behavior, public/root exports, API/node payloads, migration
 semantics, root files, deprecation warnings/telemetry, release/tag, or Registry state.

--- a/docs/architecture/python-public-api-g04a-audit.md
+++ b/docs/architecture/python-public-api-g04a-audit.md
@@ -1,0 +1,62 @@
+# Python Public API G-04A Coverage Audit
+
+## Decision
+
+G-04 is complete with the existing deterministic owners. No G-04B fixture or tool is
+required.
+
+The repository already separates three different contracts that a single replacement
+snapshot would blur:
+
+- the root compatibility and mapped-node surface;
+- feature-owned serialized schema, result, and error contracts;
+- the shipped Python archive and runtime import closure.
+
+This audit records how those owners compose. It does not copy their node definitions,
+payload schemas, or import graphs into another manifest.
+
+## Required surface
+
+| Required surface | Classification | Existing owner and direct evidence |
+| --- | --- | --- |
+| Permanent package entrypoint | covered / permanent | Root `__init__.py` declares exactly `NODE_CLASS_MAPPINGS`, `NODE_DISPLAY_NAME_MAPPINGS`, and `WEB_DIRECTORY`. `python_compatibility_surface.v1.json` and `PythonCompatibilitySurfaceTests` freeze the three-name `__all__` and their permanent-entrypoint classification. |
+| Mapped node classes | covered / supported | `node_contracts_0_5_2.json`, `PublicNodeContractTests`, and the compatibility-surface fixture freeze the 18 mapped classes, display names, public root re-exports, and exact root/canonical object identity. The two intentionally unmapped implementation classes remain private/transitional and are not promoted to supported nodes. |
+| Root and canonical `__all__` | covered | `PythonCompatibilitySurfaceTests` owns the root entrypoint and public node aliases. `PythonPackageSkeletonTests` imports the canonical package modules in isolation and checks every declared `__all__`, including the intentionally empty package surface and the explicit feature-module exports, without host imports or I/O side effects. `ApiContractCompatibilityTests` separately freezes the root/canonical API-contract identity and exports. |
+| Settings, profile, and workflow schemas | covered / supported serialized boundary | The settings projection and long-text response owners, profile v2 envelope/list/mutation contracts, legacy additive-read tests, and the versioned node/workflow fixtures freeze the externally serialized shapes. Raw legacy/future workflow input remains the intentional migration/adapter boundary recorded by F-01. |
+| API request, result, error, and correlation | covered / supported serialized boundary | API request/schema tests freeze parsing and response envelopes; profile and translation route tests freeze concrete mappings and the two named compatibility seams; request-correlation tests freeze `X-Request-ID`. The root/canonical API compatibility test preserves object identity without duplicating the payload schema. |
+| Prompt, Wildcard, and Autocomplete | covered / supported serialized boundary | Prompt correction and Prompt Data owner tests freeze the typed models and serialized Advanced fields. Wildcard model/service/API tests freeze expansion results and list/source signatures. Autocomplete dataset/index/search/classification and API tests freeze source, status, search, and classification results. Raw host/workflow values stay intentional adapters. |
+| AiO settings, request, state, and result | covered / supported serialized boundary | The v1-v4 settings and surface-coverage fixtures, `AIOGenerationConfigTests`, migration tests, and `AIOStagePipelineContractTests` freeze settings v4, typed request/state/stage ownership, migrations, and final serialization. ComfyUI model/tensor objects remain host adapter values. |
+| Common feature errors | covered / supported semantic boundary | `python_feature_error_contract.v1.json` and `PythonFeatureErrorContractTests` cover the seven categories, 24 feature errors, 15 HTTP mappings, two explicit exclusions, and the named profile/translation compatibility seams. |
+| Packed canonical/shim closure | covered | The generated backend analyzer fixture owns the shipped Python runtime-import closure and records no missing or unreachable shipped modules. `RegistryScannerSafetyTests` proves the package skeleton and API/autocomplete runtime files are tracked and not excluded by `.comfyignore`; package-skeleton imports prove the canonical modules load directly. Existing final package evidence is reused because G-04A changes no package or import surface. |
+
+## Root-name classification
+
+The executable compatibility fixture remains the single inventory owner:
+
+- **permanent:** the three ComfyUI root entrypoint names;
+- **supported:** the 18 mapped public node-class aliases with exact canonical identity;
+- **transitional:** the fixture-owned compatibility names and the compatibility-ledger
+  shims retained by current production, release-window, consumer, or rollback gates;
+- **unsupported:** no additional root name is admitted to the supported surface; private
+  implementation bindings and the two unmapped classes remain excluded.
+
+This classification does not authorize deletion or deprecation. Retirement remains an
+Issue #186 / ADR-002 decision after the relevant evidence gates.
+
+## Gap assessment
+
+There is no uncovered public surface that belongs in a new machine-readable owner.
+Every F-01 handoff row maps to an existing deterministic fixture or direct contract,
+and the archive closure is already analyzer-owned. A G-04B snapshot would only copy
+schemas and identities whose current owners are more direct.
+
+Result:
+
+```text
+G-04A COMPLETE
+G-04B NOT REQUIRED
+next: P-WC-01 wildcard pure-shim feasibility Contract
+```
+
+No production file, public export, payload, migration, package, release, or Registry
+state changes in this audit.


### PR DESCRIPTION
## 목적과 변경 경계

Issue #188 / G-04A에서 기존 공개면 fixture와 direct owner를 감사했습니다. 새 machine-readable snapshot을 추가하지 않고, 이미 존재하는 compatibility/node/schema/API/package/analyzer owner의 조합이 G-04 요구면을 완결한다는 결론을 기록합니다.

Base: `489130129d0d43d84a5ad3f944bc8631ffbe62a6`
Head: `687773644f55558fa1c8052f203087b9fba55553`

## 주요 변경

- `python-public-api-g04a-audit.md`에 required surface와 기존 deterministic owner를 매핑
- root 이름을 permanent/supported/transitional/unsupported로 분류
- G-04A COMPLETE, G-04B NOT REQUIRED 결론 기록
- roadmap의 다음 READY task를 Issue #186 / P-WC-01로 전환
- architecture index의 완료/현재 queue 갱신

Production 코드, fixture, test/tool, 공개 export, payload, migration, package, release, Registry 상태는 변경하지 않습니다.

## 검증

Focused unittest는 한 runner당 한 target으로 실행했습니다.

- PythonCompatibilitySurfaceTests: 19 PASS
- PublicNodeContractTests: 6 PASS
- PythonPackageSkeletonTests: 1 PASS
- ApiContractCompatibilityTests: 3 PASS
- PythonFeatureErrorContractTests: 9 PASS
- AIOGenerationConfigTests: 13 PASS
- AIOStagePipelineContractTests: 6 PASS
- RegistryScannerSafetyTests: 8 PASS
- `git diff --check`: PASS

문서만 변경했고 executable gate/fixture가 바뀌지 않아 roadmap 규칙에 따라 official full/package/live는 재실행하지 않았습니다.

## 남은 위험과 rollback

새 snapshot을 추가하지 않았기 때문에 기존 owner들의 분산 구조는 유지됩니다. 감사 문서가 그 조합을 명시하며, 각 owner 자체는 기존 executable test로 계속 검증됩니다. rollback은 이 문서 커밋의 revert입니다.

## Next

검토와 squash merge 후 Issue #188에 G-04A 완료를 기록하고, latest `origin/dev`에서 Issue #186 / P-WC-01 production-free feasibility Contract를 시작합니다.