### PR TITLE
refactor: make wildcard facade import-only (P-WC-02)

### DIFF
--- a/api.py
+++ b/api.py
@@ -35,8 +35,8 @@ from .easyuse_anima.autocomplete.search import (
 from .easyuse_anima.autocomplete.classification import (
     classify_prompt_text as _canonical_classify_prompt_text,
 )
+from .easyuse_anima.wildcard.service import list_wildcards
 from .easyuse_anima.wildcard.sources import resolve_wildcard_roots
-from .wildcard_engine import list_wildcards
 from .easyuse_anima.translation.contracts import (
     PromptTranslationError,
     TranslationBusyError,

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,11 +21,12 @@ then only the active task section, owning Issue, direct source, and direct tests
   API snapshot coverage are complete; existing deterministic owners required no G-04B
   fixture. Issue #188 continues to own G-05 size/complexity ratchet and G-06 test
   ownership.
-- P-WC-01 found the Wildcard facade direct-shim conversion feasible with the existing
-  canonical service owner.
+- P-WC-01/P-WC-02 selected and completed the Wildcard direct-shim conversion with the
+  existing canonical service owner. The final form has not shipped, so release N and
+  removal remain parked.
 - First READY task: Issue
-  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186) / P-WC-02
-  wildcard internal-consumer and facade Move.
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186) / P-API-01 API
+  production-facade feasibility Contract.
 - Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
   remains the retained compatibility ledger. It owns pre-retirement feasibility and
   later D-14 decisions, not an immediately executable deletion task.
@@ -48,8 +49,8 @@ COMPLETE F-02a Autocomplete typed result contracts
   -> COMPLETE G-04A public API snapshot coverage audit
   -> NOT REQUIRED G-04B gap
   -> COMPLETE Wildcard pure-shim feasibility Contract
-  -> READY Wildcard internal-consumer and facade Move
-  -> API production-facade feasibility Contract
+  -> COMPLETE Wildcard internal-consumer and facade Move
+  -> READY API production-facade feasibility Contract
   -> approved internal-consumer Moves only
   -> G-05 size ratchet
   -> G-06 test ownership
@@ -59,15 +60,14 @@ COMPLETE F-02a Autocomplete typed result contracts
 
 ## Current code boundary
 
-The current backend is functional and validated, but two root surfaces are not yet pure
-compatibility shims:
+The current backend is functional and validated. The API root surface is not yet a
+pure compatibility shim:
 
 - root `__init__.py` imports root `api.py` and passes `api.register_routes` into
   bootstrap initialization;
 - root `api.py` remains a production route/payload/runtime facade;
-- root `api.py` and `nodes.py` consume `wildcard_engine.py`;
-- root `wildcard_engine.py` retains call-time snapshot/source/build adapters over the
-  canonical Wildcard package.
+- root `wildcard_engine.py` is an import-only compatibility shim over canonical
+  Wildcard owners, but its final form has not shipped and release N has not begun.
 
 Other final shim forms completed after 0.6.2 and therefore have no release N yet.
 Older direct/public shims may already satisfy a minimum version window, but absence of

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #186 / P-WC-02 wildcard internal-consumer and facade Move.
+- Active first task: Issue #186 / P-API-01 API production-facade feasibility Contract.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -56,8 +56,8 @@ ADR-002 result when evidence is absent or ambiguous.
 - G-04 public API snapshot coverage is complete; no G-04B gate was required.
 - G-05 size/complexity growth ratchet is not implemented as a blocking incremental gate.
 - G-06 canonical test ownership is not completed.
-- `api.py` and `wildcard_engine.py` have not reached a proven pure-shim form that can
-  begin a final support window.
+- `api.py` has not reached a proven pure-shim form. `wildcard_engine.py` has reached
+  its final direct-shim form, but that form has not shipped and release N has not begun.
 
 ## 2. Execution lanes
 
@@ -79,8 +79,8 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE G-04A public API snapshot coverage audit         #188
   -> NOT REQUIRED G-04B minimal missing public-surface gate
   -> COMPLETE P-WC-01 wildcard pure-shim feasibility Contract  #186
-  -> READY P-WC-02 internal consumer/facade Move               #186
-  -> P-API-01 API production-facade feasibility Contract      #186
+  -> COMPLETE P-WC-02 internal consumer/facade Move            #186
+  -> READY P-API-01 API production-facade feasibility Contract #186
   -> OPTIONAL P-API-02 canonical production-entry Move
   -> G-05A    size/complexity baseline and changed-path ratchet #188
   -> G-06A    canonical test-ownership Contract               #188
@@ -258,6 +258,19 @@ P-WC-01 result:
 - P-WC-02 is the one bounded Move in the Contract task card. It preserves the root
   file and does not start the release-N support window.
 
+P-WC-02 result:
+
+- `api.py` and `nodes.py` have zero `wildcard_engine` import edges and use the existing
+  canonical mode, seed, expansion, source, and service owners;
+- root `wildcard_engine.py` is import-only and its seven former service wrappers/classes
+  have exact canonical service identity;
+- the private build/snapshot patch owner is canonical, while API callback, eager
+  NumPy, deterministic output, lifecycle, package/flat import, and all supported root
+  bindings are preserved;
+- the analyzer includes the shipped compatibility shim as an explicit Registry entry
+  module, retaining complete 176-module archive closure without a production import;
+- the next READY task is P-API-01. Release N remains event-gated.
+
 ### P-API-01 — API facade feasibility Contract
 
 Inventory:
@@ -399,35 +412,34 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #186 / P-WC-02 only from latest origin/dev after P-WC-01 merges.
+Start Issue #186 / P-API-01 only from latest origin/dev after P-WC-02 merges.
 
 Read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- this document's P-WC-02 card and validation sections
-- python-wildcard-pwc01-facade-feasibility.md
-- Issue #186 latest P-WC-02 checkpoint
-- api.py, nodes.py, wildcard_engine.py
-- direct wildcard/API/route/compatibility/identity/determinism/package/import owners
+- this document's P-API-01 and validation sections
+- Issue #186 latest P-API-01 checkpoint
+- root __init__.py, api.py, easyuse_anima/bootstrap.py, api/router.py, route factories
+- direct entrypoint/bootstrap/route/API compatibility and import/package owners
 
 Do not read all historical D/E PRs and do not start D-14 removal.
 
-In one cohesive Move, import api.py list_wildcards and the 19 nodes.py wildcard names
-from their existing canonical modules. Replace wildcard_engine.py's seven service
-wrappers/classes with direct canonical service imports while retaining eager numpy,
-all other root identities, package/flat fallback, signatures, results, cache/retry,
-determinism, budgets, errors, API callback monkeypatching, and node behavior. Move
-private root lifecycle patch targets to the equivalent canonical service owner.
+Without production changes, audit whether root api.py can become a pure compatibility
+facade. Inventory the root entrypoint's register_routes dependency, bootstrap
+composition, route/payload/runtime helpers, supported public names, private
+monkeypatch seams, exact object identities, and import-cycle constraints. Select one
+FEASIBLE shape with an exact bounded Move card, or RETAIN with an exact blocker and
+next evidence trigger.
 
 Run only targeted consistency/focused checks during the edit loop and git diff check.
-Run official full exactly once on the final candidate SHA. Run validate/pack/archive
-because the production import closure changes. Live is not triggered because no
-host-visible behavior changes.
+Run only targeted consistency/focused checks and git diff check. Run official full
+once only if an executable gate or fixture changes. Package/live are not triggered.
 
-Push a dev-targeted Draft PR, review, and squash merge. Record the final shim form on
-Issue #186, then select P-API-01. Do not start release N merely for the shim.
+Push a dev-targeted Draft PR, review, and squash merge. Request focused technical PRO
+review only if direct evidence still leaves multiple valid bootstrap/router/root
+facade shapes. Do not implement the later Move in P-API-01.
 
-Do not change canonical wildcard behavior, public/root exports, API/node payloads,
-migration semantics, RuntimeServices/bootstrap, deprecation warnings/telemetry,
-release/tag, or Registry state. Do not delete the root file.
+Do not change production behavior, public/root exports, routes, API payloads,
+RuntimeServices/bootstrap lifecycle, migration semantics, deprecation
+warnings/telemetry, release/tag, or Registry state. Do not delete a root file.
 ```

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports and storage compatibility tests; production callers use canonical modules | Retained; minimum window passed, but consumer evidence does not support removal |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Exact seven-name `__all__`; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports; production dataset/search owners use the canonical module | Retained; minimum window passed, but consumer evidence does not support removal |
 | `autocomplete_dataset.py` | Explicit 15-symbol dataset/search/classification identity shim (D-11) | `easyuse_anima.autocomplete.dataset`, `.search`, and `.classification` | #162, #186 D-11 | Final classification shim completed in PR #480 after v0.6.2 | External/legacy imports and direct compatibility tests; production API uses canonical owners | Retained; first complete canonical-plus-shim release N has not shipped |
-| `wildcard_engine.py` | Compatibility adapter over completed canonical wildcard snapshot/service/runtime owners; not an ADR-002 direct re-export shim because call-time source/build seams and root production consumers remain | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, `.service`, `.seed`, `.mode`, `.selector`, `.library`, and `.expansion` | #184, #186 D-12, #187 E-06 | D-12 and E-06b-E-06e complete the canonical owner, internal caller, runtime binding, and audit after v0.6.2 | `nodes.py`, `api.py`, external/legacy imports, wildcard/workflow tests | Blocked and retained; direct root production consumers remain and the final post-v0.6.2 adapter/canonical form has no release N |
+| `wildcard_engine.py` | Explicit import-only identity shim over completed canonical wildcard snapshot/service/runtime owners (P-WC-02) | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, `.service`, `.seed`, `.mode`, `.selector`, `.library`, and `.expansion` | #184, #186 D-12/P-WC-01/P-WC-02, #187 E-06 | P-WC-02 moved `api.py` and `nodes.py` to canonical owners and preserved the root surface as exact aliases after v0.6.2 | External/legacy imports and wildcard compatibility tests; production callers use canonical modules | Retained; first final canonical-plus-shim release N has not shipped |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 surface; current canonical-plus-shim paths first appear together in release tag v0.6.0 | External/legacy imports and translation compatibility tests; production callers use canonical modules | Retained; minimum window passed, but consumer evidence does not support removal |
 | `anima_prompt/` package | Explicit package and submodule identity shims (D-13) | `easyuse_anima.prompt.anima.*` | #184, #186 D-13/D-14 | Canonicalized in PR #479 after v0.6.2 with explicit `__all__`, flat/package identity, and packed closure | External/legacy imports and direct compatibility tests; production callers use the canonical package | Retained; first canonical-plus-shim release N has not shipped |
 
@@ -1529,9 +1529,12 @@ EasyUseAnimaWildcard
   canonical imports. E-06-classified root build/snapshot patching is a private test
   seam with the same call-time patch point in the canonical service, while
   `api.list_wildcards` remains a dynamic module-global callback seam.
-- P-WC-02 is the bounded Move that implements that form. Until it merges, the root
-  adapter remains behavior-bearing. After it merges, the file remains shipped and
-  retained; release N still has not started and no removal is authorized.
+- P-WC-02 completes that bounded Move. `api.py` and `nodes.py` now use canonical
+  Wildcard owners, and root `wildcard_engine.py` is import-only with exact canonical
+  service identities. The analyzer enrolls it as a direct Registry compatibility
+  entry module so archive closure does not depend on a production consumer.
+- The file remains shipped and retained. This final direct-shim form has not been
+  published, release N has not started, and no removal is authorized.
 - Removal gate: eliminate or explicitly migrate those production consumers, ship the
   final canonical-plus-adapter form through release N, retain #159/#160 behavior,
   seed/expansion and workflow parity, root/canonical identities, archive closure,

--- a/docs/architecture/python-wildcard-pwc01-facade-feasibility.md
+++ b/docs/architecture/python-wildcard-pwc01-facade-feasibility.md
@@ -6,7 +6,8 @@
 - Base: `769888aa0a48d32107d35fc0962241fee405aade`
 - Classification: Contract; production-free
 - Decision: **FEASIBLE**
-- Next: one bounded P-WC-02 Move
+- P-WC-02: **complete**
+- Next: P-API-01
 
 Root `wildcard_engine.py` can become a direct-import compatibility shim without a new
 canonical module. `easyuse_anima.wildcard.service` already owns the four transitional
@@ -130,3 +131,21 @@ Next: P-API-01 after P-WC-02 is reviewed and merged
 No focused technical PRO review is required. Direct source and executable E-06
 evidence leave one owner-preserving shape: the existing canonical service plus a root
 direct-import shim. No second valid cross-boundary design remains.
+
+## P-WC-02 implementation result
+
+P-WC-02 implements the selected shape without changing canonical wildcard behavior:
+
+- `api.py` and `nodes.py` import the existing canonical Wildcard owners directly;
+- root `wildcard_engine.py` defines no function or class and binds all seven service
+  names directly to `easyuse_anima.wildcard.service`;
+- private lifecycle patch tests use the canonical service seam, while the API
+  module-global callback remains dynamic;
+- the compatibility fixture now records 316 canonical and zero legacy `nodes.py`
+  bindings;
+- the backend analyzer treats shipped `wildcard_engine.py` as an explicit Registry
+  compatibility entry module, so all 176 shipped Python modules remain in the archive
+  import closure without a production root consumer.
+
+The final direct-shim form has not been published. Release N, deprecation, telemetry,
+and removal remain blocked by ADR-002.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #186 / P-WC-02 Wildcard facade Move;
+   - first READY task: Issue #186 / P-API-01 API facade feasibility Contract;
    - D-14/H root removal is parked, not failed.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
@@ -55,17 +55,11 @@ ordinary `dev` work.
 COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 PARKED    D-14 / Phase H root removal
-COMPLETE  #563 F-02a Autocomplete typed result contracts
-COMPLETE  #563 F-02b Prompt field-family typed contract
-COMPLETE  #563 F-02c canonical Prompt Data typed read/output contract
-COMPLETE  #563 affected Prompt-row re-audit
-COMPLETE  #563 F-02d settings typed migration contract
-COMPLETE  #563 affected settings/profile/workflow-row re-audit
-COMPLETE  #563 F-02e common feature error taxonomy contract
-COMPLETE  #563 F-02f canonical categories and feature inheritance
-READY     #563 F-02g authoritative profile/translation API mappings
-NEXT      #563 F-02h error-row and Phase F completion audit
-BLOCKED   #188 G-04 public API snapshot audit until Phase F closes
+COMPLETE  #563 Phase F typed-boundary and feature-error work
+COMPLETE  #188 G-04 public API snapshot coverage audit
+COMPLETE  #186 P-WC-01 Wildcard facade feasibility Contract
+COMPLETE  #186 P-WC-02 Wildcard direct-shim Move
+READY     #186 P-API-01 API facade feasibility Contract
 LATER     G-05 size ratchet / G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
@@ -73,40 +67,38 @@ EVENT     next ordinary release N -> later D-14 re-audit
 The D-14 stop is correct:
 
 - root `__init__.py` still imports root `api.py` for production registration;
-- `api.py` and `nodes.py` still consume `wildcard_engine.py`;
+- root `api.py` remains a production route/payload/runtime facade;
+- `wildcard_engine.py` is a direct shim, but that final form has not shipped;
 - final forms completed after 0.6.2 have no release N;
 - consumer evidence and public breaking-change approval do not support removal.
 
 That stop applies only to removal. It does not complete Phase F or G.
 
-## Active F-02g source map
+## Active P-API-01 source map
 
 Start with targeted owners rather than the full repository:
 
 ```text
