### PR TITLE
docs: P-WC-01 Wildcard facade Move 결정

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,9 +21,11 @@ then only the active task section, owning Issue, direct source, and direct tests
   API snapshot coverage are complete; existing deterministic owners required no G-04B
   fixture. Issue #188 continues to own G-05 size/complexity ratchet and G-06 test
   ownership.
+- P-WC-01 found the Wildcard facade direct-shim conversion feasible with the existing
+  canonical service owner.
 - First READY task: Issue
-  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186) / P-WC-01
-  wildcard pure-shim feasibility Contract.
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186) / P-WC-02
+  wildcard internal-consumer and facade Move.
 - Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
   remains the retained compatibility ledger. It owns pre-retirement feasibility and
   later D-14 decisions, not an immediately executable deletion task.
@@ -45,7 +47,8 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE F-02h error-row and Phase F completion audit
   -> COMPLETE G-04A public API snapshot coverage audit
   -> NOT REQUIRED G-04B gap
-  -> READY Wildcard pure-shim feasibility Contract
+  -> COMPLETE Wildcard pure-shim feasibility Contract
+  -> READY Wildcard internal-consumer and facade Move
   -> API production-facade feasibility Contract
   -> approved internal-consumer Moves only
   -> G-05 size ratchet
@@ -85,6 +88,9 @@ of architectural success by itself.
 - [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
   completed public-surface owner map, root-name classifications, archive-closure
   evidence, and the no-G-04B decision.
+- [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md):
+  FEASIBLE Wildcard direct-shim decision, public/private seam classification, and the
+  bounded P-WC-02 Move card.
 - [`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md):
   executable error inventory, canonical categories, preserved compatibility, adapter
   authority decision, and ordered F-02f/F-02g/F-02h task boundaries.

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #186 / P-WC-01 wildcard pure-shim feasibility Contract.
+- Active first task: Issue #186 / P-WC-02 wildcard internal-consumer and facade Move.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -78,8 +78,8 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE F-02h affected error-row re-audit and Phase F close #563
   -> COMPLETE G-04A public API snapshot coverage audit         #188
   -> NOT REQUIRED G-04B minimal missing public-surface gate
-  -> READY P-WC-01 wildcard pure-shim feasibility Contract     #186
-  -> OPTIONAL P-WC-02  internal consumer/facade Move
+  -> COMPLETE P-WC-01 wildcard pure-shim feasibility Contract  #186
+  -> READY P-WC-02 internal consumer/facade Move               #186
   -> P-API-01 API production-facade feasibility Contract      #186
   -> OPTIONAL P-API-02 canonical production-entry Move
   -> G-05A    size/complexity baseline and changed-path ratchet #188
@@ -245,6 +245,19 @@ RETAIN
 If feasible, P-WC-02 moves internal production consumers to the canonical facade and
 turns the root module into explicit direct imports. It does not delete the file.
 
+P-WC-01 result:
+
+- [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md)
+  records **FEASIBLE** without adding a duplicate fixture;
+- `easyuse_anima.wildcard.service` is the existing canonical facade owner; no new
+  production module or cross-boundary design is needed;
+- `api.py` and `nodes.py` are the only remaining root consumers;
+- the four root facade functions remain supported, while root snapshot/build patching
+  is an E-06-classified private test seam with an equivalent canonical service patch
+  owner;
+- P-WC-02 is the one bounded Move in the Contract task card. It preserves the root
+  file and does not start the release-N support window.
+
 ### P-API-01 — API facade feasibility Contract
 
 Inventory:
@@ -386,32 +399,35 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #186 / P-WC-01 only from latest origin/dev after G-04A merges.
+Start Issue #186 / P-WC-02 only from latest origin/dev after P-WC-01 merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- this document's P-WC-01 and validation sections
-- Issue #186 latest P-WC-01 checkpoint
-- wildcard_engine.py and its direct api.py/nodes.py/canonical callers
-- direct wildcard compatibility, identity, determinism, package, and import owners
+- this document's P-WC-02 card and validation sections
+- python-wildcard-pwc01-facade-feasibility.md
+- Issue #186 latest P-WC-02 checkpoint
+- api.py, nodes.py, wildcard_engine.py
+- direct wildcard/API/route/compatibility/identity/determinism/package/import owners
 
 Do not read all historical D/E PRs and do not start D-14 removal.
 
-Audit whether root wildcard_engine.py can become a pure compatibility shim while
-preserving call-time snapshot/source/build seams, deterministic NumPy seed, expansion
-budget, errors, object identity, and flat-import compatibility. Produce only a
-production-free FEASIBLE or RETAIN contract with exact evidence and a bounded Move
-card when feasible. Do not implement the Move in P-WC-01.
+In one cohesive Move, import api.py list_wildcards and the 19 nodes.py wildcard names
+from their existing canonical modules. Replace wildcard_engine.py's seven service
+wrappers/classes with direct canonical service imports while retaining eager numpy,
+all other root identities, package/flat fallback, signatures, results, cache/retry,
+determinism, budgets, errors, API callback monkeypatching, and node behavior. Move
+private root lifecycle patch targets to the equivalent canonical service owner.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
-Run official full once on the final test/tool SHA when the contract changes an
-executable gate or fixture.
-Package/live are not triggered.
+Run official full exactly once on the final candidate SHA. Run validate/pack/archive
+because the production import closure changes. Live is not triggered because no
+host-visible behavior changes.
 
-Push a dev-targeted Draft PR. If FEASIBLE, select only the bounded P-WC-02 Move. If
-RETAIN, record the exact blocker and next evidence trigger before selecting P-API-01.
+Push a dev-targeted Draft PR, review, and squash merge. Record the final shim form on
+Issue #186, then select P-API-01. Do not start release N merely for the shim.
 
-Do not change production behavior, public/root exports, API/node payloads, migration
-semantics, root files, deprecation warnings/telemetry, release/tag, or Registry state.
+Do not change canonical wildcard behavior, public/root exports, API/node payloads,
+migration semantics, RuntimeServices/bootstrap, deprecation warnings/telemetry,
+release/tag, or Registry state. Do not delete the root file.
 ```

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1523,6 +1523,15 @@ EasyUseAnimaWildcard
   D-12 and E-06b-E-06e complete canonical materialization, snapshot/service
   ownership, internal callers, narrow RuntimeServices binding, and cleanup audit.
   Root `nodes.py` and `api.py` nevertheless still import the adapter directly.
+- P-WC-01 finds the direct-shim conversion **FEASIBLE**. The existing
+  `easyuse_anima.wildcard.service` is the only required facade owner; the four root
+  facade functions can become direct aliases after `api.py` and `nodes.py` move to
+  canonical imports. E-06-classified root build/snapshot patching is a private test
+  seam with the same call-time patch point in the canonical service, while
+  `api.list_wildcards` remains a dynamic module-global callback seam.
+- P-WC-02 is the bounded Move that implements that form. Until it merges, the root
+  adapter remains behavior-bearing. After it merges, the file remains shipped and
+  retained; release N still has not started and no removal is authorized.
 - Removal gate: eliminate or explicitly migrate those production consumers, ship the
   final canonical-plus-adapter form through release N, retain #159/#160 behavior,
   seed/expansion and workflow parity, root/canonical identities, archive closure,

--- a/docs/architecture/python-wildcard-pwc01-facade-feasibility.md
+++ b/docs/architecture/python-wildcard-pwc01-facade-feasibility.md
@@ -1,0 +1,132 @@
+# Python Wildcard P-WC-01 Facade Feasibility Contract
+
+## Status and decision
+
+- Owner: Issue #186
+- Base: `769888aa0a48d32107d35fc0962241fee405aade`
+- Classification: Contract; production-free
+- Decision: **FEASIBLE**
+- Next: one bounded P-WC-02 Move
+
+Root `wildcard_engine.py` can become a direct-import compatibility shim without a new
+canonical module. `easyuse_anima.wildcard.service` already owns the four transitional
+facade functions, their exact signatures, the snapshot resolver, and the call-time
+source/build dependencies.
+
+P-WC-01 does not authorize root deletion or begin the ADR-002 support window. It only
+fixes the owner and exact Move needed to remove the two remaining root production
+consumer edges.
+
+## Direct evidence
+
+| Boundary | Current evidence | Decision |
+| --- | --- | --- |
+| Public facade | `python_wildcard_runtime_contract.v1.json`, `WildcardServiceTests`, and `WildcardEngineTests` cover `expand_wildcard_texts`, `expand_wildcards`, `list_wildcards`, and `wildcard_sources_signature`. | Preserve signatures and results; bind each root name directly to `easyuse_anima.wildcard.service`. |
+| Canonical behavior | `service.py` already owns list/signature/library/expansion and resolves `_wildcard_sources._scan_wildcard_sources` plus `_build_wildcard_snapshot` at call time. | No new facade module and no canonical behavior change. |
+| Snapshot lifecycle | The E-06 fixture and runtime contract own the exact `_DEFAULT_WILDCARD_SNAPSHOTS` identity, cache/build/Condition policy, retry, publication, and cleanup behavior. | Preserve the owner and every lifecycle invariant. |
+| Seed and expansion | Wildcard golden tests cover NumPy `PCG64`, sequential mode, ordered multi-text selection, recursion, budgets, missing keys, YAML/TXT sources, and source signatures. | Root keeps eager `numpy as np`; all current canonical model/source/seed/mode/selector/expansion identities remain direct aliases. |
+| Package and flat import | Root uses package-relative imports with flat-import fallbacks. Canonical wildcard modules import no root shim, bootstrap, or RuntimeServices. | Preserve both import modes and the canonical-to-root prohibition. |
+| External evidence | Repository docs identify the root module as a retained compatibility surface. A best-effort search of the owner account found no additional repository import, but this is not proof of no external consumers. | Keep the root module and all supported bindings through ADR-002; do not deprecate or warn. |
+
+## Remaining consumers
+
+Only two root modules still import `wildcard_engine.py`:
+
+- `api.py` imports `list_wildcards`; its payload factory deliberately reads the
+  module global through a lambda so `api.list_wildcards` monkeypatching remains
+  dynamic;
+- `nodes.py` imports 19 seed, mode, expansion, and service names in both package and
+  flat-import branches.
+
+Canonical node, Prompt, Regional, seed-compatibility, and Wildcard feature modules
+already import `easyuse_anima.wildcard.*` directly. P-WC-02 therefore changes no
+feature implementation and creates no canonical-to-root edge.
+
+## Public compatibility versus private test seams
+
+The E-06 executable contract distinguishes these surfaces:
+
+- the four facade functions are a transitional root public surface;
+- snapshot constants, value type, and materializer are private identity re-exports;
+- root `_wildcard_snapshot`, `_build_wildcard_snapshot`, and `_wildcard_sources`
+  patching are private lifecycle test seams.
+
+The private seams do not require root wrappers. The same isolated call-time injection
+point already exists in `easyuse_anima.wildcard.service`: tests can patch
+`service._wildcard_snapshot`, `service._build_wildcard_snapshot`, or the shared
+`service._wildcard_sources` module as appropriate. P-WC-02 moves only those private
+test patch targets. It does not treat them as supported external API.
+
+The `api.py` callback seam is different and remains intact: importing canonical
+`list_wildcards` into the existing `api.list_wildcards` global preserves the current
+lambda lookup and direct API monkeypatch tests.
+
+## Target shim shape
+
+P-WC-02 leaves `wildcard_engine.py` as import-only compatibility code:
+
+- keep eager `import numpy as np`;
+- keep package-relative and flat-import fallback branches;
+- keep all current direct model/source/snapshot/seed/mode/selector/expansion aliases;
+- directly import `_wildcard_snapshot`, `_load_wildcard_map`, `_WildcardLibrary`,
+  `list_wildcards`, `wildcard_sources_signature`, `expand_wildcard_texts`, and
+  `expand_wildcards` from `easyuse_anima.wildcard.service`;
+- define no wrapper function or adapter class.
+
+Root object identity for the seven service bindings becomes the canonical identity,
+which is the intended direct-shim form. Signatures, results, state owners, and all
+other existing root identities remain unchanged.
+
+## P-WC-02 task card
+
+```text
+Task ID: P-WC-02 wildcard internal-consumer and facade Move
+Owner Issue: #186
+Primary class: MOVE
+Base SHA: latest origin/dev after P-WC-01 merges
+Goal: move api.py/nodes.py off root wildcard_engine and make wildcard_engine import-only
+Allowed production files:
+  api.py
+  nodes.py
+  wildcard_engine.py
+Allowed test/docs files:
+  tests/test_wildcards.py
+  tests/test_api_contract.py
+  tests/test_python_wildcard_runtime_contract.py
+  tests/fixtures/python_wildcard_runtime_contract.v1.json
+  tests/test_python_compatibility_surface.py and its fixture only if generated owner changes
+  analyzer/import/package owners and python_backend_baseline.json only when generated output changes
+  this Contract, post-phase-e-maintenance-roadmap.md, python-compatibility-shims.md,
+  architecture/development indexes
+Forbidden changes:
+  canonical wildcard behavior, schema, persistence, RuntimeServices, bootstrap,
+  node/API payloads, public removal/deprecation, release/tag/Registry
+Preserve:
+  four facade signatures/results; every supported root binding; eager np identity;
+  PCG64/sequential/golden output; snapshot cache/retry/atomic publication/cleanup;
+  expansion budgets/errors/source signatures; api.list_wildcards dynamic callback;
+  package and flat-import fallback; root/canonical import direction
+Focused gates:
+  WildcardServiceTests and WildcardEngineTests — canonical/root identity and parity
+  WildcardSnapshotStoreTests plus direct concurrency methods — lifecycle and patch owner
+  WildcardNodeTests — root nodes behavior after canonical imports
+  ApiWildcardRouteTests and ApiRouteRegistrationOwnerTests — callback/payload/route parity
+  PythonWildcardRuntimeContractTests — import-only root and canonical dynamic seam
+  PythonCompatibilitySurfaceTests, PythonPackageSkeletonTests, import boundary, analyzer
+Promotion:
+  changed-file syntax/static; focused gates; git diff --check;
+  official full exactly once on final SHA; validate/pack/archive because import closure changes;
+  no live smoke because host-visible behavior does not change
+Stop:
+  a supported external root-private patch seam is proven;
+  a canonical wildcard production change or new public API is required;
+  any signature/result/object identity outside the selected service aliases changes;
+  eager NumPy, deterministic output, route/node behavior, flat import, or import direction changes
+Next: P-API-01 after P-WC-02 is reviewed and merged
+```
+
+## PRO review
+
+No focused technical PRO review is required. Direct source and executable E-06
+evidence leave one owner-preserving shape: the existing canonical service plus a root
+direct-import shim. No second valid cross-boundary design remains.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #563 / F-02g authoritative API mappings;
+   - first READY task: Issue #186 / P-WC-02 Wildcard facade Move;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -30,6 +30,7 @@ Read only the sections needed by the active task.
    - translation runtime contract: `../architecture/python-runtime-e04-translation-contract.md`
    - Autocomplete runtime contract: `../architecture/python-runtime-e05-autocomplete-contract.md`
    - Wildcard runtime contract: `../architecture/python-runtime-e06-wildcard-contract.md`
+   - Wildcard facade feasibility: `../architecture/python-wildcard-pwc01-facade-feasibility.md`
    - AiO cache runtime contract: `../architecture/python-runtime-e08-aio-cache-contract.md`
    - lifecycle runtime contract: `../architecture/python-runtime-e09-lifecycle-contract.md`
    - test-isolation runtime contract: `../architecture/python-runtime-e10-test-isolation-contract.md`


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186 / P-WC-01에서 root `wildcard_engine.py`의 pure direct-shim 가능성을 production 변경 없이 감사했습니다.

Base: `769888aa0a48d32107d35fc0962241fee405aade`
Head: `025a023`

## 결론

**FEASIBLE**

- 기존 `easyuse_anima.wildcard.service`가 4개 public facade와 private snapshot resolver를 이미 소유합니다.
- 새 canonical module이나 PRO architecture decision은 필요하지 않습니다.
- 남은 root consumer는 `api.py`와 `nodes.py` 두 개입니다.
- root build/snapshot patch는 E-06이 분류한 private test seam이며 canonical service에 동일한 call-time patch owner가 있습니다.
- root 파일은 삭제하지 않으며 release N도 시작하지 않습니다.

## 변경

- P-WC-01 feasibility Contract와 exact P-WC-02 Move card 추가
- roadmap을 P-WC-01 COMPLETE / P-WC-02 READY로 전환
- compatibility ledger와 architecture/development index 갱신

Production, test/tool, fixture, public export, API/node payload, lifecycle, release, Registry 상태는 변경하지 않습니다.

## 검증

한 runner당 한 target으로 실행했습니다.

- WildcardServiceTests: 4 PASS
- WildcardEngineTests: 51 PASS
- PythonWildcardRuntimeContractTests: 10 PASS
- ApiWildcardRouteTests: 4 PASS
- PythonPackageSkeletonTests: 1 PASS
- PythonCompatibilitySurfaceTests: 19 PASS
- CompletedPackageImportBoundaryTests: 6 PASS
- `git diff --check`: PASS

문서-only Contract이고 executable gate/fixture가 바뀌지 않아 official full/package/live는 정책대로 재실행하지 않았습니다.

## 위험과 rollback

best-effort owner-account code search에 추가 import는 없었지만 외부 consumer 부재를 증명하지는 않습니다. 그래서 root module과 모든 supported binding은 ADR-002에 따라 계속 유지합니다. rollback은 이 문서 커밋의 revert입니다.

## Next

검토와 squash merge 후 latest `origin/dev`에서 exact P-WC-02 Move를 수행합니다. P-WC-02는 `api.py`, `nodes.py`, `wildcard_engine.py`만 production 범위로 허용하며 final SHA에서 official full과 validate/pack/archive를 수행합니다.