### PR TITLE
P-API-01 API facade/E-09 lifecycle feasibility audit

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -23,13 +23,15 @@ then only the active task section, owning Issue, direct source, and direct tests
 - P-WC-01/P-WC-02 completed the Wildcard direct-shim conversion with the existing
   canonical service owner. The final form has not shipped, so release N and removal
   remain parked.
-- First READY task: Issue
-  [#582](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/582) / P-API-01 API
-  facade and E-09 lifecycle feasibility Contract.
-- P-API-01 must use
+- P-API-01 / Issue
+  [#582](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/582) completed with a
+  **RETAIN** verdict. P-API-02 is not READY.
+- The completed evidence and revisit gates are recorded in
   [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md)
-  before selecting an API application owner. P-API-02 is forbidden until that audit
-  returns FEASIBLE.
+  and preserve the E-09 application/executor timing and root call-time seams.
+- First READY task: Issue
+  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-05A size and
+  complexity ratchet.
 - Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
   remains the compatibility ledger. It owns pre-retirement evidence and later D-14
   decisions, not an immediately executable deletion task.
@@ -41,9 +43,9 @@ COMPLETE Phase F typed-boundary and feature-error work
   -> COMPLETE G-04A public API snapshot coverage audit
   -> COMPLETE P-WC-01 Wildcard facade feasibility Contract
   -> COMPLETE P-WC-02 Wildcard internal-consumer/facade Move
-  -> READY #582 P-API-01 API facade / E-09 lifecycle Contract
-  -> OPTIONAL P-API-02 only after FEASIBLE
-  -> G-05 size ratchet
+  -> COMPLETE #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
+  -> PARKED P-API-02 until a recorded revisit event
+  -> READY G-05 size ratchet
   -> G-06 test ownership
   -> next ordinary release N
   -> later H/D-14 re-audit
@@ -145,7 +147,7 @@ Read only when the task touches the surface:
 
 - Branch/release/validation policy: [`MAINTAINING.md`](../../MAINTAINING.md)
 - Development entrypoint: [`../development/README.md`](../development/README.md)
-- Active immediate queue: `post-phase-e-maintenance-roadmap.md` + Issue #582
+- Active immediate queue: `post-phase-e-maintenance-roadmap.md` + Issue #188
 - P-API lifecycle compatibility: `python-api-papi01-e09-lifecycle-gate.md`
 - Target architecture: `python-backend.md`, ADR-001, ADR-002
 - Feature behavior: owning Issue

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #186 / P-API-01 API production-facade feasibility Contract.
+- Active first task: Issue #188 / G-05A size and complexity ratchet.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -42,7 +42,7 @@ The post-Phase-E D-14 audit records zero removal-approved root surfaces.
 | --- | --- |
 | root `__init__.py` | permanent ComfyUI entrypoint; still imports root `api.py` for production route registration |
 | `api.py` | transitional production facade; current complete canonical/facade form has not shipped and root entrypoint/runtime consumers remain |
-| `wildcard_engine.py` | behavior-bearing compatibility adapter; `api.py` and `nodes.py` still consume it and final form has not shipped |
+| `wildcard_engine.py` | import-only direct shim with no production consumer; final form has not shipped and release N has not started |
 | `api_contract.py` | final direct shim form completed after 0.6.2; release N has not started |
 | `autocomplete_dataset.py` | final direct shim form completed after 0.6.2; release N has not started |
 | `anima_prompt/` | final package shim form completed after 0.6.2; release N has not started |
@@ -80,9 +80,9 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> NOT REQUIRED G-04B minimal missing public-surface gate
   -> COMPLETE P-WC-01 wildcard pure-shim feasibility Contract  #186
   -> COMPLETE P-WC-02 internal consumer/facade Move            #186
-  -> READY P-API-01 API production-facade feasibility Contract #186
-  -> OPTIONAL P-API-02 canonical production-entry Move
-  -> G-05A    size/complexity baseline and changed-path ratchet #188
+  -> COMPLETE P-API-01 API production-facade feasibility Contract #582
+  -> RETAIN P-API-02 canonical production-entry Move
+  -> READY G-05A size/complexity baseline and changed-path ratchet #188
   -> G-06A    canonical test-ownership Contract               #188
   -> G-CLOSE  Phase F/G completion audit
 ```
@@ -210,7 +210,7 @@ Audit result:
 - private/transitional bindings remain excluded or compatibility-ledger-owned, and no
   unsupported name is promoted;
 - G-04A is complete without a synthetic fixture, so G-04B is not required;
-- the next READY task is Issue #186 / P-WC-01.
+- this audit originally advanced the queue to P-WC-01; P-WC-01/P-WC-02 are now complete.
 
 ## 5. Pre-retirement preparation without removal
 
@@ -269,7 +269,7 @@ P-WC-02 result:
   bindings are preserved;
 - the analyzer includes the shipped compatibility shim as an explicit Registry entry
   module, retaining complete 176-module archive closure without a production import;
-- the next READY task is P-API-01. Release N remains event-gated.
+- P-API-01 completed with RETAIN; G-05A is next. Release N remains event-gated.
 
 ### P-API-01 — API facade feasibility Contract
 
@@ -299,6 +299,26 @@ used as a substitute for technical ownership analysis.
 
 If a safe shape is selected, P-API-02 migrates the production entrypoint and leaves a
 compatible root facade. Public removal remains forbidden.
+
+P-API-01 result:
+
+- [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md)
+  records **RETAIN** at audited base
+  `ffa986df7a477ff68af08cae4dfe834e01bf3aa4`;
+- the current root module is the application/composition identity; one executor is
+  shared by the root facade, bootstrap cleanup item 1, and translation handler;
+- a narrow isolated-package test proves ordinary late import resolves that cached
+  application and creates no duplicate runtime, atexit callback, executor, handler,
+  registrar, route marker, or route registration;
+- canonical and bootstrap-owned candidates cannot both make root `api.py` genuinely
+  late and preserve the existing registration/request-time root callback seams without
+  a canonical-to-root back-reference, a second mutable proxy owner, or a separate
+  compatibility migration;
+- moving application creation into initialize or attaching it after runtime creation
+  would change E-09 rollback and fixed cleanup-plan timing;
+- P-API-02 is not READY. G-05A is the next task; P-API may be revisited only after a
+  recorded patch-owner migration, consumer-backed seam retirement, acyclic private
+  pre-initialize publication proof, or an explicit lifecycle Behavior Contract.
 
 ## 6. G-05A — Size and complexity ratchet
 
@@ -412,32 +432,25 @@ with Codex.
 ## 10. Codex resume instruction
 
 ```text
-Start Issue #186 / P-API-01 only from latest origin/dev after P-WC-02 merges.
+P-API-01 is complete with RETAIN. Do not start P-API-02 from this result.
 
-Read:
+For the next task, start Issue #188 / G-05A from latest origin/dev and read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- this document's P-API-01 and validation sections
-- Issue #186 latest P-API-01 checkpoint
-- root __init__.py, api.py, easyuse_anima/bootstrap.py, api/router.py, route factories
-- direct entrypoint/bootstrap/route/API compatibility and import/package owners
+- this document's G-05A and validation sections
+- Issue #188 latest G-05A checkpoint
+- tools/analyze_python_backend.py metric owners and the existing analyzer fixture/tests
 
 Do not read all historical D/E PRs and do not start D-14 removal.
 
-Without production changes, audit whether root api.py can become a pure compatibility
-facade. Inventory the root entrypoint's register_routes dependency, bootstrap
-composition, route/payload/runtime helpers, supported public names, private
-monkeypatch seams, exact object identities, and import-cycle constraints. Select one
-FEASIBLE shape with an exact bounded Move card, or RETAIN with an exact blocker and
-next evidence trigger.
+Without production changes, freeze the existing analyzer size/complexity baseline and
+add only the reviewed changed-path growth ratchet described by G-05A.
 
-Run only targeted consistency/focused checks during the edit loop and git diff check.
 Run only targeted consistency/focused checks and git diff check. Run official full
 once only if an executable gate or fixture changes. Package/live are not triggered.
 
-Push a dev-targeted Draft PR, review, and squash merge. Request focused technical PRO
-review only if direct evidence still leaves multiple valid bootstrap/router/root
-facade shapes. Do not implement the later Move in P-API-01.
+Push a dev-targeted Draft PR, review, and squash merge. Do not reopen P-API-02, D-14,
+release, or Registry work while performing G-05A.
 
 Do not change production behavior, public/root exports, routes, API payloads,
 RuntimeServices/bootstrap lifecycle, migration semantics, deprecation

--- a/docs/architecture/python-api-papi01-e09-lifecycle-gate.md
+++ b/docs/architecture/python-api-papi01-e09-lifecycle-gate.md
@@ -2,11 +2,11 @@
 
 ## Status and authority
 
-- Status: active prerequisite for P-API-01.
-- Active task: Issue #582.
+- Status: P-API-01 completed with a **RETAIN** verdict.
+- Completed task: Issue #582.
 - Parent/compatibility ledger: Issues #185 and #186.
 - Lifecycle authority: [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md).
-- Baseline: `dev` after P-WC-02 / PR #581.
+- Audited baseline: `ffa986df7a477ff68af08cae4dfe834e01bf3aa4` after PR #583.
 - Type: production-free Contract/gate.
 
 This gate does not reopen E-09. It prevents an API facade move from accidentally
@@ -265,7 +265,221 @@ Validation timing:
 - P-API-02 import/registration/archive change: validate/pack/archive and isolated import
   or API live smoke as triggered by its final task card.
 
-## 7. Future conflict guards
+## 7. P-API-01 completed inventory
+
+### Identity and ownership graph
+
+There is no separate current `Application` class. The imported root `api.py` module is
+the application/composition container. Its exact process identities are:
+
+| Identity | Created or selected by | Published/consumed by | Cleanup ownership |
+| --- | --- | --- | --- |
+| application | Python import system as the single root `api.py` module object | root entrypoint and compatibility importers | no application cleanup item |
+| translation executor | `bootstrap.build_translation_route_runtime`, invoked once by root `api.py` import | root `_PROMPT_TRANSLATION_WORKER`, bootstrap `_TRANSLATION_ROUTE_EXECUTOR`, translation handler callbacks | executor `shutdown` is cleanup item 1 |
+| 21 handlers | private bootstrap composition factories, invoked by root `api.py` | root handler globals and `_ROUTE_DEFINITIONS` | no deregistration or handler cleanup |
+| route definitions | canonical router builder, invoked by root `api.py` | root `_ROUTE_DEFINITIONS`, registrar resolver, host route registry | retained after shutdown |
+| registrar | canonical router registrar builder, invoked by root `api.py` | root `register_routes`, root entrypoint, repeated initialize | no separate cleanup; marker remains |
+| route registry | host `PromptServer.instance.routes`, selected at registrar call time | registrar and host | host-owned; never closed or cleared here |
+| runtime | `bootstrap.initialize` | bootstrap `_DEFAULT_RUNTIME` and runtime `_RUNTIME_SERVICES` as the same object | bootstrap terminal shutdown invokes `RuntimeServices.close` |
+| translation facade | bootstrap installs `runtime.translation` into the canonical service facade | route translation service calls | expected-identity restore is cleanup item 6 |
+
+The identity edges are therefore:
+
+```text
+root api module (current application identity)
+  -> executor == api._PROMPT_TRANSLATION_WORKER
+              == bootstrap._TRANSLATION_ROUTE_EXECUTOR
+              == cleanup_plan.callbacks[0].__self__
+  -> handlers == each _ROUTE_DEFINITIONS[*].handler
+  -> registrar == api.register_routes
+  -> registrar resolves api.routes / definitions / signature / web at call time
+
+bootstrap._DEFAULT_RUNTIME == runtime._RUNTIME_SERVICES
+runtime.translation == canonical translation default facade after initialize
+```
+
+The narrow executable owner
+`PythonApiFacadeLifecycleContractTests.test_package_then_late_api_import_reuses_every_application_identity`
+proves the current integrated sequence in an isolated package namespace. It imports the
+actual entrypoint, actual root `api.py`, bootstrap, router, runtime, handlers, and
+registrar with only host registration objects stubbed. A later ordinary
+`import_module(<package>.api)` resolves the cached module and preserves application,
+executor, handlers, definitions, registrar, runtime, cleanup plan, facade, route marker,
+and the exact 21 registrations. A repeated initialize keeps the runtime and route table
+unchanged and does not register a second atexit callback.
+
+### Creation and cleanup sequences
+
+Package entrypoint:
+
+```text
+import root package
+  -> import root api.py
+     -> create executor and publish both root/bootstrap references
+     -> create callbacks, handlers, definitions, and registrar
+  -> bootstrap.initialize under _INITIALIZE_LOCK
+     -> register atexit once
+     -> create and install RuntimeServices
+     -> snapshot executor shutdown as cleanup item 1 of 7
+     -> install translation facade
+     -> register routes
+     -> initialize Wildcard once or retain the OSError retry
+```
+
+Direct no-host canonical import:
+
+```text
+import easyuse_anima.bootstrap/router/route owners
+  -> no root api module
+  -> no application/executor construction
+  -> no host I/O, route registration, runtime, atexit, or lifecycle state
+```
+
+Current late root API import:
+
+```text
+package entrypoint already imported root api.py
+  -> later ordinary import resolves sys.modules entry
+  -> no module execution
+  -> no second executor/application/lifecycle state/route registration
+```
+
+This cached-import proof is a current baseline, not evidence that an entrypoint which no
+longer eagerly imports `api.py` can preserve the same root patch semantics.
+
+Repeated initialize, route failure, shutdown, and process exit remain:
+
+```text
+initialize / initialize
+  -> same lock and runtime
+  -> registrar runs each call; route marker makes the same table idempotent
+  -> a new table receives the 21 definitions
+  -> Wildcard success stays once; OSError remains retryable
+
+unexpected register-routes or Wildcard failure
+  -> preserve original error
+  -> restore only attempt-created runtime and attempt-bound facade identities
+  -> do not roll back executor, routes, marker, caches, or directories
+
+shutdown / shutdown or process atexit
+  -> same initialize lock
+  -> terminal/idempotent state
+  -> detach expected runtime identity
+  -> execute fixed seven-item cleanup
+  -> retain routes/marker; no file-I/O limiter or provider close
+```
+
+### Root symbol classification and patch time
+
+Root `api.py` declares no `__all__`. Endpoint paths, payloads, handler behavior, and
+registration are supported host contracts, but most Python names below are not declared
+public exports. The exact current buckets are:
+
+| Classification | Exact symbols or symbol family | Consumer and observation time |
+| --- | --- | --- |
+| supported compatibility input | `PromptTranslationError` base and unregistered/root-derived subclasses; injected `ProfileMutationError` | profile/translation error adapters read the injected type or dynamic fields at handler call time |
+| production application identity | `_PROMPT_TRANSLATION_WORKER`, `_translate_prompt_sync`, `_translate_prompt_for_route`, `_prompt_translation_error_response`; all 21 `*_handler` globals; `_ROUTE_DEFINITIONS`, `_ROUTE_SIGNATURE`, `routes`, `register_routes` | root entrypoint, registered host routes, bootstrap cleanup; objects are created at root import except `routes`, which the registrar republishes at call time |
+| transitional late-bound dependency seam | `server`, `web`, `_get_prompt_routes`, `_register_route_definitions`, `create_request_id`, `_run_file_io`, `public_settings`, `save_setting`, `list_wildcards`, `resolve_wildcard_roots`, `autocomplete_status`, `available_autocomplete_sources`, `search_autocomplete`, `classify_prompt_text`, `resolve_autocomplete_source`, `resolve_autocomplete_limit`, `_get_runtime`, `_collect_torch_compile_diagnostics`, `_recommend_torch_compile`, `translate_prompt_markers`, `resolve_prompt_translation_settings`, `PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS` | registrar and handler closures resolve root module globals at each registration or request call; direct owner tests intentionally patch these names |
+| transitional profile operation seam | `_list_loras`, `_list_lora_profiles`, `_list_aio_profiles`, `_load_lora_profile`, `_load_aio_profile`, `_save_lora_profile`, `_save_aio_profile`, `_delete_aio_profile`, `_rename_aio_profile`, `_fix_lora_profile_payload`, `_resolve_lora_preview_path` | profile route closures resolve them at request call time; prior Move contracts preserved the root patch point |
+| transitional payload seam | `_get_settings_payload_sync`, `_save_setting_payload_sync`, `_wildcards_payload_sync`, runtime autocomplete wrapper functions, and the profile/settings/autocomplete/translation dependency dictionaries passed to bootstrap factories | root-created lambdas resolve the module globals at request call time |
+| unsupported/test-only owner inspection | `_build_route_definitions`, `_build_route_signature`, `_build_*_route_group`, `_build_translation_route_runtime`, `_build_translation_route_handler`, `_api_router`, `_api_responses`, and feature route module aliases | direct owner tests inspect canonical factory ownership; production callers do not import these names |
+| unsupported/test-only canonical mirrors | `PROFILE_KIND_*`, profile directories/limits, repository/path/normalization helpers, and canonical profile document aliases | direct API compatibility tests inspect or invoke them; they are not in a root public export list and production route callbacks use only the subset explicitly injected above |
+
+The 21 handler identities, in canonical route order, are:
+
+```text
+get_settings_handler
+set_setting_handler
+get_long_text_settings_handler
+get_wildcards_handler
+autocomplete_status_handler
+autocomplete_handler
+classify_prompt_handler
+translate_prompt_handler
+lora_preview_handler
+loras_handler
+lora_profiles_handler
+aio_profiles_handler
+load_lora_profile_handler
+load_aio_profile_handler
+save_lora_profile_handler
+save_aio_profile_handler
+delete_aio_profile_handler
+rename_aio_profile_handler
+fix_lora_profile_handler
+save_long_text_settings_handler
+aio_torch_compile_handler
+```
+
+The key distinction is not leading underscore versus public spelling. Supported host
+behavior and the two named dynamic error seams are compatibility requirements;
+repository-only factory/constant inspection is test-only. The late-bound dependency
+families are private/transitional, but they cannot be silently converted to build-time
+canonical values because their prior task cards and direct tests deliberately preserve
+request-time patch observation.
+
+## 8. Candidate matrix and verdict
+
+| E-09 / compatibility gate | A. canonical singleton | B. bootstrap-owned application | C. current root facade |
+| --- | --- | --- | --- |
+| one bootstrap lifecycle owner, one lock, atexit once | conditional | yes in principle | **pass** |
+| terminal/idempotent shutdown; fail before callbacks after shutdown | conditional | yes in principle | **pass** |
+| repeated initialize keeps runtime identity and route refresh | conditional | conditional | **pass** |
+| one executor exists before cleanup-plan composition | requires a pre-initialize publish path into bootstrap | requires pre-initialize private application construction | **pass** |
+| executor shutdown is cleanup item 1; fixed seven-item plan | fails if construction moves into initialize or the plan is mutated later | fails if application is lazy inside initialize or attached after the plan snapshot | **pass** |
+| expected-identity rollback and original error | construction outside initialize is non-rollback as today; moving it inside changes the contract | same timing conflict | **pass** |
+| no route deregistration/marker clear, limiter/provider close, reset/hot reinitialize | achievable | achievable | **pass** |
+| late root import resolves existing application/executor/handler/registrar identities | achievable only with a canonical owner that root aliases | achievable only with a private bootstrap accessor | **pass** through normal import caching |
+| no canonical-to-root or bootstrap/application cycle | fails if canonical handlers read root globals; `easyuse_anima.api` importing bootstrap also violates the enrolled outer-owner boundary | avoids a root import, but cannot read root globals without a back-reference | **pass** |
+| supported and transitional call-time root seams keep the same patch time | **fail** unless the canonical application imports root `api.py` or adds a new proxy/migration contract | **fail** because an application built before late root import cannot close over that later module's globals | **pass** |
+| no new public bootstrap export or import-time no-host application side effect | conditional and requires a new injection path | fails for a public accessor; import-time construction changes direct-bootstrap behavior | **pass** |
+
+Verdict: **RETAIN candidate C**.
+
+A and B each preserve portions of E-09 in isolation, but neither preserves both required
+facts at once:
+
+1. the executor/application must exist before `RuntimeServices` freezes cleanup item 1;
+2. the current handler and registrar closures intentionally resolve root `api.py`
+   globals at registration/request time.
+
+Making the root module genuinely late breaks the second fact. Restoring it requires a
+canonical-to-root back-reference, a second mutable proxy/state owner, or an explicit
+compatibility migration that changes patch ownership. Constructing the application in
+`initialize`, or adding it to an already-created cleanup plan, changes E-09 rollback and
+cleanup-plan timing. Those are forbidden P-API-01/P-API-02 changes, not implementation
+details.
+
+Only C satisfies every current gate, so no focused technical PRO review is required.
+P-API-02 is **not allowed** from this result.
+
+### Retention cost and revisit events
+
+Current cost:
+
+- root entrypoint keeps an eager production import of the 698-line root facade;
+- application identity remains implicit in a module namespace rather than one typed
+  bundle;
+- route composition and compatibility callback cells remain coupled to root globals;
+- direct API tests continue to patch the root facade, and package import keeps its broad
+  API composition closure.
+
+These costs do not justify weakening E-09 or changing preserved request behavior.
+Revisit P-API only after at least one of these evidence events:
+
+1. a separate compatibility Contract migrates every preserved root call-time patch seam
+   to an exact canonical patch owner and updates its consumers;
+2. direct consumer evidence proves a named seam unsupported and its existing
+   compatibility gate explicitly retires it;
+3. an acyclic private pre-initialize application publication path is demonstrated
+   without a new public bootstrap export or no-host import side effect; or
+4. an explicit lifecycle Behavior Contract authorizes different application creation,
+   rollback, or cleanup-plan timing.
+
+The next ordinary roadmap task is G-05A. P-API-02, D-14, release, and Registry work stay
+parked.
+
+## 9. Future conflict guards
 
 ### G-05 size ratchet
 
@@ -295,7 +509,7 @@ P-WC-02 moved production consumers to canonical wildcard owners. E-09 still clea
 same `_DEFAULT_WILDCARD_SNAPSHOTS` identity at cleanup step 3. P-API must consume the
 canonical wildcard facade and must not recreate a root-owned wildcard lifecycle.
 
-## 8. Stop and PRO conditions
+## 10. Stop and PRO conditions
 
 Codex performs ordinary source inventory and Contract work without PRO review.
 
@@ -313,28 +527,25 @@ Request focused technical PRO review only when, after direct evidence:
 Routine test failures, helper placement, function names, or documentation choices do
 not require PRO review.
 
-## 9. Codex resume instruction
+## 11. Codex resume instruction
 
 ```text
-Start Issue #582 / P-API-01 from latest origin/dev.
+P-API-01 is complete with RETAIN. Do not start P-API-02 from this result.
 
-Read only:
+For the next task, start Issue #188 / G-05A from latest origin/dev and read only:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- post-phase-e-maintenance-roadmap.md P-API-01 section
-- this E-09 compatibility gate
-- Issue #582 and #186 latest checkpoints
-- root __init__.py and api.py
-- easyuse_anima/bootstrap.py, runtime.py, api/router.py
-- E-09 lifecycle, API route-owner, compatibility, package/no-host direct tests
+- post-phase-e-maintenance-roadmap.md G-05A and validation sections
+- Issue #188 latest G-05A checkpoint
+- tools/analyze_python_backend.py metric owners
+- existing analyzer fixture and direct analyzer/tool tests
 
-Do not implement P-API-02.
-Do not reread all D/E history or every route module.
+Do not reopen P-API-02, D-14, release, or Registry work.
+Do not reread all D/E history or every production module.
 
-Inventory exact identities, creation order, late root import behavior, public/private
-seams, and import cycles. Compare candidate A/B/C against every E-09 invariant.
-Return FEASIBLE or RETAIN and, only if feasible, one bounded P-API-02 task card.
+Freeze the existing analyzer size/complexity baseline and add only the reviewed
+changed-path ratchet. Size thresholds remain review triggers and must not split the
+single E-09 lifecycle owner.
 
-No production change, root removal, reset/hot-reload support, deprecation warning,
-release, tag, or Registry action.
+Follow the G-05A task card and validation boundary in the active roadmap.
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,13 +13,13 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #582 / P-API-01 API facade and E-09 lifecycle feasibility Contract;
+   - first READY task: Issue #188 / G-05A size and complexity ratchet;
    - D-14/H root removal is parked, not failed.
 4. Mandatory P-API lifecycle gate:
    [`../architecture/python-api-papi01-e09-lifecycle-gate.md`](../architecture/python-api-papi01-e09-lifecycle-gate.md)
    - preserve one bootstrap lifecycle owner, terminal shutdown, translation-executor
      identity, fixed cleanup order, rollback, and late root-import behavior;
-   - P-API-01 is production-free and must return FEASIBLE or RETAIN before a Move.
+   - P-API-01 completed with RETAIN; P-API-02 remains parked until a recorded revisit event.
 5. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
 6. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
@@ -64,9 +64,10 @@ COMPLETE  #563 Phase F typed-boundary and feature-error work
 COMPLETE  #188 G-04 public API snapshot coverage audit
 COMPLETE  #186 P-WC-01 Wildcard facade feasibility Contract
 COMPLETE  #186 P-WC-02 Wildcard direct-shim Move
-READY     #582 P-API-01 API facade / E-09 lifecycle Contract
-OPTIONAL  P-API-02 only after FEASIBLE verdict
-LATER     G-05 size ratchet / G-06 test ownership
+COMPLETE  #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
+PARKED    P-API-02 until a recorded revisit event
+READY     #188 G-05 size ratchet
+LATER     #188 G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
@@ -78,25 +79,20 @@ The D-14 stop is correct:
 - final forms completed after 0.6.2 have no release N;
 - consumer evidence and public breaking-change approval do not support removal.
 
-That stop applies only to removal. P-API-01, G-05, and G-06 remain executable.
+That stop applies only to removal. G-05 and G-06 remain executable.
 
-## Active P-API-01 source map
+## Completed P-API-01 result
 
-Start with targeted owners rather than the full repository:
+The completed evidence is intentionally narrow:
 
 ```text
-Issue #582 latest checkpoint
-Issue #186 compatibility checkpoint
-docs/architecture/post-phase-e-maintenance-roadmap.md  # P-API section
-docs/architecture/python-api-papi01-e09-lifecycle-gate.md
-root __init__.py and api.py
-easyuse_anima/bootstrap.py and runtime.py
-easyuse_anima/api/router.py
-python-runtime-e09-lifecycle-contract.md
-direct API route-owner, bootstrap/lifecycle, compatibility, package/no-host tests
+Issue #582 and #186 final P-API-01 checkpoints
+python-api-papi01-e09-lifecycle-gate.md  # RETAIN decision and revisit events
+test_python_api_facade_lifecycle_contract.py  # package -> late api identity proof
+existing E-09, route-owner, compatibility, import, and package/no-host owners
 ```
 
-P-API-01 must model the current order:
+P-API-01 confirmed the current order:
 
 ```text
 import root api.py
@@ -105,13 +101,12 @@ import root api.py
   -> freeze RuntimeServices cleanup plan
 ```
 
-The audit compares canonical-application, bootstrap-owned-application, and retained-root
-shapes. A move is FEASIBLE only when it preserves one application/executor identity,
-creates the executor before cleanup-plan composition, avoids canonical-to-root cycles,
-and makes late root `api.py` import side-effect-free with respect to application and
-lifecycle state.
+The canonical-application and bootstrap-owned-application shapes cannot preserve both
+the pre-cleanup-plan executor timing and all registration/request-time root callback
+seams without a back-reference, second mutable owner, or separate Behavior Contract.
+The retained-root shape is the only candidate that satisfies every current gate.
 
-P-API-01 does not implement the Move.
+P-API-01 made no production change and does not authorize the Move.
 
 ## E-09 non-regression summary
 

--- a/tests/test_python_api_facade_lifecycle_contract.py
+++ b/tests/test_python_api_facade_lifecycle_contract.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import atexit
+import importlib
+import importlib.util
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = "_easyuse_anima_api_facade_lifecycle_contract"
+MAPPED_CLASS_NAMES = (
+    "EasyUseAnimaAIOGenerator",
+    "EasyUseAnimaArtistMixConditioning",
+    "EasyUseAnimaDetailerAlignHook",
+    "EasyUseAnimaImageScaleByMultiple",
+    "EasyUseAnimaInput",
+    "EasyUseAnimaLoraPreset",
+    "EasyUseAnimaNAIARandomPrompt",
+    "EasyUseAnimaPromptBuilder",
+    "EasyUseAnimaPromptCorrector",
+    "EasyUseAnimaPromptCorrectorSimple",
+    "EasyUseAnimaPromptDataConditioning",
+    "EasyUseAnimaPromptDataUnpack",
+    "EasyUseAnimaPromptStudio",
+    "EasyUseAnimaPromptStudioAdvanced",
+    "EasyUseAnimaPromptStudioAdvancedV2",
+    "EasyUseAnimaPromptStudioRegional",
+    "EasyUseAnimaRegionalConditioning",
+    "EasyUseAnimaWildcard",
+)
+
+
+class _RouteRegistry:
+    def __init__(self) -> None:
+        self.registrations: list[tuple[str, str, object]] = []
+
+    def get(self, path: str):
+        return self._decorator("GET", path)
+
+    def post(self, path: str):
+        return self._decorator("POST", path)
+
+    def _decorator(self, method: str, path: str):
+        def register(handler):
+            self.registrations.append((method, path, handler))
+            return handler
+
+        return register
+
+
+class _Response:
+    pass
+
+
+def _registration_stub() -> types.ModuleType:
+    module = types.ModuleType(f"{PACKAGE_NAME}.easyuse_anima.registration")
+    mapped_classes = {}
+    for name in MAPPED_CLASS_NAMES:
+        value = type(name, (), {})
+        setattr(module, name, value)
+        mapped_classes[name] = value
+    module.NODE_CLASS_MAPPINGS = mapped_classes
+    module.NODE_DISPLAY_NAME_MAPPINGS = {}
+    return module
+
+
+@contextmanager
+def _loaded_package_entrypoint():
+    prefix = f"{PACKAGE_NAME}."
+    if any(name == PACKAGE_NAME or name.startswith(prefix) for name in sys.modules):
+        raise AssertionError(f"Synthetic package namespace is already loaded: {PACKAGE_NAME}")
+
+    spec = importlib.util.spec_from_file_location(
+        PACKAGE_NAME,
+        ROOT / "__init__.py",
+        submodule_search_locations=[str(ROOT)],
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not create package entrypoint spec")
+    package = importlib.util.module_from_spec(spec)
+    sys.modules[PACKAGE_NAME] = package
+    sys.modules[f"{PACKAGE_NAME}.easyuse_anima.registration"] = _registration_stub()
+
+    routes = _RouteRegistry()
+    server = types.ModuleType("server")
+    server.PromptServer = type(
+        "PromptServer",
+        (),
+        {"instance": types.SimpleNamespace(routes=routes)},
+    )
+    web = types.SimpleNamespace(
+        FileResponse=_Response,
+        HTTPException=Exception,
+        Response=_Response,
+        json_response=lambda payload, status=200: (payload, status),
+    )
+    aiohttp = types.ModuleType("aiohttp")
+    aiohttp.web = web
+    bootstrap = None
+
+    try:
+        with (
+            patch.dict(sys.modules, {"aiohttp": aiohttp, "server": server}),
+            patch.object(atexit, "register") as register_atexit,
+        ):
+            wildcard_sources = importlib.import_module(
+                f"{PACKAGE_NAME}.easyuse_anima.wildcard.sources"
+            )
+            with patch.object(
+                wildcard_sources,
+                "ensure_default_wildcard_root",
+                return_value=object(),
+            ):
+                spec.loader.exec_module(package)
+            bootstrap = sys.modules[f"{PACKAGE_NAME}.easyuse_anima.bootstrap"]
+            yield package, routes, register_atexit
+    finally:
+        try:
+            if bootstrap is not None:
+                bootstrap.shutdown()
+        finally:
+            for name in list(sys.modules):
+                if name == PACKAGE_NAME or name.startswith(prefix):
+                    sys.modules.pop(name, None)
+
+
+class PythonApiFacadeLifecycleContractTests(unittest.TestCase):
+    def test_package_then_late_api_import_reuses_every_application_identity(self):
+        with _loaded_package_entrypoint() as (package, routes, register_atexit):
+            api = package.api
+            bootstrap = sys.modules[f"{PACKAGE_NAME}.easyuse_anima.bootstrap"]
+            runtime_module = sys.modules[f"{PACKAGE_NAME}.easyuse_anima.runtime"]
+            translation_service = sys.modules[
+                f"{PACKAGE_NAME}.easyuse_anima.translation.service"
+            ]
+
+            runtime = runtime_module.get_runtime()
+            cleanup_plan = runtime._cleanup_plan
+            executor = api._PROMPT_TRANSLATION_WORKER
+            handlers = tuple(
+                handler for _method, _path, handler in api._ROUTE_DEFINITIONS
+            )
+            definitions = api._ROUTE_DEFINITIONS
+            registrar = api.register_routes
+            marker = getattr(routes, api._ROUTE_REGISTRATION_MARKER)
+            registrations = tuple(routes.registrations)
+
+            self.assertIs(bootstrap._TRANSLATION_ROUTE_EXECUTOR, executor)
+            self.assertEqual(len(cleanup_plan._callbacks), 7)
+            self.assertIs(cleanup_plan._callbacks[0].__self__, executor)
+            self.assertIs(
+                translation_service._DEFAULT_TRANSLATION_SERVICE,
+                runtime.translation,
+            )
+            self.assertEqual(len(registrations), 21)
+            register_atexit.assert_called_once_with(bootstrap.shutdown)
+
+            late_api = importlib.import_module(f"{PACKAGE_NAME}.api")
+
+            self.assertIs(late_api, api)
+            self.assertIs(late_api._PROMPT_TRANSLATION_WORKER, executor)
+            self.assertIs(late_api._ROUTE_DEFINITIONS, definitions)
+            self.assertEqual(
+                tuple(handler for _method, _path, handler in late_api._ROUTE_DEFINITIONS),
+                handlers,
+            )
+            self.assertIs(late_api.register_routes, registrar)
+            self.assertIs(runtime_module.get_runtime(), runtime)
+            self.assertIs(runtime._cleanup_plan, cleanup_plan)
+            self.assertEqual(tuple(routes.registrations), registrations)
+            self.assertEqual(getattr(routes, api._ROUTE_REGISTRATION_MARKER), marker)
+            register_atexit.assert_called_once_with(bootstrap.shutdown)
+
+            bootstrap.initialize(
+                register_routes=late_api.register_routes,
+                initialize_wildcards=Mock(return_value=object()),
+            )
+
+            self.assertIs(runtime_module.get_runtime(), runtime)
+            self.assertEqual(tuple(routes.registrations), registrations)
+            register_atexit.assert_called_once_with(bootstrap.shutdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #582 / P-API-01의 production-free Contract를 완료합니다.

- Base: `ffa986df7a477ff68af08cae4dfe834e01bf3aa4`
- Head: `b32f762079be8520ffca278f7e9bb251781d4ec5`
- production 코드는 변경하지 않았습니다.
- root 제거, lifecycle 변경, P-API-02, release/Registry 작업은 포함하지 않습니다.

## 결론

후보 C(현재 root production facade 유지)를 **RETAIN**으로 판정했습니다.

현재 executor/application은 RuntimeServices cleanup plan이 고정되기 전에 생성되어 cleanup item 1과 정확히 같은 identity를 사용합니다. 동시에 handler와 registrar는 root `api.py` module globals를 registration/request 시점에 resolve하는 보존 seam을 갖습니다.

후보 A/B에서 root `api.py`를 실제 late facade로 만들면 이 seam을 유지하기 위해 canonical-to-root back-reference, 두 번째 mutable proxy owner, 또는 별도 compatibility migration이 필요합니다. application 생성을 initialize 내부나 cleanup-plan 생성 뒤로 옮기면 E-09 rollback/cleanup timing이 바뀝니다. 따라서 현재 gate를 모두 만족하는 후보는 C 하나이며 P-API-02는 READY가 아닙니다.

## 주요 변경

- application/executor/handler/route-definition/registrar/runtime/facade identity와 생성·cleanup 시점을 기록했습니다.
- root API symbol을 supported compatibility, production identity, transitional late-bound seam, unsupported/test-only owner로 분류했습니다.
- package/no-host/late import/repeated initialize/failure/shutdown/process-exit sequence를 기록했습니다.
- A/B/C를 모든 E-09 invariant에 대해 비교하고 RETAIN 비용과 재검토 event를 고정했습니다.
- 실제 package entrypoint 이후 일반 late `api.py` import가 application/executor/handler/registrar/runtime/route identity를 복제하지 않는 좁은 격리 test를 추가했습니다.
- roadmap의 다음 READY를 Issue #188 / G-05A로 전환했습니다.

## 검증

Focused PASS:

- late API import lifecycle contract: 1
- bootstrap lifecycle: 13
- E-09 runtime lifecycle contract: 11
- API route registration owner: 4
- translation runtime contract: 7
- package no-host direct import: 1
- current import boundary: 1
- current analyzer fixture: 1
- feature error compatibility contract: 9
- changed-file Python compile
- git diff check

최종 SHA에서 official full을 정확히 한 번 실행했습니다.

- Python unittest: 1455 PASS
- Python compile: PASS
- Pyright baseline ratchet: PASS
- import boundary: PASS
- frontend checks: PASS
- git diff check: PASS
- Ruff: 기존 report-only 140건, 새 test finding 없음

Package/live는 production import closure나 host 동작을 바꾸지 않아 실행하지 않았습니다.

## 남은 위험과 rollback

root `api.py`의 698-line composition facade와 root-global patch coupling은 유지비용으로 남습니다. production-free 변경이므로 rollback은 이 Contract/test commit을 revert하는 범위입니다.

P-API는 root patch-owner migration, consumer-backed seam retirement, acyclic private pre-initialize publication 증거, 또는 명시적 lifecycle Behavior Contract가 생길 때만 재검토합니다.

## Next

Issue #188 / G-05A size and complexity ratchet. P-API-02, D-14, release, tag, Registry는 계속 parked입니다.