-docs/architecture/python-feature-error-taxonomy-contract.md  # F-02g task card
-Issue #563 latest checkpoint
-api.py dynamic profile dependency composition
-easyuse_anima/api/responses.py and api/routes/translation.py mapping owners
-bootstrap translation composition plus taxonomy/API/runtime tests
+docs/architecture/post-phase-e-maintenance-roadmap.md  # P-API-01 task card
+Issue #186 latest checkpoint
+root __init__.py and api.py production entry/composition
+easyuse_anima/bootstrap.py and easyuse_anima/api/router.py
+direct route/API compatibility, entrypoint, package, and import owners
 ```
 
-F-02g moves profile and translation HTTP authority into canonical API adapters while
-preserving exact payloads, correlation, redaction, catch order, compatibility metadata,
-and the dynamic profile dependency seam. It does not change feature exceptions,
-taxonomy, root exports, or runtime lifecycle.
+P-API-01 is a production-free feasibility Contract. It inventories the root entrypoint,
+bootstrap composition, route/payload/runtime helpers, public names, private test seams,
+object identities, and import-cycle constraints. It selects one bounded Move only when
+the evidence converges; otherwise it records RETAIN. It does not implement the Move.
 
 ## Following queue
 
-After F-02g:
+After P-API-01:
 
-1. run F-02h to re-audit the common error row and record Phase F completion;
-2. after Phase F closes, run #188 G-04A against existing
-   compatibility/node/API/package fixtures;
-3. audit Wildcard and API pure-shim feasibility without deleting root modules;
-4. add G-05 changed-path size growth and G-06 test-ownership gates;
-5. let the next ordinary release containing final shims become release N;
-6. re-audit D-14 only after an event-gate changes.
+1. run only the bounded P-API-02 Move when P-API-01 is FEASIBLE;
+2. add G-05 changed-path size growth and G-06 test-ownership gates;
+3. let the next ordinary release containing final shims become release N;
+4. re-audit D-14 only after an event-gate changes.
 
 No dedicated release, outbound telemetry, import-time deprecation warning, or public
 root removal is authorized by this queue.

--- a/nodes.py
+++ b/nodes.py
@@ -542,25 +542,29 @@ try:
     from .easyuse_anima.translation.service import (
         translate_prompt_markers,
     )
-    from .wildcard_engine import (
+    from .easyuse_anima.wildcard.expansion import has_wildcard_syntax
+    from .easyuse_anima.wildcard.mode import (
+        PROMPT_STUDIO_WILDCARD_MODE_LABELS,
+        WILDCARD_MODE_FIXED,
+        WILDCARD_MODE_POPULATE,
+        WILDCARD_MODE_SEQUENTIAL,
+        normalize_prompt_studio_wildcard_mode,
+        normalize_wildcard_mode,
+    )
+    from .easyuse_anima.wildcard.seed import (
         MAX_SEED,
         PUBLIC_MAX_SEED,
-        PROMPT_STUDIO_WILDCARD_MODE_LABELS,
         SEED_CONTROL_DECREMENT,
         SEED_CONTROL_FIXED,
         SEED_CONTROL_INCREMENT,
         SEED_CONTROL_MODES,
         SEED_CONTROL_RANDOMIZE,
-        WILDCARD_MODE_FIXED,
-        WILDCARD_MODE_POPULATE,
-        WILDCARD_MODE_SEQUENTIAL,
-        expand_wildcard_texts,
-        expand_wildcards,
-        has_wildcard_syntax,
         next_seed,
         normalize_seed,
-        normalize_prompt_studio_wildcard_mode,
-        normalize_wildcard_mode,
+    )
+    from .easyuse_anima.wildcard.service import (
+        expand_wildcard_texts,
+        expand_wildcards,
         wildcard_sources_signature,
     )
 except ImportError:  # allows simple local import tests outside ComfyUI's package loader
@@ -1104,25 +1108,29 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.translation.service import (
         translate_prompt_markers,
     )
-    from wildcard_engine import (
+    from easyuse_anima.wildcard.expansion import has_wildcard_syntax
+    from easyuse_anima.wildcard.mode import (
+        PROMPT_STUDIO_WILDCARD_MODE_LABELS,
+        WILDCARD_MODE_FIXED,
+        WILDCARD_MODE_POPULATE,
+        WILDCARD_MODE_SEQUENTIAL,
+        normalize_prompt_studio_wildcard_mode,
+        normalize_wildcard_mode,
+    )
+    from easyuse_anima.wildcard.seed import (
         MAX_SEED,
         PUBLIC_MAX_SEED,
-        PROMPT_STUDIO_WILDCARD_MODE_LABELS,
         SEED_CONTROL_DECREMENT,
         SEED_CONTROL_FIXED,
         SEED_CONTROL_INCREMENT,
         SEED_CONTROL_MODES,
         SEED_CONTROL_RANDOMIZE,
-        WILDCARD_MODE_FIXED,
-        WILDCARD_MODE_POPULATE,
-        WILDCARD_MODE_SEQUENTIAL,
-        expand_wildcard_texts,
-        expand_wildcards,
-        has_wildcard_syntax,
         next_seed,
         normalize_seed,
-        normalize_prompt_studio_wildcard_mode,
-        normalize_wildcard_mode,
+    )
+    from easyuse_anima.wildcard.service import (
+        expand_wildcard_texts,
+        expand_wildcards,
         wildcard_sources_signature,
     )
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3226,6 +3226,24 @@
       },
       {
         "alias": null,
+        "bound_name": "list_wildcards",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.wildcard.service:list_wildcards",
+        "kind": "static_from",
+        "line": 38,
+        "name": "list_wildcards",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
         "bound_name": "resolve_wildcard_roots",
         "branch_context": [],
         "classification": "internal",
@@ -3233,7 +3251,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 38,
+        "line": 39,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -3241,24 +3259,6 @@
         "scope": "<module>",
         "source": "api.py",
         "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "list_wildcards",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".wildcard_engine:list_wildcards",
-        "kind": "static_from",
-        "line": 39,
-        "name": "list_wildcards",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
@@ -45715,7 +45715,7 @@
       },
       {
         "alias": null,
-        "bound_name": "MAX_SEED",
+        "bound_name": "has_wildcard_syntax",
         "branch_context": [
           {
             "branch": "body",
@@ -45728,21 +45728,21 @@
         "classification": "internal",
         "column": 4,
         "compatibility_pair": {
-          "bound_name": "MAX_SEED",
-          "target": "wildcard_engine.py",
+          "bound_name": "has_wildcard_syntax",
+          "target": "easyuse_anima/wildcard/expansion.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:MAX_SEED",
+        "imported": ".easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
         "line": 545,
-        "name": "MAX_SEED",
+        "name": "has_wildcard_syntax",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.expansion",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
         "alias": null,
@@ -45760,206 +45760,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
+        "imported": ".easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "PUBLIC_MAX_SEED",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PUBLIC_MAX_SEED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
-        "kind": "static_from",
-        "line": 545,
-        "name": "PUBLIC_MAX_SEED",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_DECREMENT",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_DECREMENT",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
-        "kind": "static_from",
-        "line": 545,
-        "name": "SEED_CONTROL_DECREMENT",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_FIXED",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_FIXED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
-        "kind": "static_from",
-        "line": 545,
-        "name": "SEED_CONTROL_FIXED",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_INCREMENT",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_INCREMENT",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
-        "kind": "static_from",
-        "line": 545,
-        "name": "SEED_CONTROL_INCREMENT",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_MODES",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_MODES",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:SEED_CONTROL_MODES",
-        "kind": "static_from",
-        "line": 545,
-        "name": "SEED_CONTROL_MODES",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_RANDOMIZE",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_RANDOMIZE",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
-        "kind": "static_from",
-        "line": 545,
-        "name": "SEED_CONTROL_RANDOMIZE",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -45977,20 +45791,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
+        "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -46008,20 +45822,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
+        "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -46039,144 +45853,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "expand_wildcard_texts",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "expand_wildcard_texts",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:expand_wildcard_texts",
-        "kind": "static_from",
-        "line": 545,
-        "name": "expand_wildcard_texts",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "expand_wildcards",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "expand_wildcards",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:expand_wildcards",
-        "kind": "static_from",
-        "line": 545,
-        "name": "expand_wildcards",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "has_wildcard_syntax",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_wildcard_syntax",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 545,
-        "name": "has_wildcard_syntax",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "next_seed",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "next_seed",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:next_seed",
-        "kind": "static_from",
-        "line": 545,
-        "name": "next_seed",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -46194,51 +45884,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "imported": ".easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_seed",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_seed",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": ".wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 545,
-        "name": "normalize_seed",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -46256,20 +45915,361 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:normalize_wildcard_mode",
+        "imported": ".easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "normalize_wildcard_mode",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.mode",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:MAX_SEED",
+        "kind": "static_from",
+        "line": 554,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 554,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 554,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 554,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 554,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 554,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 554,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:next_seed",
+        "kind": "static_from",
+        "line": 554,
+        "name": "next_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:normalize_seed",
+        "kind": "static_from",
+        "line": 554,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 565,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:expand_wildcards",
+        "kind": "static_from",
+        "line": 565,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "alias": null,
@@ -46287,20 +46287,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/service.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".wildcard_engine:wildcard_sources_signature",
+        "imported": ".easyuse_anima.wildcard.service:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 545,
+        "line": 565,
         "name": "wildcard_sources_signature",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.service",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "alias": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
@@ -46312,7 +46312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46327,7 +46327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46346,7 +46346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46361,7 +46361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46380,7 +46380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46395,7 +46395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46414,7 +46414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46429,7 +46429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46448,7 +46448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46463,7 +46463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46482,7 +46482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46497,7 +46497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46516,7 +46516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46531,7 +46531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -46550,7 +46550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46565,7 +46565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46584,7 +46584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46599,7 +46599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46618,7 +46618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46633,7 +46633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46652,7 +46652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46667,7 +46667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46686,7 +46686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46701,7 +46701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46720,7 +46720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46735,7 +46735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46754,7 +46754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46769,7 +46769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -46788,7 +46788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46803,7 +46803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46822,7 +46822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46837,7 +46837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46856,7 +46856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46871,7 +46871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46890,7 +46890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46905,7 +46905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46924,7 +46924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46939,7 +46939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46958,7 +46958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -46973,7 +46973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -46992,7 +46992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47007,7 +47007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -47026,7 +47026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47041,7 +47041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -47060,7 +47060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47075,7 +47075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -47094,7 +47094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47109,7 +47109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -47128,7 +47128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47143,7 +47143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -47162,7 +47162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47177,7 +47177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47196,7 +47196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47211,7 +47211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47230,7 +47230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47245,7 +47245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47264,7 +47264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47279,7 +47279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47298,7 +47298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47313,7 +47313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47332,7 +47332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47347,7 +47347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47366,7 +47366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47381,7 +47381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47400,7 +47400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47415,7 +47415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47434,7 +47434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47449,7 +47449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47468,7 +47468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47483,7 +47483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47502,7 +47502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47517,7 +47517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47536,7 +47536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47551,7 +47551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47570,7 +47570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47585,7 +47585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47604,7 +47604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47619,7 +47619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47638,7 +47638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47653,7 +47653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47672,7 +47672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47687,7 +47687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -47706,7 +47706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47721,7 +47721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 621,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -47740,7 +47740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47755,7 +47755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47774,7 +47774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47789,7 +47789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47808,7 +47808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47823,7 +47823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47842,7 +47842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47857,7 +47857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47876,7 +47876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47891,7 +47891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47910,7 +47910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47925,7 +47925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47944,7 +47944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47959,7 +47959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -47978,7 +47978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -47993,7 +47993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -48012,7 +48012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48027,7 +48027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -48046,7 +48046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48061,7 +48061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 635,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -48080,7 +48080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48095,7 +48095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 631,
+        "line": 635,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -48114,7 +48114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48129,7 +48129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 635,
+        "line": 639,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -48148,7 +48148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48163,7 +48163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 635,
+        "line": 639,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -48182,7 +48182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48197,7 +48197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -48216,7 +48216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48231,7 +48231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -48250,7 +48250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48265,7 +48265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -48284,7 +48284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48299,7 +48299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -48318,7 +48318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48333,7 +48333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -48352,7 +48352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48367,7 +48367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -48386,7 +48386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48401,7 +48401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -48420,7 +48420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48435,7 +48435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48454,7 +48454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48469,7 +48469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48488,7 +48488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48503,7 +48503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48522,7 +48522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48537,7 +48537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48556,7 +48556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48571,7 +48571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48590,7 +48590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48605,7 +48605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48624,7 +48624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48639,7 +48639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48658,7 +48658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48673,7 +48673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48692,7 +48692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48707,7 +48707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48726,7 +48726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48741,7 +48741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48760,7 +48760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48775,7 +48775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48794,7 +48794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48809,7 +48809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -48828,7 +48828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48843,7 +48843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -48862,7 +48862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48877,7 +48877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -48896,7 +48896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48911,7 +48911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -48930,7 +48930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48945,7 +48945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -48964,7 +48964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -48979,7 +48979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -48998,7 +48998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49013,7 +49013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49032,7 +49032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49047,7 +49047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49066,7 +49066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49081,7 +49081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49100,7 +49100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49115,7 +49115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49134,7 +49134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49149,7 +49149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49168,7 +49168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49183,7 +49183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -49202,7 +49202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49217,7 +49217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49236,7 +49236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49251,7 +49251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49270,7 +49270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49285,7 +49285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49304,7 +49304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49319,7 +49319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49338,7 +49338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49353,7 +49353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49372,7 +49372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49387,7 +49387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49406,7 +49406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49421,7 +49421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49440,7 +49440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49455,7 +49455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49474,7 +49474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49489,7 +49489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -49508,7 +49508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49523,7 +49523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49542,7 +49542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49557,7 +49557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49576,7 +49576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49591,7 +49591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49610,7 +49610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49625,7 +49625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49644,7 +49644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49659,7 +49659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49678,7 +49678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49693,7 +49693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49712,7 +49712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49727,7 +49727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -49746,7 +49746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49761,7 +49761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 697,
+        "line": 701,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -49780,7 +49780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49795,7 +49795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 697,
+        "line": 701,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -49814,7 +49814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49829,7 +49829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -49848,7 +49848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49863,7 +49863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -49882,7 +49882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49897,7 +49897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -49916,7 +49916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49931,7 +49931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -49950,7 +49950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49965,7 +49965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -49984,7 +49984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -49999,7 +49999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50018,7 +50018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50033,7 +50033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50052,7 +50052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50067,7 +50067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50086,7 +50086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50101,7 +50101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50120,7 +50120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50135,7 +50135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50154,7 +50154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50169,7 +50169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50188,7 +50188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50203,7 +50203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50222,7 +50222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50237,7 +50237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50256,7 +50256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50271,7 +50271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50290,7 +50290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50305,7 +50305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -50324,7 +50324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50339,7 +50339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -50358,7 +50358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50373,7 +50373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -50392,7 +50392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50407,7 +50407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -50426,7 +50426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50441,7 +50441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -50460,7 +50460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50475,7 +50475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -50494,7 +50494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50509,7 +50509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -50528,7 +50528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50543,7 +50543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -50562,7 +50562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50577,7 +50577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -50596,7 +50596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50611,7 +50611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -50630,7 +50630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50645,7 +50645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -50664,7 +50664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50679,7 +50679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -50698,7 +50698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50713,7 +50713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 735,
+        "line": 739,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -50732,7 +50732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50747,7 +50747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -50766,7 +50766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50781,7 +50781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -50800,7 +50800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50815,7 +50815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -50834,7 +50834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50849,7 +50849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -50868,7 +50868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50883,7 +50883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -50902,7 +50902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50917,7 +50917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -50936,7 +50936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50951,7 +50951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -50970,7 +50970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -50985,7 +50985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -51004,7 +51004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51019,7 +51019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -51038,7 +51038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51053,7 +51053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -51072,7 +51072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51087,7 +51087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -51106,7 +51106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51121,7 +51121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -51140,7 +51140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51155,7 +51155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51174,7 +51174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51189,7 +51189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51208,7 +51208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51223,7 +51223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51242,7 +51242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51257,7 +51257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51276,7 +51276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51291,7 +51291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51310,7 +51310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51325,7 +51325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51344,7 +51344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51359,7 +51359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -51378,7 +51378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51393,7 +51393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51412,7 +51412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51427,7 +51427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51446,7 +51446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51461,7 +51461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51480,7 +51480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51495,7 +51495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51514,7 +51514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51529,7 +51529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51548,7 +51548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51563,7 +51563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51582,7 +51582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51597,7 +51597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51616,7 +51616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51631,7 +51631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51650,7 +51650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51665,7 +51665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51684,7 +51684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51699,7 +51699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51718,7 +51718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51733,7 +51733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51752,7 +51752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51767,7 +51767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51786,7 +51786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51801,7 +51801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51820,7 +51820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51835,7 +51835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51854,7 +51854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51869,7 +51869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51888,7 +51888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51903,7 +51903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51922,7 +51922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51937,7 +51937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51956,7 +51956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -51971,7 +51971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -51990,7 +51990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52005,7 +52005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -52024,7 +52024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52039,7 +52039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -52058,7 +52058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52073,7 +52073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -52092,7 +52092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52107,7 +52107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52126,7 +52126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52141,7 +52141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52160,7 +52160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52175,7 +52175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52194,7 +52194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52209,7 +52209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52228,7 +52228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52243,7 +52243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52262,7 +52262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52277,7 +52277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52296,7 +52296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52311,7 +52311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52330,7 +52330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52345,7 +52345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52364,7 +52364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52379,7 +52379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52398,7 +52398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52413,7 +52413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52432,7 +52432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52447,7 +52447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52466,7 +52466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52481,7 +52481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52500,7 +52500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52515,7 +52515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -52534,7 +52534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52549,7 +52549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52568,7 +52568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52583,7 +52583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52602,7 +52602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52617,7 +52617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52636,7 +52636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52651,7 +52651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52670,7 +52670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52685,7 +52685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52704,7 +52704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52719,7 +52719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52738,7 +52738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52753,7 +52753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52772,7 +52772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52787,7 +52787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -52806,7 +52806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52821,7 +52821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -52840,7 +52840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52855,7 +52855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -52874,7 +52874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52889,7 +52889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -52908,7 +52908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52923,7 +52923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -52942,7 +52942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52957,7 +52957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -52976,7 +52976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -52991,7 +52991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53010,7 +53010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53025,7 +53025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53044,7 +53044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53059,7 +53059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53078,7 +53078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53093,7 +53093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53112,7 +53112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53127,7 +53127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53146,7 +53146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53161,7 +53161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53180,7 +53180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53195,7 +53195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53214,7 +53214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53229,7 +53229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53248,7 +53248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53263,7 +53263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53282,7 +53282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53297,7 +53297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53316,7 +53316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53331,7 +53331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53350,7 +53350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53365,7 +53365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53384,7 +53384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53399,7 +53399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53418,7 +53418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53433,7 +53433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53452,7 +53452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53467,7 +53467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53486,7 +53486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53501,7 +53501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53520,7 +53520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53535,7 +53535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53554,7 +53554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53569,7 +53569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53588,7 +53588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53603,7 +53603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -53622,7 +53622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53637,7 +53637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -53656,7 +53656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53671,7 +53671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -53690,7 +53690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53705,7 +53705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -53724,7 +53724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53739,7 +53739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -53758,7 +53758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53773,7 +53773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -53792,7 +53792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53807,7 +53807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -53826,7 +53826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53841,7 +53841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 938,
+        "line": 942,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -53860,7 +53860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53875,7 +53875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 938,
+        "line": 942,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -53894,7 +53894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53909,7 +53909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "name": "EASY_USE_ANIMA_INPUT_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -53928,7 +53928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53943,7 +53943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -53962,7 +53962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -53977,7 +53977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -53996,7 +53996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54011,7 +54011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -54030,7 +54030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54045,7 +54045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -54064,7 +54064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54079,7 +54079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -54098,7 +54098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54113,7 +54113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -54132,7 +54132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54147,7 +54147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -54166,7 +54166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54181,7 +54181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -54200,7 +54200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54215,7 +54215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -54234,7 +54234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54249,7 +54249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -54268,7 +54268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54283,7 +54283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 973,
+        "line": 977,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -54302,7 +54302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54317,7 +54317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 973,
+        "line": 977,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -54336,7 +54336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54351,7 +54351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -54370,7 +54370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54385,7 +54385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -54404,7 +54404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54419,7 +54419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -54438,7 +54438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54453,7 +54453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -54472,7 +54472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54487,7 +54487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -54506,7 +54506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54521,7 +54521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -54540,7 +54540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54555,7 +54555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -54574,7 +54574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54589,7 +54589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -54608,7 +54608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54623,7 +54623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -54642,7 +54642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54657,7 +54657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -54676,7 +54676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54691,7 +54691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -54710,7 +54710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54725,7 +54725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1004,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -54744,7 +54744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54759,7 +54759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1004,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -54778,7 +54778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54793,7 +54793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1008,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -54812,7 +54812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54827,7 +54827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1008,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -54846,7 +54846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54861,7 +54861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -54880,7 +54880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54895,7 +54895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -54914,7 +54914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54929,7 +54929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -54948,7 +54948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54963,7 +54963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -54982,7 +54982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -54997,7 +54997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1018,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -55016,7 +55016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55031,7 +55031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1018,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -55050,7 +55050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55065,7 +55065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -55084,7 +55084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55099,7 +55099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -55118,7 +55118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55133,7 +55133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -55152,7 +55152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55167,7 +55167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -55186,7 +55186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55201,7 +55201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -55220,7 +55220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55235,7 +55235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -55254,7 +55254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55269,7 +55269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -55288,7 +55288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55303,7 +55303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -55322,7 +55322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55337,7 +55337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1063,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -55356,7 +55356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55371,7 +55371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1066,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -55390,7 +55390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55405,7 +55405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55424,7 +55424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55439,7 +55439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55458,7 +55458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55473,7 +55473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55492,7 +55492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55507,7 +55507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55526,7 +55526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55541,7 +55541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55560,7 +55560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55575,7 +55575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55594,7 +55594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55609,7 +55609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55628,7 +55628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55643,7 +55643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55662,7 +55662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55677,7 +55677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55696,7 +55696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55711,7 +55711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55730,7 +55730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55745,7 +55745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55764,7 +55764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55779,7 +55779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55798,7 +55798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55813,7 +55813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55832,7 +55832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55847,7 +55847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -55866,7 +55866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55881,7 +55881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -55900,7 +55900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55915,7 +55915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -55934,7 +55934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55949,7 +55949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -55968,7 +55968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -55983,7 +55983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -56002,7 +56002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56017,7 +56017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -56036,7 +56036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56051,7 +56051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -56070,7 +56070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56085,7 +56085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -56104,7 +56104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56119,7 +56119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1095,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -56138,7 +56138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56153,7 +56153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima:correct_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1098,
         "name": "correct_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.anima",
@@ -56172,7 +56172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56187,7 +56187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima:load_knowledge_base",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1098,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "easyuse_anima.prompt.anima",
@@ -56206,7 +56206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56221,7 +56221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1099,
         "name": "parse_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.anima.parser",
@@ -56240,7 +56240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56255,7 +56255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -56274,7 +56274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56289,7 +56289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -56308,7 +56308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56323,7 +56323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -56342,7 +56342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56357,7 +56357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1105,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "easyuse_anima.translation.markers",
@@ -56376,7 +56376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56391,7 +56391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1108,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "easyuse_anima.translation.service",
@@ -56399,448 +56399,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/translation/service.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "MAX_SEED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "MAX_SEED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:MAX_SEED",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "MAX_SEED",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "PUBLIC_MAX_SEED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PUBLIC_MAX_SEED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "PUBLIC_MAX_SEED",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_DECREMENT",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_DECREMENT",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "SEED_CONTROL_DECREMENT",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_FIXED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_FIXED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "SEED_CONTROL_FIXED",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_INCREMENT",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_INCREMENT",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "SEED_CONTROL_INCREMENT",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_MODES",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_MODES",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_MODES",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "SEED_CONTROL_MODES",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "SEED_CONTROL_RANDOMIZE",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "SEED_CONTROL_RANDOMIZE",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "SEED_CONTROL_RANDOMIZE",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "WILDCARD_MODE_FIXED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "WILDCARD_MODE_FIXED",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "WILDCARD_MODE_FIXED",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "WILDCARD_MODE_POPULATE",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "WILDCARD_MODE_POPULATE",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "WILDCARD_MODE_POPULATE",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "WILDCARD_MODE_SEQUENTIAL",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "expand_wildcard_texts",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "expand_wildcard_texts",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:expand_wildcard_texts",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "expand_wildcard_texts",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "expand_wildcards",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "expand_wildcards",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:expand_wildcards",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "expand_wildcards",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
@@ -56852,7 +56410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56861,24 +56419,24 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/expansion.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "wildcard_engine:has_wildcard_syntax",
+        "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1111,
         "name": "has_wildcard_syntax",
         "optional": false,
-        "requested": "wildcard_engine",
+        "requested": "easyuse_anima.wildcard.expansion",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
         "alias": null,
-        "bound_name": "next_seed",
+        "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "branch_context": [
           {
             "branch": "except",
@@ -56886,7 +56444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56894,21 +56452,123 @@
         "classification": "compatibility_fallback",
         "column": 4,
         "compatibility_pair": {
-          "bound_name": "next_seed",
-          "target": "wildcard_engine.py",
+          "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "wildcard_engine:next_seed",
+        "imported": "easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1107,
-        "name": "next_seed",
+        "line": 1112,
+        "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
-        "requested": "wildcard_engine",
+        "requested": "easyuse_anima.wildcard.mode",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_FIXED",
+          "target": "easyuse_anima/wildcard/mode.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 1112,
+        "name": "WILDCARD_MODE_FIXED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.mode",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_POPULATE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_POPULATE",
+          "target": "easyuse_anima/wildcard/mode.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 1112,
+        "name": "WILDCARD_MODE_POPULATE",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.mode",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+          "target": "easyuse_anima/wildcard/mode.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 1112,
+        "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.mode",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -56920,7 +56580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56929,54 +56589,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "imported": "easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
-        "requested": "wildcard_engine",
+        "requested": "easyuse_anima.wildcard.mode",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_seed",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 4
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_seed",
-          "target": "wildcard_engine.py",
-          "try_line": 4
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 1107,
-        "name": "normalize_seed",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "alias": null,
@@ -56988,7 +56614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -56997,20 +56623,394 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/mode.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "imported": "easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "name": "normalize_wildcard_mode",
         "optional": false,
-        "requested": "wildcard_engine",
+        "requested": "easyuse_anima.wildcard.mode",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:next_seed",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "next_seed",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:normalize_seed",
+        "kind": "static_from",
+        "line": 1120,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 1131,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 4
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 4
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcards",
+        "kind": "static_from",
+        "line": 1131,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "alias": null,
@@ -57022,7 +57022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -57031,20 +57031,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
-          "target": "wildcard_engine.py",
+          "target": "easyuse_anima/wildcard/service.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "wildcard_engine:wildcard_sources_signature",
+        "imported": "easyuse_anima.wildcard.service:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1131,
         "name": "wildcard_sources_signature",
         "optional": false,
-        "requested": "wildcard_engine",
+        "requested": "easyuse_anima.wildcard.service",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "alias": null,
@@ -62445,57 +62445,6 @@
         "source": "wildcard_engine.py"
       },
       {
-        "alias": null,
-        "bound_name": "Path",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "pathlib:Path",
-        "kind": "static_from",
-        "line": 3,
-        "name": "Path",
-        "optional": false,
-        "requested": "pathlib",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Iterable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Iterable",
-        "kind": "static_from",
-        "line": 4,
-        "name": "Iterable",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Sequence",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Sequence",
-        "kind": "static_from",
-        "line": 4,
-        "name": "Sequence",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
         "alias": "np",
         "bound_name": "np",
         "branch_context": [],
@@ -62504,7 +62453,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 8,
+        "line": 5,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -62521,7 +62470,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62529,12 +62478,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62552,7 +62501,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62560,12 +62509,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62583,7 +62532,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62591,12 +62540,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62614,7 +62563,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62622,12 +62571,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62645,7 +62594,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62653,12 +62602,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62676,7 +62625,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62684,12 +62633,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62707,7 +62656,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62715,12 +62664,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62738,7 +62687,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62746,12 +62695,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62769,7 +62718,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62777,12 +62726,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62800,7 +62749,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62808,12 +62757,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62831,7 +62780,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62839,12 +62788,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62862,7 +62811,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -62870,12 +62819,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 11,
+        "line": 8,
         "name": "WildcardOption",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -62894,9 +62843,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -62904,12 +62853,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -62928,9 +62877,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -62938,12 +62887,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -62962,9 +62911,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -62972,12 +62921,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -62996,9 +62945,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63006,12 +62955,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63030,9 +62979,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63040,12 +62989,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63064,9 +63013,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63074,12 +63023,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63098,9 +63047,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63108,12 +63057,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63132,9 +63081,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63142,12 +63091,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63166,9 +63115,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63176,12 +63125,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63200,9 +63149,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63210,12 +63159,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63234,9 +63183,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63244,12 +63193,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63268,9 +63217,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -63278,12 +63227,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 10
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "name": "WildcardOption",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -63301,7 +63250,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63309,12 +63258,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 42,
+        "line": 39,
         "name": "sources",
         "optional": false,
         "requested": ".easyuse_anima.wildcard",
@@ -63332,7 +63281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63340,12 +63289,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63363,7 +63312,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63371,12 +63320,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63394,7 +63343,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63402,12 +63351,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63425,7 +63374,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63433,12 +63382,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "WILDCARD_EXTENSIONS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63456,7 +63405,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63464,12 +63413,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63487,7 +63436,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63495,12 +63444,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63518,7 +63467,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63526,12 +63475,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63549,7 +63498,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "internal",
@@ -63557,12 +63506,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 43,
+        "line": 40,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -63581,9 +63530,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63591,12 +63540,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 54,
+        "line": 51,
         "name": "sources",
         "optional": false,
         "requested": "easyuse_anima.wildcard",
@@ -63615,9 +63564,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63625,12 +63574,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63649,9 +63598,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63659,12 +63608,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63683,9 +63632,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63693,12 +63642,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63717,9 +63666,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63727,12 +63676,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "WILDCARD_EXTENSIONS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63751,9 +63700,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63761,12 +63710,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63785,9 +63734,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63795,12 +63744,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63819,9 +63768,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63829,12 +63778,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63853,9 +63802,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
@@ -63863,12 +63812,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 41
+          "try_line": 38
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -63886,7 +63835,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "internal",
@@ -63894,12 +63843,12 @@
         "compatibility_pair": {
           "bound_name": "_DEFAULT_WILDCARD_SNAPSHOTS",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "_DEFAULT_WILDCARD_SNAPSHOTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -63917,7 +63866,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "internal",
@@ -63925,12 +63874,12 @@
         "compatibility_pair": {
           "bound_name": "_SNAPSHOT_CACHE_LIMIT",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_SNAPSHOT_CACHE_LIMIT",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "_SNAPSHOT_CACHE_LIMIT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -63948,7 +63897,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "internal",
@@ -63956,12 +63905,12 @@
         "compatibility_pair": {
           "bound_name": "_WildcardSnapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "_WildcardSnapshot",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -63979,7 +63928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "internal",
@@ -63987,12 +63936,12 @@
         "compatibility_pair": {
           "bound_name": "_build_wildcard_snapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "_build_wildcard_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -64011,9 +63960,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
@@ -64021,12 +63970,12 @@
         "compatibility_pair": {
           "bound_name": "_DEFAULT_WILDCARD_SNAPSHOTS",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "name": "_DEFAULT_WILDCARD_SNAPSHOTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -64045,9 +63994,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
@@ -64055,12 +64004,12 @@
         "compatibility_pair": {
           "bound_name": "_SNAPSHOT_CACHE_LIMIT",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_SNAPSHOT_CACHE_LIMIT",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "name": "_SNAPSHOT_CACHE_LIMIT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -64079,9 +64028,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
@@ -64089,12 +64038,12 @@
         "compatibility_pair": {
           "bound_name": "_WildcardSnapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "name": "_WildcardSnapshot",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -64113,9 +64062,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
@@ -64123,12 +64072,12 @@
         "compatibility_pair": {
           "bound_name": "_build_wildcard_snapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 66
+          "try_line": 63
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "name": "_build_wildcard_snapshot",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -64146,7 +64095,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64154,12 +64103,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:MAX_SEED",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64177,7 +64126,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64185,12 +64134,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64208,7 +64157,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64216,12 +64165,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64239,7 +64188,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64247,12 +64196,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64270,7 +64219,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64278,12 +64227,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64301,7 +64250,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64309,12 +64258,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64332,7 +64281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64340,12 +64289,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64363,7 +64312,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64371,12 +64320,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:next_seed",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "next_seed",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64394,7 +64343,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "internal",
@@ -64402,12 +64351,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.seed:normalize_seed",
         "kind": "static_from",
-        "line": 82,
+        "line": 79,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.seed",
@@ -64426,9 +64375,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64436,12 +64385,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64460,9 +64409,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64470,12 +64419,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64494,9 +64443,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64504,12 +64453,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64528,9 +64477,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64538,12 +64487,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64562,9 +64511,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64572,12 +64521,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64596,9 +64545,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64606,12 +64555,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64630,9 +64579,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64640,12 +64589,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64664,9 +64613,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64674,12 +64623,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:next_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "next_seed",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64698,9 +64647,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
@@ -64708,12 +64657,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "easyuse_anima/wildcard/seed.py",
-          "try_line": 81
+          "try_line": 78
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:normalize_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "name": "normalize_seed",
         "optional": false,
         "requested": "easyuse_anima.wildcard.seed",
@@ -64731,7 +64680,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64739,12 +64688,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64762,7 +64711,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64770,12 +64719,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODES",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODES",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODES",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64793,7 +64742,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64801,12 +64750,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_ALIASES",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_ALIASES",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_ALIASES",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64824,7 +64773,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64832,12 +64781,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64855,7 +64804,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64863,12 +64812,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64886,7 +64835,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64894,12 +64843,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64917,7 +64866,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64925,12 +64874,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64948,7 +64897,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64956,12 +64905,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -64979,7 +64928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -64987,12 +64936,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -65010,7 +64959,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "internal",
@@ -65018,12 +64967,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 107,
+        "line": 104,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.mode",
@@ -65042,9 +64991,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65052,12 +65001,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65076,9 +65025,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65086,12 +65035,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODES",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODES",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODES",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65110,9 +65059,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65120,12 +65069,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_ALIASES",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_ALIASES",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65144,9 +65093,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65154,12 +65103,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65178,9 +65127,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65188,12 +65137,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65212,9 +65161,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65222,12 +65171,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65246,9 +65195,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65256,12 +65205,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65280,9 +65229,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65290,12 +65239,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65314,9 +65263,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65324,12 +65273,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65348,9 +65297,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
@@ -65358,12 +65307,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "easyuse_anima/wildcard/mode.py",
-          "try_line": 106
+          "try_line": 103
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "easyuse_anima.wildcard.mode",
@@ -65381,7 +65330,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 133
+            "line": 130
           }
         ],
         "classification": "internal",
@@ -65389,12 +65338,12 @@
         "compatibility_pair": {
           "bound_name": "_Selector",
           "target": "easyuse_anima/wildcard/selector.py",
-          "try_line": 133
+          "try_line": 130
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.selector:_Selector",
         "kind": "static_from",
-        "line": 134,
+        "line": 131,
         "name": "_Selector",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.selector",
@@ -65413,9 +65362,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 135,
+            "handler_line": 132,
             "kind": "try",
-            "line": 133
+            "line": 130
           }
         ],
         "classification": "compatibility_fallback",
@@ -65423,12 +65372,12 @@
         "compatibility_pair": {
           "bound_name": "_Selector",
           "target": "easyuse_anima/wildcard/selector.py",
-          "try_line": 133
+          "try_line": 130
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.selector:_Selector",
         "kind": "static_from",
-        "line": 136,
+        "line": 133,
         "name": "_Selector",
         "optional": false,
         "requested": "easyuse_anima.wildcard.selector",
@@ -65446,7 +65395,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65454,12 +65403,12 @@
         "compatibility_pair": {
           "bound_name": "COMMENT_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:COMMENT_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65477,7 +65426,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65485,12 +65434,12 @@
         "compatibility_pair": {
           "bound_name": "COUNT_SPEC_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:COUNT_SPEC_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "COUNT_SPEC_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65508,7 +65457,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65516,12 +65465,12 @@
         "compatibility_pair": {
           "bound_name": "DYNAMIC_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:DYNAMIC_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "DYNAMIC_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65539,7 +65488,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65547,12 +65496,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_FULL_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:WILDCARD_FULL_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "WILDCARD_FULL_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65570,7 +65519,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65578,12 +65527,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUANTIFIER_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:WILDCARD_QUANTIFIER_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "WILDCARD_QUANTIFIER_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65601,7 +65550,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65609,12 +65558,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:WILDCARD_RE",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "WILDCARD_RE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65632,7 +65581,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65640,12 +65589,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionLane",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_ExpansionLane",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_ExpansionLane",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65663,7 +65612,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65671,12 +65620,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionSegment",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_ExpansionSegment",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_ExpansionSegment",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65694,7 +65643,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65702,12 +65651,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionState",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_ExpansionState",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_ExpansionState",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65725,7 +65674,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65733,12 +65682,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionText",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_ExpansionText",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_ExpansionText",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65756,7 +65705,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65764,12 +65713,12 @@
         "compatibility_pair": {
           "bound_name": "_Replacement",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_Replacement",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_Replacement",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65787,7 +65736,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65795,12 +65744,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_output_prefix",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_bounded_output_prefix",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_bounded_output_prefix",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65818,7 +65767,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65826,12 +65775,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_multiselect_options",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_expand_multiselect_options",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_expand_multiselect_options",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65849,7 +65798,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65857,12 +65806,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_snapshot_texts",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_expand_snapshot_texts",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_expand_snapshot_texts",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65880,7 +65829,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65888,12 +65837,12 @@
         "compatibility_pair": {
           "bound_name": "_expansion_state_signature",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_expansion_state_signature",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_expansion_state_signature",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65911,7 +65860,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65919,12 +65868,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_count_spec",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_parse_count_spec",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_parse_count_spec",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65942,7 +65891,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65950,12 +65899,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_dynamic_options",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_parse_dynamic_options",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_parse_dynamic_options",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -65973,7 +65922,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -65981,12 +65930,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_dynamic",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_replace_dynamic",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_replace_dynamic",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66004,7 +65953,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66012,12 +65961,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_file_wildcards",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_replace_file_wildcards",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_replace_file_wildcards",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66035,7 +65984,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66043,12 +65992,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_quantified_wildcards",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_replace_quantified_wildcards",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_replace_quantified_wildcards",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66066,7 +66015,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66074,12 +66023,12 @@
         "compatibility_pair": {
           "bound_name": "_split_unescaped",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_split_unescaped",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_split_unescaped",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66097,7 +66046,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66105,12 +66054,12 @@
         "compatibility_pair": {
           "bound_name": "_utf8_length",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_utf8_length",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_utf8_length",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66128,7 +66077,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66136,12 +66085,12 @@
         "compatibility_pair": {
           "bound_name": "_utf8_width",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:_utf8_width",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_utf8_width",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66159,7 +66108,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -66167,12 +66116,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.expansion",
@@ -66191,9 +66140,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66201,12 +66150,12 @@
         "compatibility_pair": {
           "bound_name": "COMMENT_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COMMENT_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66225,9 +66174,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66235,12 +66184,12 @@
         "compatibility_pair": {
           "bound_name": "COUNT_SPEC_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COUNT_SPEC_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "COUNT_SPEC_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66259,9 +66208,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66269,12 +66218,12 @@
         "compatibility_pair": {
           "bound_name": "DYNAMIC_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:DYNAMIC_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "DYNAMIC_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66293,9 +66242,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66303,12 +66252,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_FULL_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_FULL_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "WILDCARD_FULL_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66327,9 +66276,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66337,12 +66286,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUANTIFIER_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_QUANTIFIER_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "WILDCARD_QUANTIFIER_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66361,9 +66310,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66371,12 +66320,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RE",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "WILDCARD_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66395,9 +66344,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66405,12 +66354,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionLane",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionLane",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_ExpansionLane",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66429,9 +66378,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66439,12 +66388,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionSegment",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionSegment",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_ExpansionSegment",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66463,9 +66412,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66473,12 +66422,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionState",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionState",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_ExpansionState",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66497,9 +66446,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66507,12 +66456,12 @@
         "compatibility_pair": {
           "bound_name": "_ExpansionText",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionText",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_ExpansionText",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66531,9 +66480,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66541,12 +66490,12 @@
         "compatibility_pair": {
           "bound_name": "_Replacement",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_Replacement",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_Replacement",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66565,9 +66514,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66575,12 +66524,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_output_prefix",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_bounded_output_prefix",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_bounded_output_prefix",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66599,9 +66548,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66609,12 +66558,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_multiselect_options",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expand_multiselect_options",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_expand_multiselect_options",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66633,9 +66582,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66643,12 +66592,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_snapshot_texts",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expand_snapshot_texts",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_expand_snapshot_texts",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66667,9 +66616,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66677,12 +66626,12 @@
         "compatibility_pair": {
           "bound_name": "_expansion_state_signature",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expansion_state_signature",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_expansion_state_signature",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66701,9 +66650,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66711,12 +66660,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_count_spec",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_parse_count_spec",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_parse_count_spec",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66735,9 +66684,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66745,12 +66694,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_dynamic_options",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_parse_dynamic_options",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_parse_dynamic_options",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66769,9 +66718,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66779,12 +66728,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_dynamic",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_dynamic",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_replace_dynamic",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66803,9 +66752,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66813,12 +66762,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_file_wildcards",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_file_wildcards",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_replace_file_wildcards",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66837,9 +66786,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66847,12 +66796,12 @@
         "compatibility_pair": {
           "bound_name": "_replace_quantified_wildcards",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_quantified_wildcards",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_replace_quantified_wildcards",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66871,9 +66820,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66881,12 +66830,12 @@
         "compatibility_pair": {
           "bound_name": "_split_unescaped",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_split_unescaped",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_split_unescaped",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66905,9 +66854,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66915,12 +66864,12 @@
         "compatibility_pair": {
           "bound_name": "_utf8_length",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_length",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_utf8_length",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66939,9 +66888,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66949,12 +66898,12 @@
         "compatibility_pair": {
           "bound_name": "_utf8_width",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_width",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "_utf8_width",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66973,9 +66922,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -66983,12 +66932,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "easyuse_anima/wildcard/expansion.py",
-          "try_line": 138
+          "try_line": 135
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -66998,104 +66947,225 @@
         "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
-        "alias": "_WildcardLibraryCore",
-        "bound_name": "_WildcardLibraryCore",
+        "alias": null,
+        "bound_name": "_WildcardLibrary",
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 193
+            "line": 190
           }
         ],
         "classification": "internal",
         "column": 4,
         "compatibility_pair": {
-          "bound_name": "_WildcardLibraryCore",
-          "target": "easyuse_anima/wildcard/library.py",
-          "try_line": 193
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.wildcard.library:_WildcardLibrary",
-        "kind": "static_from",
-        "line": 194,
-        "name": "_WildcardLibrary",
-        "optional": false,
-        "requested": ".easyuse_anima.wildcard.library",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/library.py"
-      },
-      {
-        "alias": "_WildcardLibraryCore",
-        "bound_name": "_WildcardLibraryCore",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 197,
-            "kind": "try",
-            "line": 193
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_WildcardLibraryCore",
-          "target": "easyuse_anima/wildcard/library.py",
-          "try_line": 193
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.library:_WildcardLibrary",
-        "kind": "static_from",
-        "line": 198,
-        "name": "_WildcardLibrary",
-        "optional": false,
-        "requested": "easyuse_anima.wildcard.library",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/library.py"
-      },
-      {
-        "alias": "_wildcard_service",
-        "bound_name": "_wildcard_service",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 202
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_wildcard_service",
+          "bound_name": "_WildcardLibrary",
           "target": "easyuse_anima/wildcard/service.py",
-          "try_line": 202
+          "try_line": 190
         },
         "conditional": true,
-        "imported": ".easyuse_anima.wildcard:service",
+        "imported": ".easyuse_anima.wildcard.service:_WildcardLibrary",
         "kind": "static_from",
-        "line": 203,
-        "name": "service",
+        "line": 191,
+        "name": "_WildcardLibrary",
         "optional": false,
-        "requested": ".easyuse_anima.wildcard",
+        "requested": ".easyuse_anima.wildcard.service",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "wildcard_engine.py",
         "target": "easyuse_anima/wildcard/service.py"
       },
       {
-        "alias": "_wildcard_service",
-        "bound_name": "_wildcard_service",
+        "alias": null,
+        "bound_name": "_load_wildcard_map",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_load_wildcard_map",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:_load_wildcard_map",
+        "kind": "static_from",
+        "line": 191,
+        "name": "_load_wildcard_map",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_wildcard_snapshot",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_wildcard_snapshot",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 191,
+        "name": "_wildcard_snapshot",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 191,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:expand_wildcards",
+        "kind": "static_from",
+        "line": 191,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "list_wildcards",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "list_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:list_wildcards",
+        "kind": "static_from",
+        "line": 191,
+        "name": "list_wildcards",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.service:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 191,
+        "name": "wildcard_sources_signature",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardLibrary",
         "branch_context": [
           {
             "branch": "except",
@@ -67103,25 +67173,229 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 204,
+            "handler_line": 200,
             "kind": "try",
-            "line": 202
+            "line": 190
           }
         ],
         "classification": "compatibility_fallback",
         "column": 4,
         "compatibility_pair": {
-          "bound_name": "_wildcard_service",
+          "bound_name": "_WildcardLibrary",
           "target": "easyuse_anima/wildcard/service.py",
-          "try_line": 202
+          "try_line": 190
         },
         "conditional": true,
-        "imported": "easyuse_anima.wildcard:service",
+        "imported": "easyuse_anima.wildcard.service:_WildcardLibrary",
         "kind": "static_from",
-        "line": 205,
-        "name": "service",
+        "line": 201,
+        "name": "_WildcardLibrary",
         "optional": false,
-        "requested": "easyuse_anima.wildcard",
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_load_wildcard_map",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_load_wildcard_map",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:_load_wildcard_map",
+        "kind": "static_from",
+        "line": 201,
+        "name": "_load_wildcard_map",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_wildcard_snapshot",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_wildcard_snapshot",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 201,
+        "name": "_wildcard_snapshot",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 201,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcards",
+        "kind": "static_from",
+        "line": 201,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "list_wildcards",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "list_wildcards",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:list_wildcards",
+        "kind": "static_from",
+        "line": 201,
+        "name": "list_wildcards",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "easyuse_anima/wildcard/service.py",
+          "try_line": 190
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 201,
+        "name": "wildcard_sources_signature",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.service",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "wildcard_engine.py",
@@ -67283,11 +67557,11 @@
       },
       {
         "from": "api.py",
-        "to": "easyuse_anima/wildcard/sources.py"
+        "to": "easyuse_anima/wildcard/service.py"
       },
       {
         "from": "api.py",
-        "to": "wildcard_engine.py"
+        "to": "easyuse_anima/wildcard/sources.py"
       },
       {
         "from": "api_contract.py",
@@ -69203,11 +69477,23 @@
       },
       {
         "from": "nodes.py",
-        "to": "easyuse_anima/workflow.py"
+        "to": "easyuse_anima/wildcard/expansion.py"
       },
       {
         "from": "nodes.py",
-        "to": "wildcard_engine.py"
+        "to": "easyuse_anima/wildcard/mode.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/workflow.py"
       },
       {
         "from": "prompt_translation.py",
@@ -69248,10 +69534,6 @@
       {
         "from": "wildcard_engine.py",
         "to": "easyuse_anima/wildcard/expansion.py"
-      },
-      {
-        "from": "wildcard_engine.py",
-        "to": "easyuse_anima/wildcard/library.py"
       },
       {
         "from": "wildcard_engine.py",
@@ -70455,7 +70737,7 @@
         "is_package": false,
         "loc": 698,
         "module": "api",
-        "normalized_git_blob_sha1": "ebce1b80abadd8b749b6ed657c5f45bcbdbc88e0",
+        "normalized_git_blob_sha1": "471ed41b4d023c7b30fc1a4408c2e356547a35e2",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
@@ -72409,9 +72691,9 @@
       },
       {
         "is_package": false,
-        "loc": 1148,
+        "loc": 1156,
         "module": "nodes",
-        "normalized_git_blob_sha1": "e218339d08d3b6eef0392f746f6998ec4293bc5e",
+        "normalized_git_blob_sha1": "fe124beda36e09e3c4c003764b9be9895cbae2b5",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -72457,13 +72739,13 @@
       },
       {
         "is_package": false,
-        "loc": 291,
+        "loc": 209,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "66bb83507b63b45e14d65a02d76e133a0004563b",
+        "normalized_git_blob_sha1": "887d1ef7dea2667f6183d3f6f215ce6a18f6c706",
         "path": "wildcard_engine.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 6,
+          "class_count": 0,
+          "function_count": 0,
           "global_count": 0
         }
       }
@@ -74304,7 +74586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74313,7 +74595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74327,7 +74609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74336,7 +74618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74350,7 +74632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74359,7 +74641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74373,7 +74655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74382,7 +74664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74396,7 +74678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74405,7 +74687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74419,7 +74701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74428,7 +74710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74442,7 +74724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74451,7 +74733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74465,7 +74747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74474,7 +74756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74488,7 +74770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74497,7 +74779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74511,7 +74793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74520,7 +74802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74534,7 +74816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74543,7 +74825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74557,7 +74839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74566,7 +74848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74580,7 +74862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74589,7 +74871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74603,7 +74885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74612,7 +74894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74626,7 +74908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74635,7 +74917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74649,7 +74931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74658,7 +74940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74672,7 +74954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74681,7 +74963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74695,7 +74977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74704,7 +74986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74718,7 +75000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74727,7 +75009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74741,7 +75023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74750,7 +75032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74764,7 +75046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74773,7 +75055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74787,7 +75069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74796,7 +75078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74810,7 +75092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74819,7 +75101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74833,7 +75115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74842,7 +75124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74856,7 +75138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74865,7 +75147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74879,7 +75161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74888,7 +75170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74902,7 +75184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74911,7 +75193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74925,7 +75207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74934,7 +75216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74948,7 +75230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74957,7 +75239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74971,7 +75253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -74980,7 +75262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -74994,7 +75276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75003,7 +75285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75017,7 +75299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75026,7 +75308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75040,7 +75322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75049,7 +75331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75063,7 +75345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75072,7 +75354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75086,7 +75368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75095,7 +75377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75109,7 +75391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75118,7 +75400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75132,7 +75414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75141,7 +75423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75155,7 +75437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75164,7 +75446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75178,7 +75460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75187,7 +75469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75201,7 +75483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75210,7 +75492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75224,7 +75506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75233,7 +75515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75247,7 +75529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75256,7 +75538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75270,7 +75552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75279,7 +75561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75293,7 +75575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75302,7 +75584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75316,7 +75598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75325,7 +75607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75339,7 +75621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75348,7 +75630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75362,7 +75644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75371,7 +75653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75385,7 +75667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75394,7 +75676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75408,7 +75690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75417,7 +75699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75431,7 +75713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75440,7 +75722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75454,7 +75736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75463,7 +75745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75477,7 +75759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75486,7 +75768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75500,7 +75782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75509,7 +75791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 631,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75523,7 +75805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75532,7 +75814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 635,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75546,7 +75828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75555,7 +75837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 635,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75569,7 +75851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75578,7 +75860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75592,7 +75874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75601,7 +75883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75615,7 +75897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75624,7 +75906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75638,7 +75920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75647,7 +75929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 639,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75661,7 +75943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75670,7 +75952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75684,7 +75966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75693,7 +75975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75707,7 +75989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75716,7 +75998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75730,7 +76012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75739,7 +76021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75753,7 +76035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75762,7 +76044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75776,7 +76058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75785,7 +76067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75799,7 +76081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75808,7 +76090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75822,7 +76104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75831,7 +76113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75845,7 +76127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75854,7 +76136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75868,7 +76150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75877,7 +76159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75891,7 +76173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75900,7 +76182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75914,7 +76196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75923,7 +76205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75937,7 +76219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75946,7 +76228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75960,7 +76242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75969,7 +76251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -75983,7 +76265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -75992,7 +76274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 650,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76006,7 +76288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76015,7 +76297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76029,7 +76311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76038,7 +76320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76052,7 +76334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76061,7 +76343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76075,7 +76357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76084,7 +76366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76098,7 +76380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76107,7 +76389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76121,7 +76403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76130,7 +76412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76144,7 +76426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76153,7 +76435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76167,7 +76449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76176,7 +76458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76190,7 +76472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76199,7 +76481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76213,7 +76495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76222,7 +76504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76236,7 +76518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76245,7 +76527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 664,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76259,7 +76541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76268,7 +76550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76282,7 +76564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76291,7 +76573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76305,7 +76587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76314,7 +76596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76328,7 +76610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76337,7 +76619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76351,7 +76633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76360,7 +76642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76374,7 +76656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76383,7 +76665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76397,7 +76679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76406,7 +76688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76420,7 +76702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76429,7 +76711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76443,7 +76725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76452,7 +76734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 677,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76466,7 +76748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76475,7 +76757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76489,7 +76771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76498,7 +76780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76512,7 +76794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76521,7 +76803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76535,7 +76817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76544,7 +76826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76558,7 +76840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76567,7 +76849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76581,7 +76863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76590,7 +76872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76604,7 +76886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76613,7 +76895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76627,7 +76909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76636,7 +76918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 697,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76650,7 +76932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76659,7 +76941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 697,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76673,7 +76955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76682,7 +76964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76696,7 +76978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76705,7 +76987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76719,7 +77001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76728,7 +77010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76742,7 +77024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76751,7 +77033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76765,7 +77047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76774,7 +77056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76788,7 +77070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76797,7 +77079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76811,7 +77093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76820,7 +77102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76834,7 +77116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76843,7 +77125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76857,7 +77139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76866,7 +77148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76880,7 +77162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76889,7 +77171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76903,7 +77185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76912,7 +77194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76926,7 +77208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76935,7 +77217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76949,7 +77231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76958,7 +77240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76972,7 +77254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -76981,7 +77263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -76995,7 +77277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77004,7 +77286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77018,7 +77300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77027,7 +77309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77041,7 +77323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77050,7 +77332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77064,7 +77346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77073,7 +77355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77087,7 +77369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77096,7 +77378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77110,7 +77392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77119,7 +77401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77133,7 +77415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77142,7 +77424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77156,7 +77438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77165,7 +77447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77179,7 +77461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77188,7 +77470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77202,7 +77484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77211,7 +77493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77225,7 +77507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77234,7 +77516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77248,7 +77530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77257,7 +77539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 730,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77271,7 +77553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77280,7 +77562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 735,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77294,7 +77576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77303,7 +77585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77317,7 +77599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77326,7 +77608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77340,7 +77622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77349,7 +77631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77363,7 +77645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77372,7 +77654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77386,7 +77668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77395,7 +77677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77409,7 +77691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77418,7 +77700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77432,7 +77714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77441,7 +77723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77455,7 +77737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77464,7 +77746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77478,7 +77760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77487,7 +77769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77501,7 +77783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77510,7 +77792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77524,7 +77806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77533,7 +77815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77547,7 +77829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77556,7 +77838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77570,7 +77852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77579,7 +77861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77593,7 +77875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77602,7 +77884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77616,7 +77898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77625,7 +77907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77639,7 +77921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77648,7 +77930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77662,7 +77944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77671,7 +77953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77685,7 +77967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77694,7 +77976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77708,7 +77990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77717,7 +77999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 754,
+        "line": 758,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77731,7 +78013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77740,7 +78022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77754,7 +78036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77763,7 +78045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77777,7 +78059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77786,7 +78068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77800,7 +78082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77809,7 +78091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77823,7 +78105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77832,7 +78114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77846,7 +78128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77855,7 +78137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77869,7 +78151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77878,7 +78160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77892,7 +78174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77901,7 +78183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77915,7 +78197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77924,7 +78206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77938,7 +78220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77947,7 +78229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77961,7 +78243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77970,7 +78252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -77984,7 +78266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -77993,7 +78275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78007,7 +78289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78016,7 +78298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78030,7 +78312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78039,7 +78321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78053,7 +78335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78062,7 +78344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78076,7 +78358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78085,7 +78367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78099,7 +78381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78108,7 +78390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78122,7 +78404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78131,7 +78413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78145,7 +78427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78154,7 +78436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78168,7 +78450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78177,7 +78459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78191,7 +78473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78200,7 +78482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78214,7 +78496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78223,7 +78505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78237,7 +78519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78246,7 +78528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78260,7 +78542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78269,7 +78551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78283,7 +78565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78292,7 +78574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78306,7 +78588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78315,7 +78597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78329,7 +78611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78338,7 +78620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78352,7 +78634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78361,7 +78643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78375,7 +78657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78384,7 +78666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78398,7 +78680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78407,7 +78689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78421,7 +78703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78430,7 +78712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78444,7 +78726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78453,7 +78735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78467,7 +78749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78476,7 +78758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78490,7 +78772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78499,7 +78781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 811,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78513,7 +78795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78522,7 +78804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78536,7 +78818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78545,7 +78827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78559,7 +78841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78568,7 +78850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78582,7 +78864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78591,7 +78873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78605,7 +78887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78614,7 +78896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78628,7 +78910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78637,7 +78919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78651,7 +78933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78660,7 +78942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78674,7 +78956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78683,7 +78965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 834,
+        "line": 838,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78697,7 +78979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78706,7 +78988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78720,7 +79002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78729,7 +79011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78743,7 +79025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78752,7 +79034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78766,7 +79048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78775,7 +79057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78789,7 +79071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78798,7 +79080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78812,7 +79094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78821,7 +79103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78835,7 +79117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78844,7 +79126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78858,7 +79140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78867,7 +79149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78881,7 +79163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78890,7 +79172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78904,7 +79186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78913,7 +79195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78927,7 +79209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78936,7 +79218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78950,7 +79232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78959,7 +79241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78973,7 +79255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -78982,7 +79264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -78996,7 +79278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79005,7 +79287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79019,7 +79301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79028,7 +79310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79042,7 +79324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79051,7 +79333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79065,7 +79347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79074,7 +79356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79088,7 +79370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79097,7 +79379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79111,7 +79393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79120,7 +79402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79134,7 +79416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79143,7 +79425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79157,7 +79439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79166,7 +79448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79180,7 +79462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79189,7 +79471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79203,7 +79485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79212,7 +79494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79226,7 +79508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79235,7 +79517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 849,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79249,7 +79531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79258,7 +79540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79272,7 +79554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79281,7 +79563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79295,7 +79577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79304,7 +79586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79318,7 +79600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79327,7 +79609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79341,7 +79623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79350,7 +79632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79364,7 +79646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79373,7 +79655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 933,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79387,7 +79669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79396,7 +79678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 938,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79410,7 +79692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79419,7 +79701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 938,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79433,7 +79715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79442,7 +79724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79456,7 +79738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79465,7 +79747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79479,7 +79761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79488,7 +79770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79502,7 +79784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79511,7 +79793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79525,7 +79807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79534,7 +79816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79548,7 +79830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79557,7 +79839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79571,7 +79853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79580,7 +79862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79594,7 +79876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79603,7 +79885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 950,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79617,7 +79899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79626,7 +79908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79640,7 +79922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79649,7 +79931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79663,7 +79945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79672,7 +79954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79686,7 +79968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79695,7 +79977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 973,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79709,7 +79991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79718,7 +80000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 973,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79732,7 +80014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79741,7 +80023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79755,7 +80037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79764,7 +80046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79778,7 +80060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79787,7 +80069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79801,7 +80083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79810,7 +80092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79824,7 +80106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79833,7 +80115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79847,7 +80129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79856,7 +80138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 987,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79870,7 +80152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79879,7 +80161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79893,7 +80175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79902,7 +80184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79916,7 +80198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79925,7 +80207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79939,7 +80221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79948,7 +80230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79962,7 +80244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79971,7 +80253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -79985,7 +80267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -79994,7 +80276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80008,7 +80290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80017,7 +80299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80031,7 +80313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80040,7 +80322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80054,7 +80336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80063,7 +80345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80077,7 +80359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80086,7 +80368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80100,7 +80382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80109,7 +80391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80123,7 +80405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80132,7 +80414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80146,7 +80428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80155,7 +80437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80169,7 +80451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80178,7 +80460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80192,7 +80474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80201,7 +80483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80215,7 +80497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80224,7 +80506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80238,7 +80520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80247,7 +80529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80261,7 +80543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80270,7 +80552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80284,7 +80566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80293,7 +80575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80307,7 +80589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80316,7 +80598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80330,7 +80612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80339,7 +80621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80353,7 +80635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80362,7 +80644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80376,7 +80658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80385,7 +80667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80399,7 +80681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80408,7 +80690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80422,7 +80704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80431,7 +80713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80445,7 +80727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80454,7 +80736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80468,7 +80750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80477,7 +80759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80491,7 +80773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80500,7 +80782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80514,7 +80796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80523,7 +80805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80537,7 +80819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80546,7 +80828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80560,7 +80842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80569,7 +80851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80583,7 +80865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80592,7 +80874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80606,7 +80888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80615,7 +80897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80629,7 +80911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80638,7 +80920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80652,7 +80934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80661,7 +80943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80675,7 +80957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80684,7 +80966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80698,7 +80980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80707,7 +80989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80721,7 +81003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80730,7 +81012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80744,7 +81026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80753,7 +81035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80767,7 +81049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80776,7 +81058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80790,7 +81072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80799,7 +81081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80813,7 +81095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80822,7 +81104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80836,7 +81118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80845,7 +81127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80859,7 +81141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80868,7 +81150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80882,7 +81164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80891,7 +81173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80905,7 +81187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80914,7 +81196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80928,7 +81210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80937,7 +81219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80951,7 +81233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80960,7 +81242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima:correct_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80974,7 +81256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -80983,7 +81265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima:load_knowledge_base",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -80997,7 +81279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81006,7 +81288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.anima.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81020,7 +81302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81029,7 +81311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81043,7 +81325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81052,7 +81334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81066,7 +81348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81075,7 +81357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81089,7 +81371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81098,7 +81380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81112,7 +81394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
@@ -81121,7 +81403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -81135,20 +81417,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:MAX_SEED",
+        "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
         "branch_context": [
@@ -81158,20 +81440,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
+        "imported": "easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81181,20 +81463,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81204,20 +81486,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81227,20 +81509,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81250,20 +81532,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "imported": "easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81273,20 +81555,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "imported": "easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/mode.py"
       },
       {
         "branch_context": [
@@ -81296,20 +81578,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81319,20 +81601,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81342,20 +81624,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81365,20 +81647,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81388,20 +81670,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:expand_wildcard_texts",
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81411,20 +81693,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:expand_wildcards",
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81434,20 +81716,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:has_wildcard_syntax",
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81457,20 +81739,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:next_seed",
+        "imported": "easyuse_anima.wildcard.seed:next_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81480,20 +81762,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "imported": "easyuse_anima.wildcard.seed:normalize_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1120,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/seed.py"
       },
       {
         "branch_context": [
@@ -81503,20 +81785,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:normalize_seed",
+        "imported": "easyuse_anima.wildcard.service:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1131,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "branch_context": [
@@ -81526,20 +81808,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "imported": "easyuse_anima.wildcard.service:expand_wildcards",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1131,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "branch_context": [
@@ -81549,20 +81831,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 570,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:wildcard_sources_signature",
+        "imported": "easyuse_anima.wildcard.service:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1131,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "branch_context": [
@@ -83458,16 +83740,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83481,16 +83763,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83504,16 +83786,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83527,16 +83809,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83550,16 +83832,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83573,16 +83855,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83596,16 +83878,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83619,16 +83901,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83642,16 +83924,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83665,16 +83947,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83688,16 +83970,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83711,16 +83993,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 25,
+            "handler_line": 22,
             "kind": "try",
-            "line": 10
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 26,
+        "line": 23,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83734,16 +84016,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 54,
+        "line": 51,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83757,16 +84039,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83780,16 +84062,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83803,16 +84085,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83826,16 +84108,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83849,16 +84131,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83872,16 +84154,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83895,16 +84177,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83918,16 +84200,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 50,
             "kind": "try",
-            "line": 41
+            "line": 38
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 55,
+        "line": 52,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83941,16 +84223,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_DEFAULT_WILDCARD_SNAPSHOTS",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83964,16 +84246,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_SNAPSHOT_CACHE_LIMIT",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83987,16 +84269,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84010,16 +84292,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 73,
+            "handler_line": 70,
             "kind": "try",
-            "line": 66
+            "line": 63
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 74,
+        "line": 71,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84033,16 +84315,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84056,16 +84338,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84079,16 +84361,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84102,16 +84384,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84125,16 +84407,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84148,16 +84430,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84171,16 +84453,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84194,16 +84476,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:next_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84217,16 +84499,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 93,
+            "handler_line": 90,
             "kind": "try",
-            "line": 81
+            "line": 78
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.seed:normalize_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 91,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84240,16 +84522,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84263,16 +84545,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODES",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84286,16 +84568,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_ALIASES",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84309,16 +84591,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84332,16 +84614,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84355,16 +84637,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84378,16 +84660,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84401,16 +84683,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84424,16 +84706,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84447,16 +84729,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 119,
+            "handler_line": 116,
             "kind": "try",
-            "line": 106
+            "line": 103
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.mode:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 120,
+        "line": 117,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84470,16 +84752,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 135,
+            "handler_line": 132,
             "kind": "try",
-            "line": 133
+            "line": 130
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.selector:_Selector",
         "kind": "static_from",
-        "line": 136,
+        "line": 133,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84493,16 +84775,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COMMENT_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84516,16 +84798,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COUNT_SPEC_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84539,16 +84821,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:DYNAMIC_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84562,16 +84844,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_FULL_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84585,16 +84867,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_QUANTIFIER_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84608,16 +84890,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_RE",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84631,16 +84913,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionLane",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84654,16 +84936,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionSegment",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84677,16 +84959,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionState",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84700,16 +84982,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionText",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84723,16 +85005,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_Replacement",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84746,16 +85028,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_bounded_output_prefix",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84769,16 +85051,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expand_multiselect_options",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84792,16 +85074,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expand_snapshot_texts",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84815,16 +85097,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expansion_state_signature",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84838,16 +85120,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_parse_count_spec",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84861,16 +85143,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_parse_dynamic_options",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84884,16 +85166,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_dynamic",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84907,16 +85189,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_file_wildcards",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84930,16 +85212,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_replace_quantified_wildcards",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84953,16 +85235,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_split_unescaped",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84976,16 +85258,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_length",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -84999,16 +85281,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_width",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -85022,16 +85304,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 165,
+            "handler_line": 162,
             "kind": "try",
-            "line": 138
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 166,
+        "line": 163,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -85045,20 +85327,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 197,
+            "handler_line": 200,
             "kind": "try",
-            "line": 193
+            "line": 190
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.wildcard.library:_WildcardLibrary",
+        "imported": "easyuse_anima.wildcard.service:_WildcardLibrary",
         "kind": "static_from",
-        "line": 198,
+        "line": 201,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/library.py"
+        "target": "easyuse_anima/wildcard/service.py"
       },
       {
         "branch_context": [
@@ -85068,16 +85350,131 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 204,
+            "handler_line": 200,
             "kind": "try",
-            "line": 202
+            "line": 190
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.wildcard:service",
+        "imported": "easyuse_anima.wildcard.service:_load_wildcard_map",
         "kind": "static_from",
-        "line": 205,
+        "line": 201,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 201,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 201,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:expand_wildcards",
+        "kind": "static_from",
+        "line": 201,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:list_wildcards",
+        "kind": "static_from",
+        "line": 201,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 200,
+            "kind": "try",
+            "line": 190
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.service:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 201,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -85099,7 +85496,8 @@
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
-      "storage.py"
+      "storage.py",
+      "wildcard_engine.py"
     ],
     "external_imports": [
       {
@@ -92295,42 +92693,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "pathlib:Path",
-        "kind": "static_from",
-        "line": 3,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Iterable",
-        "kind": "static_from",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Sequence",
-        "kind": "static_from",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 8,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -96083,7 +96448,7 @@
       },
       {
         "kind": "list",
-        "line": 1129,
+        "line": 1137,
         "module": "nodes.py",
         "name": "__all__"
       }

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -118,8 +118,8 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 0,
-    "nodes_canonical_bindings": 297,
-    "nodes_legacy_bindings": 19,
+    "nodes_canonical_bindings": 316,
+    "nodes_legacy_bindings": 0,
     "nodes_public_exports": 18,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
@@ -2833,18 +2833,18 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.workflow:unsupported_test_only",
+      "id": "nodes_canonical_bindings:easyuse_anima.wildcard.expansion:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_get_workflow_node": "_get_workflow_node"
+        "has_wildcard_syntax": "has_wildcard_syntax"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.workflow",
+      "canonical_target": "easyuse_anima.wildcard.expansion",
       "target_state": "canonical",
       "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.workflow",
+      "import_target": "easyuse_anima.wildcard.expansion",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
@@ -2862,37 +2862,121 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_legacy_bindings:wildcard_engine:unsupported_test_only",
-      "surface": "nodes_legacy_bindings",
+      "id": "nodes_canonical_bindings:easyuse_anima.wildcard.mode:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "PROMPT_STUDIO_WILDCARD_MODE_LABELS": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
+        "WILDCARD_MODE_FIXED": "WILDCARD_MODE_FIXED",
+        "WILDCARD_MODE_POPULATE": "WILDCARD_MODE_POPULATE",
+        "WILDCARD_MODE_SEQUENTIAL": "WILDCARD_MODE_SEQUENTIAL",
+        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode",
+        "normalize_wildcard_mode": "normalize_wildcard_mode"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.wildcard.mode",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.wildcard.mode",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.wildcard.seed:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
       "symbols": {
         "MAX_SEED": "MAX_SEED",
-        "PROMPT_STUDIO_WILDCARD_MODE_LABELS": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "PUBLIC_MAX_SEED": "PUBLIC_MAX_SEED",
         "SEED_CONTROL_DECREMENT": "SEED_CONTROL_DECREMENT",
         "SEED_CONTROL_FIXED": "SEED_CONTROL_FIXED",
         "SEED_CONTROL_INCREMENT": "SEED_CONTROL_INCREMENT",
         "SEED_CONTROL_MODES": "SEED_CONTROL_MODES",
         "SEED_CONTROL_RANDOMIZE": "SEED_CONTROL_RANDOMIZE",
-        "WILDCARD_MODE_FIXED": "WILDCARD_MODE_FIXED",
-        "WILDCARD_MODE_POPULATE": "WILDCARD_MODE_POPULATE",
-        "WILDCARD_MODE_SEQUENTIAL": "WILDCARD_MODE_SEQUENTIAL",
+        "next_seed": "next_seed",
+        "normalize_seed": "normalize_seed"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.wildcard.seed",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.wildcard.seed",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.wildcard.service:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
         "expand_wildcard_texts": "expand_wildcard_texts",
         "expand_wildcards": "expand_wildcards",
-        "has_wildcard_syntax": "has_wildcard_syntax",
-        "next_seed": "next_seed",
-        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode",
-        "normalize_seed": "normalize_seed",
-        "normalize_wildcard_mode": "normalize_wildcard_mode",
         "wildcard_sources_signature": "wildcard_sources_signature"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
-      "canonical_target": null,
-      "target_state": "legacy_owner",
+      "canonical_target": "easyuse_anima.wildcard.service",
+      "target_state": "canonical",
       "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
-      "import_target": "wildcard_engine",
-      "owner": "#184/#186",
+      "import_target": "easyuse_anima.wildcard.service",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.workflow:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_get_workflow_node": "_get_workflow_node"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.workflow",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.workflow",
+      "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
         "repository tests may import this root name"

--- a/tests/fixtures/python_wildcard_runtime_contract.v1.json
+++ b/tests/fixtures/python_wildcard_runtime_contract.v1.json
@@ -2,8 +2,14 @@
   "classification": "Contract",
   "compatibility_surfaces": [
     {
+      "canonical_bindings": {
+        "expand_wildcard_texts": "easyuse_anima.wildcard.service",
+        "expand_wildcards": "easyuse_anima.wildcard.service",
+        "list_wildcards": "easyuse_anima.wildcard.service",
+        "wildcard_sources_signature": "easyuse_anima.wildcard.service"
+      },
       "id": "root-public-wildcard-facade",
-      "kind": "transitional_root_facade",
+      "kind": "identity_reexport",
       "module": "wildcard_engine.py",
       "symbols": [
         "expand_wildcard_texts",
@@ -30,9 +36,24 @@
       ]
     },
     {
-      "id": "root-lifecycle-patch-seams",
-      "kind": "dynamic_reference",
+      "canonical_bindings": {
+        "_WildcardLibrary": "easyuse_anima.wildcard.service",
+        "_load_wildcard_map": "easyuse_anima.wildcard.service",
+        "_wildcard_snapshot": "easyuse_anima.wildcard.service"
+      },
+      "id": "root-private-service-identities",
+      "kind": "identity_reexport",
       "module": "wildcard_engine.py",
+      "symbols": [
+        "_wildcard_snapshot",
+        "_load_wildcard_map",
+        "_WildcardLibrary"
+      ]
+    },
+    {
+      "id": "canonical-private-lifecycle-patch-seams",
+      "kind": "dynamic_reference",
+      "module": "easyuse_anima/wildcard/service.py",
       "symbols": [
         "_build_wildcard_snapshot",
         "_wildcard_sources"
@@ -97,6 +118,19 @@
     "production_changes": 0,
     "root_identity_bindings": [
       {
+        "canonical_module": "easyuse_anima.wildcard.service",
+        "root_module": "wildcard_engine.py",
+        "symbols": [
+          "_wildcard_snapshot",
+          "_load_wildcard_map",
+          "_WildcardLibrary",
+          "expand_wildcard_texts",
+          "expand_wildcards",
+          "list_wildcards",
+          "wildcard_sources_signature"
+        ]
+      },
+      {
         "canonical_module": "easyuse_anima.wildcard.snapshot",
         "root_module": "wildcard_engine.py",
         "symbols": [
@@ -112,10 +146,10 @@
     "default_root_initialization": "Bootstrap wildcard-directory initialization and its retry state remain E-09 and are not part of the snapshot owner.",
     "generic_cache_condition_port": "rejected",
     "resource_partition": "Verified wildcard snapshots, building-key admission, and their Condition form one feature-private owner because they share one cache-key publication invariant.",
-    "root_facade": "After E-06c root wildcard_engine is a compatibility adapter over the canonical wildcard service. It retains the exact root names, signatures, results, private snapshot identities, and call-time source/build seams without owning service behavior or raw lifecycle state.",
+    "root_facade": "After P-WC-02 root wildcard_engine is an import-only compatibility shim. Its service facade names, private helpers, and snapshot identities bind directly to canonical owners while signatures, results, eager NumPy, and package/flat import parity remain.",
     "runtime_composition": "E-06d installs only one feature-specific narrow wildcard snapshot capability backed by the exact default owner; feature modules never receive the complete RuntimeServices object.",
     "snapshot_materialization": "D-12c canonical immutable snapshot values and stateless materialization remain separate behavior authorities and are not reimplemented by E-06.",
-    "test_seams": "Root build and source-module patch seams remain call-time dependencies or gain an equivalent isolated-owner injection seam before raw globals are removed."
+    "test_seams": "Private build, snapshot, and source-module patching uses the equivalent call-time seam in easyuse_anima.wildcard.service; api.list_wildcards remains a dynamic module-global callback seam."
   },
   "move_queue": [
     {
@@ -248,6 +282,67 @@
       "target_phase": "E-06b-complete"
     }
   ],
+  "post_e06_facade_move": {
+    "canonical_private_patch_owner": {
+      "module": "easyuse_anima/wildcard/service.py",
+      "symbols": [
+        "_wildcard_snapshot",
+        "_build_wildcard_snapshot",
+        "_wildcard_sources"
+      ]
+    },
+    "classification": "Move",
+    "id": "P-WC-02",
+    "next_task": "P-API-01",
+    "production_files": [
+      "api.py",
+      "nodes.py",
+      "wildcard_engine.py"
+    ],
+    "root_consumer_migrations": [
+      {
+        "canonical_imports": [
+          ["easyuse_anima.wildcard.service", "list_wildcards"],
+          ["easyuse_anima.wildcard.sources", "resolve_wildcard_roots"]
+        ],
+        "module": "api.py"
+      },
+      {
+        "canonical_imports": [
+          ["easyuse_anima.wildcard.expansion", "has_wildcard_syntax"],
+          ["easyuse_anima.wildcard.mode", "PROMPT_STUDIO_WILDCARD_MODE_LABELS"],
+          ["easyuse_anima.wildcard.mode", "WILDCARD_MODE_FIXED"],
+          ["easyuse_anima.wildcard.mode", "WILDCARD_MODE_POPULATE"],
+          ["easyuse_anima.wildcard.mode", "WILDCARD_MODE_SEQUENTIAL"],
+          ["easyuse_anima.wildcard.mode", "normalize_prompt_studio_wildcard_mode"],
+          ["easyuse_anima.wildcard.mode", "normalize_wildcard_mode"],
+          ["easyuse_anima.wildcard.seed", "MAX_SEED"],
+          ["easyuse_anima.wildcard.seed", "PUBLIC_MAX_SEED"],
+          ["easyuse_anima.wildcard.seed", "SEED_CONTROL_DECREMENT"],
+          ["easyuse_anima.wildcard.seed", "SEED_CONTROL_FIXED"],
+          ["easyuse_anima.wildcard.seed", "SEED_CONTROL_INCREMENT"],
+          ["easyuse_anima.wildcard.seed", "SEED_CONTROL_MODES"],
+          ["easyuse_anima.wildcard.seed", "SEED_CONTROL_RANDOMIZE"],
+          ["easyuse_anima.wildcard.seed", "next_seed"],
+          ["easyuse_anima.wildcard.seed", "normalize_seed"],
+          ["easyuse_anima.wildcard.service", "expand_wildcard_texts"],
+          ["easyuse_anima.wildcard.service", "expand_wildcards"],
+          ["easyuse_anima.wildcard.service", "wildcard_sources_signature"]
+        ],
+        "module": "nodes.py"
+      }
+    ],
+    "root_service_bindings": [
+      "_wildcard_snapshot",
+      "_load_wildcard_map",
+      "_WildcardLibrary",
+      "expand_wildcard_texts",
+      "expand_wildcards",
+      "list_wildcards",
+      "wildcard_sources_signature"
+    ],
+    "status": "complete"
+  },
   "production_callers": [
     {
       "function": "_load_wildcard_map",
@@ -320,5 +415,5 @@
     }
   },
   "schema_version": 1,
-  "scope": "Completed E-06 wildcard ownership sequence through the production-free E-06e audit"
+  "scope": "Completed E-06 wildcard ownership and P-WC-02 import-only root facade move"
 }

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "e218339d08d3b6eef0392f746f6998ec4293bc5e")
+        self.assertEqual(report["git_blob_sha1"], "fe124beda36e09e3c4c003764b9be9895cbae2b5")
         # B-11d removes the final residual implementation globals and records
         # the supported mapped class surface in an explicit __all__.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_148)
+        self.assertEqual(report["line_count"], 1_156)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -711,6 +711,7 @@ ignored/
                 "prompt_translation.py",
                 "settings.py",
                 "storage.py",
+                "wildcard_engine.py",
             ],
         )
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
@@ -1013,7 +1014,7 @@ ignored/
         self.assertIn(
             {
                 "from": "wildcard_engine.py",
-                "to": "easyuse_anima/wildcard/library.py",
+                "to": "easyuse_anima/wildcard/service.py",
             },
             report["imports"]["module_graph"],
         )
@@ -1150,10 +1151,13 @@ ignored/
             (item["source"], item["target"])
             for item in report["registry"]["compatibility_fallback_imports"]
         }
-        self.assertTrue(
-            {
-                ("nodes.py", "wildcard_engine.py"),
-            }.issubset(fallback_targets)
+        self.assertNotIn(
+            ("nodes.py", "wildcard_engine.py"),
+            fallback_targets,
+        )
+        self.assertIn(
+            ("wildcard_engine.py", "easyuse_anima/wildcard/service.py"),
+            fallback_targets,
         )
         self.assertFalse(
             [

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2361,8 +2361,8 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 0,
-            "nodes_canonical_bindings": 297,
-            "nodes_legacy_bindings": 19,
+            "nodes_canonical_bindings": 316,
+            "nodes_legacy_bindings": 0,
             "nodes_public_exports": 18,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,

--- a/tests/test_python_wildcard_runtime_contract.py
+++ b/tests/test_python_wildcard_runtime_contract.py
@@ -199,6 +199,7 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
                 "internal_consumers",
                 "move_queue",
                 "owners",
+                "post_e06_facade_move",
                 "production_callers",
                 "production_changes",
                 "runtime_port",
@@ -306,11 +307,13 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
             with self.subTest(module=module):
                 self.assertEqual(imports & forbidden, set())
 
-        identity_surfaces = {
-            surface["module"]: set(surface["symbols"])
-            for surface in self.fixture["compatibility_surfaces"]
-            if surface["kind"] == "identity_reexport"
-        }
+        identity_surfaces: dict[str, set[str]] = {}
+        for surface in self.fixture["compatibility_surfaces"]:
+            if surface["kind"] != "identity_reexport":
+                continue
+            identity_surfaces.setdefault(surface["module"], set()).update(
+                surface["symbols"]
+            )
         audited_bindings: dict[str, set[str]] = {}
         for binding in audit["root_identity_bindings"]:
             root_module = binding["root_module"]
@@ -420,22 +423,15 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
             & root_bindings,
             set(),
         )
-        root_lifecycle = _top_level_function(
-            "wildcard_engine.py",
-            "_wildcard_snapshot",
-        )
-        self.assertTrue(
-            {
-                "_DEFAULT_WILDCARD_SNAPSHOTS",
-                "_build_wildcard_snapshot",
-                "_wildcard_sources",
-            }
-            <= _references(root_lifecycle)
-        )
-        self.assertIn(
-            "snapshot_for_roots",
-            _called(root_lifecycle),
-        )
+        root_definitions = {
+            statement.name
+            for statement in _tree("wildcard_engine.py").body
+            if isinstance(
+                statement,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            )
+        }
+        self.assertEqual(root_definitions, set())
 
     def test_canonical_snapshot_value_remains_immutable_and_root_independent(self):
         module = "easyuse_anima/wildcard/snapshot.py"
@@ -612,15 +608,60 @@ class PythonWildcardRuntimeContractTests(unittest.TestCase):
                     _imported_names("wildcard_engine.py"),
                 )
 
-        lifecycle_references = _references(
-            _top_level_function("wildcard_engine.py", "_wildcard_snapshot")
-        )
         dynamic = next(
             surface
             for surface in self.fixture["compatibility_surfaces"]
             if surface["kind"] == "dynamic_reference"
         )
+        lifecycle_references = _references(
+            _top_level_function(dynamic["module"], "_wildcard_snapshot")
+        )
         self.assertEqual(set(dynamic["symbols"]) - lifecycle_references, set())
+
+    def test_post_e06_facade_move_is_current_and_import_only(self):
+        move = self.fixture["post_e06_facade_move"]
+        self.assertEqual(move["id"], "P-WC-02")
+        self.assertEqual(move["classification"], "Move")
+        self.assertEqual(move["status"], "complete")
+        self.assertEqual(move["next_task"], "P-API-01")
+        self.assertEqual(
+            move["production_files"],
+            ["api.py", "nodes.py", "wildcard_engine.py"],
+        )
+
+        root_imports = _imported_names("wildcard_engine.py")
+        expected_service_imports = {
+            ("easyuse_anima.wildcard.service", symbol)
+            for symbol in move["root_service_bindings"]
+        }
+        self.assertEqual(expected_service_imports - root_imports, set())
+        self.assertIn("np", _top_level_bindings("wildcard_engine.py"))
+
+        for migration in move["root_consumer_migrations"]:
+            imported = _imported_names(migration["module"])
+            with self.subTest(module=migration["module"]):
+                self.assertEqual(
+                    {tuple(binding) for binding in migration["canonical_imports"]}
+                    - imported,
+                    set(),
+                )
+                self.assertEqual(
+                    {
+                        imported_module
+                        for imported_module, _ in imported
+                        if imported_module.split(".")[-1] == "wildcard_engine"
+                    },
+                    set(),
+                )
+
+        patch_owner = move["canonical_private_patch_owner"]
+        lifecycle_references = _references(
+            _top_level_function(patch_owner["module"], "_wildcard_snapshot")
+        )
+        self.assertEqual(
+            set(patch_owner["symbols"]) - lifecycle_references,
+            {"_wildcard_snapshot"},
+        )
 
     def test_contract_document_is_linked_from_maintained_entries(self):
         self.assertTrue(CONTRACT_DOC.is_file())

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -159,6 +159,10 @@ class WildcardServiceTests(unittest.TestCase):
             "expand_wildcards",
         ):
             with self.subTest(name=name):
+                self.assertIs(
+                    getattr(wildcard_engine, name),
+                    getattr(wildcard_service, name),
+                )
                 self.assertEqual(
                     inspect.signature(getattr(wildcard_engine, name)),
                     inspect.signature(getattr(wildcard_service, name)),
@@ -249,6 +253,10 @@ class WildcardServiceTests(unittest.TestCase):
 class WildcardEngineTests(unittest.TestCase):
     def test_root_library_adapter_uses_canonical_lookup_core(self):
         self.assertEqual(wildcard_library.__all__, ())
+        self.assertIs(
+            wildcard_engine._WildcardLibrary,
+            wildcard_service._WildcardLibrary,
+        )
         self.assertTrue(
             issubclass(
                 wildcard_engine._WildcardLibrary,
@@ -469,7 +477,7 @@ class WildcardEngineTests(unittest.TestCase):
 
     def test_empty_text_batch_returns_before_snapshot_lifecycle(self):
         with patch.object(
-            wildcard_engine,
+            wildcard_service,
             "_wildcard_snapshot",
             side_effect=AssertionError("empty batch resolved a snapshot"),
         ):
@@ -993,7 +1001,7 @@ class WildcardEngineTests(unittest.TestCase):
             snapshot = wildcard_engine._wildcard_snapshot([root])
 
             with patch.object(
-                wildcard_engine,
+                wildcard_service,
                 "_load_wildcard_map",
                 side_effect=AssertionError("runtime library copied the snapshot mapping"),
             ):
@@ -1183,7 +1191,7 @@ class WildcardEngineTests(unittest.TestCase):
         build_started = threading.Event()
         release_build = threading.Event()
         build_calls = []
-        original_build = wildcard_engine._build_wildcard_snapshot
+        original_build = wildcard_service._build_wildcard_snapshot
 
         def blocked_first_build(source_state):
             snapshot = original_build(source_state)
@@ -1200,7 +1208,7 @@ class WildcardEngineTests(unittest.TestCase):
             colors.write_text("colors: [red]\n", encoding="utf-8")
 
             with patch.object(
-                wildcard_engine,
+                wildcard_service,
                 "_build_wildcard_snapshot",
                 side_effect=blocked_first_build,
             ), ThreadPoolExecutor(max_workers=1) as executor:
@@ -1225,7 +1233,7 @@ class WildcardEngineTests(unittest.TestCase):
         release_build = threading.Event()
         waiter_entered = threading.Event()
         build_calls = []
-        original_build = wildcard_engine._build_wildcard_snapshot
+        original_build = wildcard_service._build_wildcard_snapshot
         original_wait = (
             wildcard_snapshot._DEFAULT_WILDCARD_SNAPSHOTS._condition.wait
         )
@@ -1250,7 +1258,7 @@ class WildcardEngineTests(unittest.TestCase):
             )
 
             with patch.object(
-                wildcard_engine,
+                wildcard_service,
                 "_build_wildcard_snapshot",
                 side_effect=blocked_build,
             ), patch.object(

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -46,6 +46,7 @@ REGISTRY_ENTRY_MODULE_CANDIDATES = (
     "prompt_translation.py",
     "settings.py",
     "storage.py",
+    "wildcard_engine.py",
 )
 DYNAMIC_IMPORT_CALLEES = frozenset({"__import__", "importlib.import_module"})
 MUTABLE_CONSTRUCTORS = {

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Iterable, Sequence
-
 # NumPy is mandatory in supported ComfyUI runtimes and defines the seeded
 # wildcard sampling contract. A stdlib fallback would produce different results.
 import numpy as np
@@ -191,101 +188,22 @@ except ImportError:
     )
 
 try:
-    from .easyuse_anima.wildcard.library import (
-        _WildcardLibrary as _WildcardLibraryCore,
+    from .easyuse_anima.wildcard.service import (
+        _load_wildcard_map,
+        _wildcard_snapshot,
+        _WildcardLibrary,
+        expand_wildcard_texts,
+        expand_wildcards,
+        list_wildcards,
+        wildcard_sources_signature,
     )
 except ImportError:
-    from easyuse_anima.wildcard.library import (
-        _WildcardLibrary as _WildcardLibraryCore,
+    from easyuse_anima.wildcard.service import (
+        _load_wildcard_map,
+        _wildcard_snapshot,
+        _WildcardLibrary,
+        expand_wildcard_texts,
+        expand_wildcards,
+        list_wildcards,
+        wildcard_sources_signature,
     )
-
-try:
-    from .easyuse_anima.wildcard import service as _wildcard_service
-except ImportError:
-    from easyuse_anima.wildcard import service as _wildcard_service
-
-def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:
-    return _DEFAULT_WILDCARD_SNAPSHOTS.snapshot_for_roots(
-        roots,
-        scan_sources=_wildcard_sources._scan_wildcard_sources,
-        build_snapshot=_build_wildcard_snapshot,
-    )
-
-
-def _load_wildcard_map(roots: Iterable[Path]) -> dict[str, list[WildcardOption]]:
-    return _wildcard_service._load_wildcard_map_with(
-        roots,
-        snapshot_for_roots=_wildcard_snapshot,
-    )
-
-
-def list_wildcards(extra_paths: str | None = None, roots: Iterable[Path] | None = None) -> list[str]:
-    return _wildcard_service._list_wildcards_with(
-        extra_paths,
-        roots,
-        snapshot_for_roots=_wildcard_snapshot,
-    )
-
-
-def wildcard_sources_signature(extra_paths: str | None = None, roots: Iterable[Path] | None = None) -> dict:
-    return _wildcard_service._wildcard_sources_signature_with(
-        extra_paths,
-        roots,
-        snapshot_for_roots=_wildcard_snapshot,
-    )
-
-
-class _WildcardLibrary(_WildcardLibraryCore):
-    def __init__(
-        self,
-        roots: Iterable[Path] | None = None,
-        *,
-        snapshot: _WildcardSnapshot | None = None,
-    ):
-        if snapshot is None:
-            snapshot = _wildcard_snapshot(roots or ())
-        super().__init__(snapshot)
-
-
-def expand_wildcard_texts(
-    texts: Sequence[str],
-    seed=0,
-    mode: str = WILDCARD_MODE_POPULATE,
-    extra_paths: str | None = None,
-    roots: Iterable[Path] | None = None,
-    budget: WildcardExpansionBudget | None = None,
-) -> tuple[WildcardExpansionResult, ...]:
-    """Expand ordered texts through one deterministic selector stream.
-
-    Each text keeps its existing recursion and safety budget, while expansion
-    stages run across the texts in order. This matches expanding one Prompt
-    Studio prompt without joining fields through a lossy delimiter.
-    """
-    return _wildcard_service._expand_wildcard_texts_with(
-        texts,
-        seed=seed,
-        mode=mode,
-        extra_paths=extra_paths,
-        roots=roots,
-        budget=budget,
-        snapshot_for_roots=_wildcard_snapshot,
-    )
-
-
-
-def expand_wildcards(
-    text: str,
-    seed=0,
-    mode: str = WILDCARD_MODE_POPULATE,
-    extra_paths: str | None = None,
-    roots: Iterable[Path] | None = None,
-    budget: WildcardExpansionBudget | None = None,
-) -> WildcardExpansionResult:
-    return expand_wildcard_texts(
-        (text,),
-        seed=seed,
-        mode=mode,
-        extra_paths=extra_paths,
-        roots=roots,
-        budget=budget,
-    )[0]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186 / P-WC-02의 bounded Move입니다.

- `api.py`와 `nodes.py`의 Wildcard production imports를 canonical `easyuse_anima.wildcard.*` owner로 이동합니다.
- root `wildcard_engine.py`의 wrapper/adapter 구현을 제거하고 기존 공개·비공개 compatibility surface를 exact canonical identity alias로 유지합니다.
- Registry analyzer가 import-only root shim을 명시적인 package entry로 계속 추적하도록 합니다.
- 동작, seed/PCG64/sequential 결과, snapshot cache/retry/atomic publication, budget/error, root binding, dynamic API callback seam은 변경하지 않습니다.

Base: `506dacefb2181dd251b53d49c18877883d7b2103`  
Head: `4c4d59615238b82fe43f47536b12b0490fa72f25`

## 주요 파일

- Production: `api.py`, `nodes.py`, `wildcard_engine.py`, `tools/analyze_python_backend.py`
- Contracts/tests: wildcard runtime, compatibility surface, nodes/backend analyzer, direct wildcard/API/package/import owners
- Generated fixtures: Python backend analyzer, compatibility surface, wildcard runtime contract
- Docs: P-WC-02 완료와 P-API-01 READY 상태를 roadmap/ledger/index에 반영

## 검증

Focused:

- Wildcard runtime contract 11 PASS
- Wildcard service 4 PASS
- Wildcard engine 51 PASS
- Wildcard API routes 4 PASS
- Snapshot store 2 PASS
- Wildcard nodes 25 PASS
- Route registration owner 4 PASS
- Package skeleton 1 PASS
- Compatibility surface 19 PASS
- Import boundaries 6 PASS
- Registry scanner safety 8 PASS
- Backend analyzer 18 PASS
- 전체 wildcard module 88 PASS
- Nodes module analyzer 4 PASS
- changed-file AST/JSON 및 `git diff --check` PASS

Promotion:

- official full PASS: Python 1,454 tests, Pyright baseline, 11 import-boundary groups, frontend 120 files
- `comfy node validate` PASS
- `comfy node pack` PASS
- archive에 root shim과 canonical wildcard package 전체 포함, tests/docs 제외
- live ComfyUI는 host-visible behavior 변경이 없어 미실행

Ruff는 현재 정책대로 report-only이며 기존 compatibility alias/import-order finding을 유지합니다.

## 위험과 rollback

- root `wildcard_engine.py`는 외부/legacy import compatibility를 위해 유지됩니다.
- final canonical-plus-shim form은 아직 release N에 포함되지 않았으므로 제거는 승인되지 않습니다.
- rollback은 이 단일 cohesive commit revert로 가능합니다.

## Next

검토·squash merge 후 Issue #186 / P-API-01 API production-facade feasibility Contract로 진행합니다.