### PR TITLE
G-05A Python size/complexity changed-path ratchet

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,8 +18,8 @@ then only the active task section, owning Issue, direct source, and direct tests
   owns the current queue.
 - Phase F and Issue
   [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-04 public
-  API snapshot coverage are complete. Issue #188 continues to own G-05 size/complexity
-  ratchet and G-06 test ownership.
+  API snapshot coverage and G-05 size/complexity ratchet are complete. Issue #188
+  continues to own G-06 test ownership.
 - P-WC-01/P-WC-02 completed the Wildcard direct-shim conversion with the existing
   canonical service owner. The final form has not shipped, so release N and removal
   remain parked.
@@ -30,8 +30,8 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md)
   and preserve the E-09 application/executor timing and root call-time seams.
 - First READY task: Issue
-  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-05A size and
-  complexity ratchet.
+  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-06A canonical
+  test-ownership Contract.
 - Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
   remains the compatibility ledger. It owns pre-retirement evidence and later D-14
   decisions, not an immediately executable deletion task.
@@ -45,8 +45,8 @@ COMPLETE Phase F typed-boundary and feature-error work
   -> COMPLETE P-WC-02 Wildcard internal-consumer/facade Move
   -> COMPLETE #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
   -> PARKED P-API-02 until a recorded revisit event
-  -> READY G-05 size ratchet
-  -> G-06 test ownership
+  -> COMPLETE G-05 size ratchet
+  -> READY G-06 test ownership
   -> next ordinary release N
   -> later H/D-14 re-audit
 ```
@@ -92,6 +92,9 @@ of architectural success by itself.
   completed Phase F typed-boundary inventory and classifications.
 - [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
   completed public-surface owner map, root-name classifications, and no-G-04B decision.
+- [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md):
+  analyzer-owned line metrics, compact reviewed-overage ledger, and incremental growth
+  ratchet.
 - [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md):
   FEASIBLE Wildcard direct-shim decision and P-WC-02 boundary.
 - [`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md):

--- a/docs/architecture/post-phase-e-maintenance-roadmap.md
+++ b/docs/architecture/post-phase-e-maintenance-roadmap.md
@@ -4,7 +4,7 @@
 
 - Status: active execution plan after Phase D and Phase E completion.
 - Primary parent: Issue #185.
-- Active first task: Issue #188 / G-05A size and complexity ratchet.
+- Active first task: Issue #188 / G-06A canonical test ownership.
 - Quality owner: Issue #188.
 - Compatibility ledger: Issue #186.
 - D-14/H status: parked by compatibility gates, not failed.
@@ -54,7 +54,7 @@ ADR-002 result when evidence is absent or ambiguous.
 ### Remaining global roadmap work
 
 - G-04 public API snapshot coverage is complete; no G-04B gate was required.
-- G-05 size/complexity growth ratchet is not implemented as a blocking incremental gate.
+- G-05 size/complexity growth ratchet is complete as a blocking incremental gate.
 - G-06 canonical test ownership is not completed.
 - `api.py` has not reached a proven pure-shim form. `wildcard_engine.py` has reached
   its final direct-shim form, but that form has not shipped and release N has not begun.
@@ -82,8 +82,8 @@ COMPLETE F-02a Autocomplete typed result contracts             #563 / PR #566
   -> COMPLETE P-WC-02 internal consumer/facade Move            #186
   -> COMPLETE P-API-01 API production-facade feasibility Contract #582
   -> RETAIN P-API-02 canonical production-entry Move
-  -> READY G-05A size/complexity baseline and changed-path ratchet #188
-  -> G-06A    canonical test-ownership Contract               #188
+  -> COMPLETE G-05A size/complexity baseline and changed-path ratchet #188
+  -> READY G-06A canonical test-ownership Contract             #188
   -> G-CLOSE  Phase F/G completion audit
 ```
 
@@ -159,7 +159,7 @@ Audit result, updated after F-02d merged at
 - the common feature error taxonomy row is complete after F-02e fixes the executable
   inventory, F-02f adds category inheritance, F-02g makes fixture-known concrete HTTP
   policy API-authoritative, and F-02h records zero unmapped errors;
-- Phase F is complete and Issue #188 / G-04A is READY.
+- Phase F and Issue #188 / G-04A are complete.
 
 ## 4. G-04A — Public API snapshot coverage audit
 
@@ -269,7 +269,8 @@ P-WC-02 result:
   bindings are preserved;
 - the analyzer includes the shipped compatibility shim as an explicit Registry entry
   module, retaining complete 176-module archive closure without a production import;
-- P-API-01 completed with RETAIN; G-05A is next. Release N remains event-gated.
+- P-API-01 completed with RETAIN; G-05A is complete and G-06A is next. Release N
+  remains event-gated.
 
 ### P-API-01 — API facade feasibility Contract
 
@@ -316,7 +317,8 @@ P-API-01 result:
   compatibility migration;
 - moving application creation into initialize or attaching it after runtime creation
   would change E-09 rollback and fixed cleanup-plan timing;
-- P-API-02 is not READY. G-05A is the next task; P-API may be revisited only after a
+- P-API-02 is not READY. G-05A is complete and G-06A is the next task; P-API may be
+  revisited only after a
   recorded patch-owner migration, consumer-backed seam retirement, acyclic private
   pre-initialize publication proof, or an explicit lifecycle Behavior Contract.
 
@@ -325,6 +327,9 @@ P-API-01 result:
 Owner: Issue #188.
 
 Type: Contract/tool.
+
+Status: complete. The executable contract is documented in
+[`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md).
 
 Reuse `tools/analyze_python_backend.py` module/function metrics. Do not introduce a
 second repository inventory.
@@ -434,23 +439,24 @@ with Codex.
 ```text
 P-API-01 is complete with RETAIN. Do not start P-API-02 from this result.
 
-For the next task, start Issue #188 / G-05A from latest origin/dev and read:
+For the next task, start Issue #188 / G-06A from latest origin/dev and read:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
-- this document's G-05A and validation sections
-- Issue #188 latest G-05A checkpoint
-- tools/analyze_python_backend.py metric owners and the existing analyzer fixture/tests
+- this document's G-06A and validation sections
+- Issue #188 latest G-06A checkpoint
+- existing feature-package test owners, compatibility/package/live matrices, and their
+  direct contract tests
 
 Do not read all historical D/E PRs and do not start D-14 removal.
 
-Without production changes, freeze the existing analyzer size/complexity baseline and
-add only the reviewed changed-path growth ratchet described by G-05A.
+Without production changes, create only the compact canonical test-ownership map
+described by G-06A. Reuse existing tests and do not move historical tests for symmetry.
 
 Run only targeted consistency/focused checks and git diff check. Run official full
 once only if an executable gate or fixture changes. Package/live are not triggered.
 
 Push a dev-targeted Draft PR, review, and squash merge. Do not reopen P-API-02, D-14,
-release, or Registry work while performing G-05A.
+release, or Registry work while performing G-06A.
 
 Do not change production behavior, public/root exports, routes, API payloads,
 RuntimeServices/bootstrap lifecycle, migration semantics, deprecation

--- a/docs/architecture/python-size-complexity-g05a-contract.md
+++ b/docs/architecture/python-size-complexity-g05a-contract.md
@@ -1,0 +1,73 @@
+# Python Size and Complexity G-05A Contract
+
+## Status and scope
+
+- Status: completed G-05A Contract/tool.
+- Owner: Issue #188.
+- Production behavior: unchanged.
+- Metric owner: `tools/analyze_python_backend.py` schema 3.
+- Blocking gate: `tools/check_python_size_complexity.py` through the ordinary Python
+  quality runner.
+
+G-05A is an incremental review ratchet. It is not a mandate to split a cohesive
+module or function merely because a line trigger is exceeded.
+
+## Metric and inventory ownership
+
+The existing AST-only backend analyzer remains the only shipped-Python inventory. Its
+module records now include deterministic function/method records with qualified name,
+definition span, async/kind classification, and line count. Decorators are included in
+the definition span; nested functions and methods are recorded; duplicate qualified
+names receive a stable source-order suffix.
+
+`python_size_complexity_contract.v1.json` is a compact projection containing only the
+current reviewed overages. It is not a second file inventory. The initial line-based
+review triggers are:
+
+| Owner type | Trigger |
+| --- | ---: |
+| ordinary production module | 800 lines |
+| API/node/composition/infrastructure adapter module | 400 lines |
+| production function or method | 120 lines |
+
+The adapter classification is deterministic: root `__init__.py`, `api.py`, `nodes.py`,
+canonical bootstrap/registration, and canonical API, node, and infrastructure package
+paths. Changing that classification is a contract change reviewed under Issue #188.
+
+## Ratchet rules
+
+- A current metric at or below its trigger passes without a ledger entry.
+- A new over-trigger module/function fails until a reviewed exception names an owner
+  issue and a concrete decomposition boundary.
+- A reviewed overage may stay equal or decrease. Growth above its checked-in
+  `baseline_loc` fails.
+- Deleting or renaming a reviewed path or qualified function leaves a stale-ledger
+  failure. A deliberate Move updates the ledger in the same reviewed PR.
+- Raising a reviewed cap is an explicit fixture diff; it does not happen implicitly
+  from analyzer regeneration.
+- The checker does not read Git history, import production modules, or write state.
+
+The initial G-05A contract is line-based. It does not invent a cyclomatic threshold or
+authorize broad cleanup that the owning roadmap did not request.
+
+## E-09 non-regression
+
+`easyuse_anima/bootstrap.py` and `initialize` use Issue #187 as their reviewed owner.
+Their decomposition boundary keeps the E-09 lifecycle lock, initialization, rollback,
+fixed cleanup plan, repeated-initialize identity, terminal shutdown, and cleanup order
+cohesive. G-05A therefore cannot be used to create a second lifecycle owner or a hot
+reset/reinitialize API.
+
+## Direct evidence and maintenance
+
+- `tests/test_python_backend_analyzer.py` owns deterministic metric identity and the
+  repository analyzer fixture.
+- `tests/test_python_size_complexity.py` owns threshold, decrease, growth, new-owner,
+  rename, and exception-metadata behavior.
+- `tests/test_python_quality_contract.py` owns the exactly-once quality-runner call.
+
+When production Python changes, run the checker before updating an exception. Ratchet a
+decrease by lowering or removing the affected ledger record. For deliberate
+over-trigger growth or a Move, update only the affected record with its reviewed
+owner/decomposition evidence, then regenerate the analyzer fixture if the existing
+analyzer contract requires it.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Current backend queue:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - first READY task: Issue #188 / G-05A size and complexity ratchet;
+   - first READY task: Issue #188 / G-06A canonical test-ownership Contract;
    - D-14/H root removal is parked, not failed.
 4. Mandatory P-API lifecycle gate:
    [`../architecture/python-api-papi01-e09-lifecycle-gate.md`](../architecture/python-api-papi01-e09-lifecycle-gate.md)
@@ -66,8 +66,8 @@ COMPLETE  #186 P-WC-01 Wildcard facade feasibility Contract
 COMPLETE  #186 P-WC-02 Wildcard direct-shim Move
 COMPLETE  #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
 PARKED    P-API-02 until a recorded revisit event
-READY     #188 G-05 size ratchet
-LATER     #188 G-06 test ownership
+COMPLETE  #188 G-05 size ratchet
+READY     #188 G-06 test ownership
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
@@ -122,11 +122,11 @@ P-API-01 made no production change and does not authorize the Move.
 
 ## Following queue
 
-After P-API-01:
+After P-API-01 and G-05A:
 
 1. run one bounded P-API-02 only when the verdict is FEASIBLE;
-2. otherwise record RETAIN and continue to G-05;
-3. add G-05 changed-path size growth and G-06 test-ownership gates;
+2. retain the recorded P-API verdict and completed G-05 changed-path growth gate;
+3. continue with the G-06 test-ownership Contract;
 4. let the next ordinary release containing final shims become release N;
 5. re-audit D-14 only after an event gate changes.
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -2,7 +2,7 @@
   "determinism": {
     "encoding": "utf-8-sig",
     "newline_normalization": "CRLF and CR become LF before parsing and hashing",
-    "ordering": "paths, modules, edges, candidates, SCCs, and JSON keys are sorted",
+    "ordering": "paths, modules, functions, edges, candidates, SCCs, and JSON keys are sorted",
     "path_format": "repository-relative POSIX"
   },
   "imports": {
@@ -70638,6 +70638,16 @@
     "module_count": 176,
     "modules": [
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 35,
+            "kind": "function",
+            "line": 30,
+            "loc": 6,
+            "qualified_name": "_load_comfy_nodes"
+          }
+        ],
         "is_package": true,
         "loc": 50,
         "module": "__root__",
@@ -70650,6 +70660,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 38,
         "module": "anima_prompt",
@@ -70662,6 +70673,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 16,
         "module": "anima_prompt.correction",
@@ -70674,6 +70686,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 23,
         "module": "anima_prompt.knowledge",
@@ -70686,6 +70699,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 26,
         "module": "anima_prompt.models",
@@ -70698,6 +70712,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 16,
         "module": "anima_prompt.normalize",
@@ -70710,6 +70725,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 44,
         "module": "anima_prompt.ordering",
@@ -70722,6 +70738,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 8,
         "module": "anima_prompt.parser",
@@ -70734,6 +70751,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 197,
+            "kind": "function",
+            "line": 191,
+            "loc": 7,
+            "qualified_name": "_runtime_autocomplete"
+          },
+          {
+            "async": false,
+            "end_line": 204,
+            "kind": "function",
+            "line": 200,
+            "loc": 5,
+            "qualified_name": "resolve_autocomplete_source_path"
+          },
+          {
+            "async": false,
+            "end_line": 211,
+            "kind": "function",
+            "line": 207,
+            "loc": 5,
+            "qualified_name": "available_autocomplete_sources"
+          },
+          {
+            "async": false,
+            "end_line": 218,
+            "kind": "function",
+            "line": 214,
+            "loc": 5,
+            "qualified_name": "autocomplete_status"
+          },
+          {
+            "async": false,
+            "end_line": 240,
+            "kind": "function",
+            "line": 221,
+            "loc": 20,
+            "qualified_name": "search_autocomplete"
+          },
+          {
+            "async": false,
+            "end_line": 259,
+            "kind": "function",
+            "line": 243,
+            "loc": 17,
+            "qualified_name": "classify_prompt_text"
+          }
+        ],
         "is_package": false,
         "loc": 698,
         "module": "api",
@@ -70746,6 +70813,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 54,
         "module": "api_contract",
@@ -70758,6 +70826,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 58,
         "module": "autocomplete_dataset",
@@ -70770,6 +70839,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 35,
         "module": "autocomplete_index",
@@ -70782,6 +70852,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 5,
         "module": "easyuse_anima",
@@ -70794,6 +70865,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.aio",
@@ -70806,6 +70878,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "function",
+            "line": 21,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 32,
+            "kind": "function",
+            "line": 27,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 35,
+            "loc": 8,
+            "qualified_name": "_aio_prompt_data_fields_for_usdu"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 45,
+            "loc": 32,
+            "qualified_name": "_aio_usdu_prompt_without_general"
+          },
+          {
+            "async": false,
+            "end_line": 127,
+            "kind": "function",
+            "line": 79,
+            "loc": 49,
+            "qualified_name": "_aio_usdu_conditioning"
+          }
+        ],
         "is_package": false,
         "loc": 130,
         "module": "easyuse_anima.aio.conditioning",
@@ -70818,6 +70932,248 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "method",
+            "line": 39,
+            "loc": 20,
+            "qualified_name": "_AIOFirstPassCacheEntry.capture"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "method",
+            "line": 60,
+            "loc": 5,
+            "qualified_name": "_AIOFirstPassCacheEntry.checkout"
+          },
+          {
+            "async": false,
+            "end_line": 93,
+            "kind": "method",
+            "line": 82,
+            "loc": 12,
+            "qualified_name": "_AIOFirstPassCacheStore.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 98,
+            "kind": "method",
+            "line": 95,
+            "loc": 4,
+            "qualified_name": "_AIOFirstPassCacheStore.enabled"
+          },
+          {
+            "async": false,
+            "end_line": 109,
+            "kind": "method",
+            "line": 100,
+            "loc": 10,
+            "qualified_name": "_AIOFirstPassCacheStore._collections"
+          },
+          {
+            "async": false,
+            "end_line": 121,
+            "kind": "method",
+            "line": 111,
+            "loc": 11,
+            "qualified_name": "_AIOFirstPassCacheStore.total_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 130,
+            "kind": "method",
+            "line": 123,
+            "loc": 8,
+            "qualified_name": "_AIOFirstPassCacheStore.metrics_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 135,
+            "kind": "method",
+            "line": 132,
+            "loc": 4,
+            "qualified_name": "_AIOFirstPassCacheStore.reset_metrics"
+          },
+          {
+            "async": false,
+            "end_line": 139,
+            "kind": "method",
+            "line": 137,
+            "loc": 3,
+            "qualified_name": "_AIOFirstPassCacheStore.record_metric"
+          },
+          {
+            "async": false,
+            "end_line": 151,
+            "kind": "method",
+            "line": 141,
+            "loc": 11,
+            "qualified_name": "_AIOFirstPassCacheStore.clear"
+          },
+          {
+            "async": false,
+            "end_line": 168,
+            "kind": "method",
+            "line": 153,
+            "loc": 16,
+            "qualified_name": "_AIOFirstPassCacheStore.set_enabled"
+          },
+          {
+            "async": false,
+            "end_line": 206,
+            "kind": "method",
+            "line": 170,
+            "loc": 37,
+            "qualified_name": "_AIOFirstPassCacheStore.get"
+          },
+          {
+            "async": false,
+            "end_line": 252,
+            "kind": "method",
+            "line": 208,
+            "loc": 45,
+            "qualified_name": "_AIOFirstPassCacheStore.put"
+          },
+          {
+            "async": false,
+            "end_line": 282,
+            "kind": "function",
+            "line": 260,
+            "loc": 23,
+            "qualified_name": "_clone_aio_cache_value"
+          },
+          {
+            "async": false,
+            "end_line": 344,
+            "kind": "function",
+            "line": 285,
+            "loc": 60,
+            "qualified_name": "_aio_cache_value_size_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 352,
+            "kind": "function",
+            "line": 347,
+            "loc": 6,
+            "qualified_name": "_aio_cache_pair_size_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 363,
+            "kind": "function",
+            "line": 355,
+            "loc": 9,
+            "qualified_name": "_aio_first_pass_cache_entry_size_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 369,
+            "kind": "function",
+            "line": 366,
+            "loc": 4,
+            "qualified_name": "_aio_first_pass_cache_total_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 373,
+            "kind": "function",
+            "line": 372,
+            "loc": 2,
+            "qualified_name": "_aio_first_pass_cache_metrics_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 377,
+            "kind": "function",
+            "line": 376,
+            "loc": 2,
+            "qualified_name": "_reset_aio_first_pass_cache_metrics"
+          },
+          {
+            "async": false,
+            "end_line": 381,
+            "kind": "function",
+            "line": 380,
+            "loc": 2,
+            "qualified_name": "_record_aio_first_pass_cache_metric"
+          },
+          {
+            "async": false,
+            "end_line": 388,
+            "kind": "function",
+            "line": 384,
+            "loc": 5,
+            "qualified_name": "_clear_aio_first_pass_cache"
+          },
+          {
+            "async": false,
+            "end_line": 396,
+            "kind": "function",
+            "line": 391,
+            "loc": 6,
+            "qualified_name": "_set_aio_first_pass_cache_enabled"
+          },
+          {
+            "async": false,
+            "end_line": 400,
+            "kind": "function",
+            "line": 399,
+            "loc": 2,
+            "qualified_name": "_aio_first_pass_cache_now"
+          },
+          {
+            "async": false,
+            "end_line": 426,
+            "kind": "function",
+            "line": 403,
+            "loc": 24,
+            "qualified_name": "_aio_first_pass_resource_revision"
+          },
+          {
+            "async": false,
+            "end_line": 413,
+            "kind": "function",
+            "line": 409,
+            "loc": 5,
+            "qualified_name": "_aio_first_pass_resource_revision.revision"
+          },
+          {
+            "async": false,
+            "end_line": 505,
+            "kind": "function",
+            "line": 429,
+            "loc": 77,
+            "qualified_name": "_aio_first_pass_model_patch_plan"
+          },
+          {
+            "async": false,
+            "end_line": 568,
+            "kind": "function",
+            "line": 508,
+            "loc": 61,
+            "qualified_name": "_aio_first_pass_cache_key"
+          },
+          {
+            "async": false,
+            "end_line": 576,
+            "kind": "function",
+            "line": 571,
+            "loc": 6,
+            "qualified_name": "_get_aio_first_pass_cache"
+          },
+          {
+            "async": false,
+            "end_line": 586,
+            "kind": "function",
+            "line": 579,
+            "loc": 8,
+            "qualified_name": "_put_aio_first_pass_cache"
+          }
+        ],
         "is_package": false,
         "loc": 589,
         "module": "easyuse_anima.aio.first_pass_cache",
@@ -70830,6 +71186,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 487,
         "module": "easyuse_anima.aio.generation_defaults",
@@ -70842,6 +71199,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "method",
+            "line": 31,
+            "loc": 9,
+            "qualified_name": "AIOGenerationSAM3Config.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "method",
+            "line": 41,
+            "loc": 2,
+            "qualified_name": "AIOGenerationSAM3Config.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 135,
+            "kind": "method",
+            "line": 82,
+            "loc": 54,
+            "qualified_name": "AIOGenerationDetailerTargetConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 157,
+            "kind": "method",
+            "line": 137,
+            "loc": 21,
+            "qualified_name": "AIOGenerationDetailerTargetConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 169,
+            "kind": "function",
+            "line": 166,
+            "loc": 4,
+            "qualified_name": "_is_detailer_target_name"
+          },
+          {
+            "async": false,
+            "end_line": 201,
+            "kind": "method",
+            "line": 180,
+            "loc": 22,
+            "qualified_name": "AIOGenerationDetailerConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 208,
+            "kind": "method",
+            "line": 203,
+            "loc": 6,
+            "qualified_name": "AIOGenerationDetailerConfig.to_dict"
+          }
+        ],
         "is_package": false,
         "loc": 209,
         "module": "easyuse_anima.aio.generation_detailer",
@@ -70854,6 +71269,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "method",
+            "line": 45,
+            "loc": 10,
+            "qualified_name": "AIODetailerStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 93,
+            "kind": "method",
+            "line": 56,
+            "loc": 38,
+            "qualified_name": "AIODetailerStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 96,
         "module": "easyuse_anima.aio.generation_detailer_stage",
@@ -70866,6 +71299,264 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 33,
+            "kind": "method",
+            "line": 27,
+            "loc": 7,
+            "qualified_name": "AIOGenerationAuraFlowConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "method",
+            "line": 35,
+            "loc": 2,
+            "qualified_name": "AIOGenerationAuraFlowConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 57,
+            "kind": "method",
+            "line": 47,
+            "loc": 11,
+            "qualified_name": "AIOGenerationStageScopeConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 65,
+            "kind": "method",
+            "line": 59,
+            "loc": 7,
+            "qualified_name": "AIOGenerationStageScopeConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "method",
+            "line": 77,
+            "loc": 15,
+            "qualified_name": "AIOGenerationDAVEConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 98,
+            "kind": "method",
+            "line": 93,
+            "loc": 6,
+            "qualified_name": "AIOGenerationDAVEConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 139,
+            "kind": "method",
+            "line": 115,
+            "loc": 25,
+            "qualified_name": "AIOGenerationSafePAGConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "method",
+            "line": 141,
+            "loc": 10,
+            "qualified_name": "AIOGenerationSafePAGConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 194,
+            "kind": "method",
+            "line": 166,
+            "loc": 29,
+            "qualified_name": "AIOGenerationTorchCompileConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 204,
+            "kind": "method",
+            "line": 196,
+            "loc": 9,
+            "qualified_name": "AIOGenerationTorchCompileConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 242,
+            "kind": "method",
+            "line": 216,
+            "loc": 27,
+            "qualified_name": "AIOGenerationKJConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 251,
+            "kind": "method",
+            "line": 244,
+            "loc": 8,
+            "qualified_name": "AIOGenerationKJConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 273,
+            "kind": "method",
+            "line": 262,
+            "loc": 12,
+            "qualified_name": "AIOGenerationModelPatchesConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 280,
+            "kind": "method",
+            "line": 275,
+            "loc": 6,
+            "qualified_name": "AIOGenerationModelPatchesConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 314,
+            "kind": "method",
+            "line": 296,
+            "loc": 19,
+            "qualified_name": "AIOGenerationModGuidanceAdvancedConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 323,
+            "kind": "method",
+            "line": 316,
+            "loc": 8,
+            "qualified_name": "AIOGenerationModGuidanceAdvancedConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 345,
+            "kind": "method",
+            "line": 333,
+            "loc": 13,
+            "qualified_name": "AIOGenerationModGuidanceConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 350,
+            "kind": "method",
+            "line": 347,
+            "loc": 4,
+            "qualified_name": "AIOGenerationModGuidanceConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 389,
+            "kind": "method",
+            "line": 366,
+            "loc": 24,
+            "qualified_name": "AIOGenerationArtistMixConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 399,
+            "kind": "method",
+            "line": 391,
+            "loc": 9,
+            "qualified_name": "AIOGenerationArtistMixConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 447,
+            "kind": "method",
+            "line": 419,
+            "loc": 29,
+            "qualified_name": "AIOGenerationHighresConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 458,
+            "kind": "method",
+            "line": 449,
+            "loc": 10,
+            "qualified_name": "AIOGenerationHighresConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 516,
+            "kind": "method",
+            "line": 485,
+            "loc": 32,
+            "qualified_name": "AIOGenerationUSDUConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 533,
+            "kind": "method",
+            "line": 518,
+            "loc": 16,
+            "qualified_name": "AIOGenerationUSDUConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 558,
+            "kind": "method",
+            "line": 546,
+            "loc": 13,
+            "qualified_name": "AIOGenerationResShiftConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 564,
+            "kind": "method",
+            "line": 560,
+            "loc": 5,
+            "qualified_name": "AIOGenerationResShiftConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 612,
+            "kind": "method",
+            "line": 584,
+            "loc": 29,
+            "qualified_name": "AIOGenerationUpscaleConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 623,
+            "kind": "method",
+            "line": 614,
+            "loc": 10,
+            "qualified_name": "AIOGenerationUpscaleConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 644,
+            "kind": "method",
+            "line": 634,
+            "loc": 11,
+            "qualified_name": "AIOGenerationFitConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 650,
+            "kind": "method",
+            "line": 646,
+            "loc": 5,
+            "qualified_name": "AIOGenerationFitConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 668,
+            "kind": "method",
+            "line": 659,
+            "loc": 10,
+            "qualified_name": "AIOGenerationPostprocessConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 671,
+            "kind": "method",
+            "line": 670,
+            "loc": 2,
+            "qualified_name": "AIOGenerationPostprocessConfig.to_dict"
+          }
+        ],
         "is_package": false,
         "loc": 672,
         "module": "easyuse_anima.aio.generation_features",
@@ -70878,6 +71569,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "method",
+            "line": 67,
+            "loc": 10,
+            "qualified_name": "AIOFirstPassStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "method",
+            "line": 78,
+            "loc": 71,
+            "qualified_name": "AIOFirstPassStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 151,
         "module": "easyuse_anima.aio.generation_first_pass",
@@ -70890,6 +71599,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "method",
+            "line": 51,
+            "loc": 10,
+            "qualified_name": "AIOHighresStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 110,
+            "kind": "method",
+            "line": 62,
+            "loc": 49,
+            "qualified_name": "AIOHighresStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 113,
         "module": "easyuse_anima.aio.generation_highres",
@@ -70902,6 +71629,128 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 40,
+            "loc": 2,
+            "qualified_name": "_new_model_list"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 44,
+            "loc": 2,
+            "qualified_name": "_new_variant_cache"
+          },
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "function",
+            "line": 48,
+            "loc": 2,
+            "qualified_name": "_new_stage_patch_map"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "method",
+            "line": 53,
+            "loc": 8,
+            "qualified_name": "PreviewSaver.__call__"
+          },
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "method",
+            "line": 77,
+            "loc": 5,
+            "qualified_name": "EphemeralModelRegistry.register_model"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "method",
+            "line": 83,
+            "loc": 3,
+            "qualified_name": "EphemeralModelRegistry.closed"
+          },
+          {
+            "async": false,
+            "end_line": 105,
+            "kind": "method",
+            "line": 87,
+            "loc": 19,
+            "qualified_name": "EphemeralModelRegistry.close"
+          },
+          {
+            "async": false,
+            "end_line": 132,
+            "kind": "method",
+            "line": 129,
+            "loc": 4,
+            "qualified_name": "ModelVariantResolver.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 136,
+            "kind": "method",
+            "line": 134,
+            "loc": 3,
+            "qualified_name": "ModelVariantResolver.mod_guidance_model"
+          },
+          {
+            "async": false,
+            "end_line": 156,
+            "kind": "method",
+            "line": 138,
+            "loc": 19,
+            "qualified_name": "ModelVariantResolver.standalone_model"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "method",
+            "line": 158,
+            "loc": 6,
+            "qualified_name": "ModelVariantResolver.for_backend"
+          },
+          {
+            "async": false,
+            "end_line": 180,
+            "kind": "method",
+            "line": 165,
+            "loc": 16,
+            "qualified_name": "ModelVariantResolver.prepare_first_pass"
+          },
+          {
+            "async": false,
+            "end_line": 220,
+            "kind": "method",
+            "line": 205,
+            "loc": 16,
+            "qualified_name": "StageModelVariantResolver.resolve"
+          },
+          {
+            "async": false,
+            "end_line": 223,
+            "kind": "method",
+            "line": 222,
+            "loc": 2,
+            "qualified_name": "StageModelVariantResolver.patch_ids"
+          },
+          {
+            "async": false,
+            "end_line": 255,
+            "kind": "method",
+            "line": 241,
+            "loc": 15,
+            "qualified_name": "PreviewCollector.add"
+          }
+        ],
         "is_package": false,
         "loc": 258,
         "module": "easyuse_anima.aio.generation_lifecycle",
@@ -70914,6 +71763,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "function",
+            "line": 35,
+            "loc": 4,
+            "qualified_name": "_require_positive_version"
+          },
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 41,
+            "loc": 7,
+            "qualified_name": "_copy_generation_settings"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 50,
+            "loc": 12,
+            "qualified_name": "detect_aio_generation_settings_version"
+          },
+          {
+            "async": false,
+            "end_line": 84,
+            "kind": "method",
+            "line": 70,
+            "loc": 15,
+            "qualified_name": "AIOGenerationMigrationStep.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "method",
+            "line": 91,
+            "loc": 12,
+            "qualified_name": "AIOGenerationMigrationRegistry.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 108,
+            "kind": "method",
+            "line": 104,
+            "loc": 5,
+            "qualified_name": "AIOGenerationMigrationRegistry.step_from"
+          },
+          {
+            "async": false,
+            "end_line": 118,
+            "kind": "method",
+            "line": 110,
+            "loc": 9,
+            "qualified_name": "AIOGenerationMigrationRegistry.with_step"
+          },
+          {
+            "async": false,
+            "end_line": 137,
+            "kind": "function",
+            "line": 121,
+            "loc": 17,
+            "qualified_name": "_migrate_aio_generation_settings_v1_to_v2"
+          },
+          {
+            "async": false,
+            "end_line": 156,
+            "kind": "function",
+            "line": 140,
+            "loc": 17,
+            "qualified_name": "_migrate_aio_generation_settings_v2_to_v3"
+          },
+          {
+            "async": false,
+            "end_line": 175,
+            "kind": "function",
+            "line": 159,
+            "loc": 17,
+            "qualified_name": "_migrate_aio_generation_settings_v3_to_v4"
+          },
+          {
+            "async": false,
+            "end_line": 242,
+            "kind": "function",
+            "line": 198,
+            "loc": 45,
+            "qualified_name": "migrate_aio_generation_settings"
+          }
+        ],
         "is_package": false,
         "loc": 245,
         "module": "easyuse_anima.aio.generation_migrations",
@@ -70926,6 +71865,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 88,
+            "kind": "function",
+            "line": 85,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 91,
+            "loc": 6,
+            "qualified_name": "_comfy_max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 103,
+            "kind": "function",
+            "line": 102,
+            "loc": 2,
+            "qualified_name": "_is_aio_detailer_target_name"
+          },
+          {
+            "async": false,
+            "end_line": 117,
+            "kind": "function",
+            "line": 106,
+            "loc": 12,
+            "qualified_name": "_aio_detailer_target_defaults"
+          },
+          {
+            "async": false,
+            "end_line": 138,
+            "kind": "function",
+            "line": 120,
+            "loc": 19,
+            "qualified_name": "_aio_detailer_target_order"
+          },
+          {
+            "async": false,
+            "end_line": 126,
+            "kind": "function",
+            "line": 123,
+            "loc": 4,
+            "qualified_name": "_aio_detailer_target_order.append_target"
+          },
+          {
+            "async": false,
+            "end_line": 154,
+            "kind": "function",
+            "line": 141,
+            "loc": 14,
+            "qualified_name": "_aio_detailer_has_enabled_targets"
+          },
+          {
+            "async": false,
+            "end_line": 158,
+            "kind": "function",
+            "line": 157,
+            "loc": 2,
+            "qualified_name": "_normalize_aio_seed"
+          },
+          {
+            "async": false,
+            "end_line": 174,
+            "kind": "function",
+            "line": 161,
+            "loc": 14,
+            "qualified_name": "_merge_versioned_settings"
+          },
+          {
+            "async": false,
+            "end_line": 172,
+            "kind": "function",
+            "line": 165,
+            "loc": 8,
+            "qualified_name": "_merge_versioned_settings.merge_dict"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "function",
+            "line": 177,
+            "loc": 15,
+            "qualified_name": "_migrate_supported_aio_generation_settings"
+          },
+          {
+            "async": false,
+            "end_line": 296,
+            "kind": "function",
+            "line": 194,
+            "loc": 103,
+            "qualified_name": "_normalize_aio_spectrum_settings"
+          },
+          {
+            "async": false,
+            "end_line": 429,
+            "kind": "function",
+            "line": 299,
+            "loc": 131,
+            "qualified_name": "_normalize_aio_dit_corrections_settings"
+          },
+          {
+            "async": false,
+            "end_line": 1112,
+            "kind": "function",
+            "line": 432,
+            "loc": 681,
+            "qualified_name": "_normalize_aio_generation_settings"
+          }
+        ],
         "is_package": false,
         "loc": 1115,
         "module": "easyuse_anima.aio.generation_normalization",
@@ -70938,6 +71991,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "method",
+            "line": 26,
+            "loc": 11,
+            "qualified_name": "AIOGenerationCivitaiHashFetcherConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "method",
+            "line": 38,
+            "loc": 5,
+            "qualified_name": "AIOGenerationCivitaiHashFetcherConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 115,
+            "kind": "method",
+            "line": 67,
+            "loc": 49,
+            "qualified_name": "AIOGenerationImageSaverConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 132,
+            "kind": "method",
+            "line": 117,
+            "loc": 16,
+            "qualified_name": "AIOGenerationImageSaverConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 154,
+            "kind": "method",
+            "line": 142,
+            "loc": 13,
+            "qualified_name": "AIOGenerationSaveConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 160,
+            "kind": "method",
+            "line": 156,
+            "loc": 5,
+            "qualified_name": "AIOGenerationSaveConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 186,
+            "kind": "method",
+            "line": 171,
+            "loc": 16,
+            "qualified_name": "AIOGenerationPreviewConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 193,
+            "kind": "method",
+            "line": 188,
+            "loc": 6,
+            "qualified_name": "AIOGenerationPreviewConfig.to_dict"
+          }
+        ],
         "is_package": false,
         "loc": 194,
         "module": "easyuse_anima.aio.generation_output",
@@ -70950,6 +72069,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "function",
+            "line": 20,
+            "loc": 2,
+            "qualified_name": "_new_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 24,
+            "loc": 2,
+            "qualified_name": "_new_previews"
+          },
+          {
+            "async": false,
+            "end_line": 97,
+            "kind": "method",
+            "line": 93,
+            "loc": 5,
+            "qualified_name": "GenerationStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 103,
+            "kind": "method",
+            "line": 99,
+            "loc": 5,
+            "qualified_name": "GenerationStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 116,
         "module": "easyuse_anima.aio.generation_pipeline",
@@ -70962,6 +72115,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "method",
+            "line": 40,
+            "loc": 10,
+            "qualified_name": "AIOPostprocessStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 95,
+            "kind": "method",
+            "line": 51,
+            "loc": 45,
+            "qualified_name": "AIOPostprocessStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 98,
         "module": "easyuse_anima.aio.generation_postprocess_stage",
@@ -70974,6 +72145,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "method",
+            "line": 37,
+            "loc": 23,
+            "qualified_name": "AIOGenerationSpectrumConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 69,
+            "kind": "method",
+            "line": 61,
+            "loc": 9,
+            "qualified_name": "AIOGenerationSpectrumConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 92,
+            "kind": "method",
+            "line": 80,
+            "loc": 13,
+            "qualified_name": "AIOGenerationSPDConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 98,
+            "kind": "method",
+            "line": 94,
+            "loc": 5,
+            "qualified_name": "AIOGenerationSPDConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 152,
+            "kind": "method",
+            "line": 122,
+            "loc": 31,
+            "qualified_name": "AIOGenerationDiTCorrectionsConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "method",
+            "line": 154,
+            "loc": 12,
+            "qualified_name": "AIOGenerationDiTCorrectionsConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 211,
+            "kind": "method",
+            "line": 185,
+            "loc": 27,
+            "qualified_name": "AIOGenerationSamplerConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 223,
+            "kind": "method",
+            "line": 213,
+            "loc": 11,
+            "qualified_name": "AIOGenerationSamplerConfig.to_dict"
+          }
+        ],
         "is_package": false,
         "loc": 224,
         "module": "easyuse_anima.aio.generation_sampling",
@@ -70986,6 +72223,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "method",
+            "line": 39,
+            "loc": 10,
+            "qualified_name": "AIOSaveOutputStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 190,
+            "kind": "method",
+            "line": 50,
+            "loc": 141,
+            "qualified_name": "AIOSaveOutputStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 193,
         "module": "easyuse_anima.aio.generation_save_output_stage",
@@ -70998,6 +72253,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 74,
+            "kind": "method",
+            "line": 52,
+            "loc": 23,
+            "qualified_name": "AIOGenerationConfig.from_dict"
+          },
+          {
+            "async": false,
+            "end_line": 87,
+            "kind": "method",
+            "line": 76,
+            "loc": 12,
+            "qualified_name": "AIOGenerationConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 95,
+            "kind": "function",
+            "line": 90,
+            "loc": 6,
+            "qualified_name": "_aio_generation_config_from_dict"
+          },
+          {
+            "async": false,
+            "end_line": 103,
+            "kind": "function",
+            "line": 98,
+            "loc": 6,
+            "qualified_name": "_aio_generation_config_to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 109,
+            "kind": "function",
+            "line": 106,
+            "loc": 4,
+            "qualified_name": "round_trip_aio_generation_settings"
+          },
+          {
+            "async": false,
+            "end_line": 125,
+            "kind": "function",
+            "line": 112,
+            "loc": 14,
+            "qualified_name": "migrate_normalize_and_round_trip_aio_generation_settings"
+          }
+        ],
         "is_package": false,
         "loc": 128,
         "module": "easyuse_anima.aio.generation_settings",
@@ -71010,6 +72315,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "method",
+            "line": 20,
+            "loc": 18,
+            "qualified_name": "UpscaleRunner.__call__"
+          },
+          {
+            "async": false,
+            "end_line": 65,
+            "kind": "method",
+            "line": 56,
+            "loc": 10,
+            "qualified_name": "AIOUpscaleStage.validate"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "method",
+            "line": 67,
+            "loc": 45,
+            "qualified_name": "AIOUpscaleStage.run"
+          }
+        ],
         "is_package": false,
         "loc": 114,
         "module": "easyuse_anima.aio.generation_upscale_stage",
@@ -71022,6 +72353,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 40,
+            "kind": "function",
+            "line": 26,
+            "loc": 15,
+            "qualified_name": "freeze_json"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 43,
+            "loc": 6,
+            "qualified_name": "thaw_json"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 51,
+            "loc": 5,
+            "qualified_name": "freeze_object"
+          },
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "function",
+            "line": 58,
+            "loc": 2,
+            "qualified_name": "thaw_object"
+          },
+          {
+            "async": false,
+            "end_line": 65,
+            "kind": "function",
+            "line": 62,
+            "loc": 4,
+            "qualified_name": "required"
+          },
+          {
+            "async": false,
+            "end_line": 74,
+            "kind": "function",
+            "line": 68,
+            "loc": 7,
+            "qualified_name": "expect_object"
+          },
+          {
+            "async": false,
+            "end_line": 80,
+            "kind": "function",
+            "line": 77,
+            "loc": 4,
+            "qualified_name": "expect_str"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 83,
+            "loc": 4,
+            "qualified_name": "expect_bool"
+          },
+          {
+            "async": false,
+            "end_line": 92,
+            "kind": "function",
+            "line": 89,
+            "loc": 4,
+            "qualified_name": "expect_int"
+          },
+          {
+            "async": false,
+            "end_line": 98,
+            "kind": "function",
+            "line": 95,
+            "loc": 4,
+            "qualified_name": "expect_number"
+          },
+          {
+            "async": false,
+            "end_line": 107,
+            "kind": "function",
+            "line": 101,
+            "loc": 7,
+            "qualified_name": "expect_string_list"
+          },
+          {
+            "async": false,
+            "end_line": 114,
+            "kind": "function",
+            "line": 110,
+            "loc": 5,
+            "qualified_name": "expect_object_list"
+          },
+          {
+            "async": false,
+            "end_line": 134,
+            "kind": "method",
+            "line": 122,
+            "loc": 13,
+            "qualified_name": "ObjectState.from_source"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "method",
+            "line": 136,
+            "loc": 13,
+            "qualified_name": "ObjectState.compose"
+          }
+        ],
         "is_package": false,
         "loc": 149,
         "module": "easyuse_anima.aio.generation_values",
@@ -71034,6 +72479,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "function",
+            "line": 10,
+            "loc": 10,
+            "qualified_name": "_easy_use_anima_input_signature"
+          },
+          {
+            "async": false,
+            "end_line": 35,
+            "kind": "function",
+            "line": 22,
+            "loc": 14,
+            "qualified_name": "_require_easy_use_anima_input"
+          }
+        ],
         "is_package": false,
         "loc": 38,
         "module": "easyuse_anima.aio.input_context",
@@ -71046,6 +72509,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 62,
         "module": "easyuse_anima.aio.input_defaults",
@@ -71058,6 +72522,112 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 119,
+            "kind": "function",
+            "line": 116,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 127,
+            "kind": "function",
+            "line": 122,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 139,
+            "kind": "function",
+            "line": 130,
+            "loc": 10,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 214,
+            "kind": "function",
+            "line": 142,
+            "loc": 73,
+            "qualified_name": "_run_aio_highres_stage"
+          },
+          {
+            "async": false,
+            "end_line": 265,
+            "kind": "function",
+            "line": 217,
+            "loc": 49,
+            "qualified_name": "_run_aio_detailer_stage"
+          },
+          {
+            "async": false,
+            "end_line": 387,
+            "kind": "function",
+            "line": 268,
+            "loc": 120,
+            "qualified_name": "_run_aio_detailer_target"
+          },
+          {
+            "async": false,
+            "end_line": 543,
+            "kind": "function",
+            "line": 390,
+            "loc": 154,
+            "qualified_name": "_run_aio_usdu_upscale_stage"
+          },
+          {
+            "async": false,
+            "end_line": 606,
+            "kind": "function",
+            "line": 546,
+            "loc": 61,
+            "qualified_name": "_run_aio_resshift_upscale_stage"
+          },
+          {
+            "async": false,
+            "end_line": 660,
+            "kind": "function",
+            "line": 609,
+            "loc": 52,
+            "qualified_name": "_run_aio_upscale_stage"
+          },
+          {
+            "async": false,
+            "end_line": 685,
+            "kind": "function",
+            "line": 663,
+            "loc": 23,
+            "qualified_name": "_run_aio_legacy_generation"
+          },
+          {
+            "async": false,
+            "end_line": 705,
+            "kind": "function",
+            "line": 688,
+            "loc": 18,
+            "qualified_name": "_run_aio_normalized_legacy_generation"
+          },
+          {
+            "async": false,
+            "end_line": 1092,
+            "kind": "function",
+            "line": 708,
+            "loc": 385,
+            "qualified_name": "_run_aio_generation_pipeline"
+          },
+          {
+            "async": false,
+            "end_line": 852,
+            "kind": "function",
+            "line": 829,
+            "loc": 24,
+            "qualified_name": "_run_aio_generation_pipeline.variants_for"
+          }
+        ],
         "is_package": false,
         "loc": 1095,
         "module": "easyuse_anima.aio.legacy_generation",
@@ -71070,6 +72640,208 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 51,
+            "kind": "function",
+            "line": 38,
+            "loc": 14,
+            "qualified_name": "_aio_safe_pag_in_stage"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 54,
+            "loc": 8,
+            "qualified_name": "_aio_sage_attention_mode"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 64,
+            "loc": 13,
+            "qualified_name": "_aio_sage_attention_in_stage"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 79,
+            "loc": 13,
+            "qualified_name": "_aio_stage_kj_settings"
+          },
+          {
+            "async": false,
+            "end_line": 97,
+            "kind": "function",
+            "line": 94,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 105,
+            "kind": "function",
+            "line": 100,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 117,
+            "kind": "function",
+            "line": 108,
+            "loc": 10,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 129,
+            "kind": "function",
+            "line": 120,
+            "loc": 10,
+            "qualified_name": "_require_any_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "function",
+            "line": 132,
+            "loc": 34,
+            "qualified_name": "_require_aio_sage_attention_class"
+          },
+          {
+            "async": false,
+            "end_line": 186,
+            "kind": "function",
+            "line": 168,
+            "loc": 19,
+            "qualified_name": "_patch_model_sampling_aura_flow"
+          },
+          {
+            "async": false,
+            "end_line": 220,
+            "kind": "function",
+            "line": 189,
+            "loc": 32,
+            "qualified_name": "_apply_aio_kj_non_compile_patches"
+          },
+          {
+            "async": false,
+            "end_line": 249,
+            "kind": "function",
+            "line": 223,
+            "loc": 27,
+            "qualified_name": "_apply_aio_kj_torch_compile_patch"
+          },
+          {
+            "async": false,
+            "end_line": 254,
+            "kind": "function",
+            "line": 252,
+            "loc": 3,
+            "qualified_name": "_apply_aio_kj_model_patches"
+          },
+          {
+            "async": false,
+            "end_line": 323,
+            "kind": "function",
+            "line": 257,
+            "loc": 67,
+            "qualified_name": "_aio_stage_model_patch_plan"
+          },
+          {
+            "async": false,
+            "end_line": 358,
+            "kind": "function",
+            "line": 326,
+            "loc": 33,
+            "qualified_name": "_apply_aio_stage_model_patch_plan"
+          },
+          {
+            "async": false,
+            "end_line": 363,
+            "kind": "function",
+            "line": 361,
+            "loc": 3,
+            "qualified_name": "_apply_aio_model_patches"
+          },
+          {
+            "async": false,
+            "end_line": 405,
+            "kind": "function",
+            "line": 366,
+            "loc": 40,
+            "qualified_name": "_normalize_aio_lora_stack"
+          },
+          {
+            "async": false,
+            "end_line": 418,
+            "kind": "function",
+            "line": 408,
+            "loc": 11,
+            "qualified_name": "_aio_lora_stack_signature"
+          },
+          {
+            "async": false,
+            "end_line": 453,
+            "kind": "function",
+            "line": 421,
+            "loc": 33,
+            "qualified_name": "_apply_aio_lora_stack"
+          },
+          {
+            "async": false,
+            "end_line": 477,
+            "kind": "function",
+            "line": 456,
+            "loc": 22,
+            "qualified_name": "_apply_aio_anima_dave_patch"
+          },
+          {
+            "async": false,
+            "end_line": 502,
+            "kind": "function",
+            "line": 480,
+            "loc": 23,
+            "qualified_name": "_apply_aio_safe_pag_patch"
+          },
+          {
+            "async": false,
+            "end_line": 527,
+            "kind": "function",
+            "line": 505,
+            "loc": 23,
+            "qualified_name": "_cleanup_aio_ephemeral_model"
+          },
+          {
+            "async": false,
+            "end_line": 588,
+            "kind": "function",
+            "line": 530,
+            "loc": 59,
+            "qualified_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler"
+          },
+          {
+            "async": false,
+            "end_line": 635,
+            "kind": "function",
+            "line": 591,
+            "loc": 45,
+            "qualified_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler"
+          },
+          {
+            "async": false,
+            "end_line": 653,
+            "kind": "function",
+            "line": 638,
+            "loc": 16,
+            "qualified_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler"
+          }
+        ],
         "is_package": false,
         "loc": 656,
         "module": "easyuse_anima.aio.model_preparation",
@@ -71082,6 +72854,208 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 63,
+            "kind": "method",
+            "line": 53,
+            "loc": 11,
+            "qualified_name": "AIOGenerationNegPipConfig.from_value"
+          },
+          {
+            "async": false,
+            "end_line": 67,
+            "kind": "method",
+            "line": 65,
+            "loc": 3,
+            "qualified_name": "AIOGenerationNegPipConfig.is_turbo"
+          },
+          {
+            "async": false,
+            "end_line": 70,
+            "kind": "method",
+            "line": 69,
+            "loc": 2,
+            "qualified_name": "AIOGenerationNegPipConfig.effective_cfg"
+          },
+          {
+            "async": false,
+            "end_line": 73,
+            "kind": "method",
+            "line": 72,
+            "loc": 2,
+            "qualified_name": "AIOGenerationNegPipConfig.to_dict"
+          },
+          {
+            "async": false,
+            "end_line": 79,
+            "kind": "function",
+            "line": 76,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 82,
+            "loc": 10,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 105,
+            "kind": "function",
+            "line": 94,
+            "loc": 12,
+            "qualified_name": "_payload"
+          },
+          {
+            "async": false,
+            "end_line": 112,
+            "kind": "function",
+            "line": 108,
+            "loc": 5,
+            "qualified_name": "_input_type_name"
+          },
+          {
+            "async": false,
+            "end_line": 144,
+            "kind": "function",
+            "line": 115,
+            "loc": 30,
+            "qualified_name": "_execute_contract_is_compatible"
+          },
+          {
+            "async": false,
+            "end_line": 170,
+            "kind": "function",
+            "line": 147,
+            "loc": 24,
+            "qualified_name": "_inspect_negpip_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 193,
+            "kind": "function",
+            "line": 173,
+            "loc": 21,
+            "qualified_name": "collect_negpip_contract"
+          },
+          {
+            "async": false,
+            "end_line": 223,
+            "kind": "function",
+            "line": 196,
+            "loc": 28,
+            "qualified_name": "invoke_negpip_node"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "function",
+            "line": 226,
+            "loc": 7,
+            "qualified_name": "_is_escaped"
+          },
+          {
+            "async": false,
+            "end_line": 242,
+            "kind": "function",
+            "line": 235,
+            "loc": 8,
+            "qualified_name": "_line_ending"
+          },
+          {
+            "async": false,
+            "end_line": 250,
+            "kind": "function",
+            "line": 245,
+            "loc": 6,
+            "qualified_name": "_turbo_prompt_error"
+          },
+          {
+            "async": false,
+            "end_line": 274,
+            "kind": "function",
+            "line": 253,
+            "loc": 22,
+            "qualified_name": "_strip_top_level_comments_and_validate"
+          },
+          {
+            "async": false,
+            "end_line": 296,
+            "kind": "function",
+            "line": 277,
+            "loc": 20,
+            "qualified_name": "_split_top_level_prompt_items"
+          },
+          {
+            "async": false,
+            "end_line": 304,
+            "kind": "function",
+            "line": 299,
+            "loc": 6,
+            "qualified_name": "_toggle_numeric_weight"
+          },
+          {
+            "async": false,
+            "end_line": 316,
+            "kind": "function",
+            "line": 307,
+            "loc": 10,
+            "qualified_name": "_derive_aio_negpip_turbo_negative_contribution"
+          },
+          {
+            "async": false,
+            "end_line": 336,
+            "kind": "function",
+            "line": 319,
+            "loc": 18,
+            "qualified_name": "_aio_negpip_execution_prompts"
+          },
+          {
+            "async": false,
+            "end_line": 341,
+            "kind": "function",
+            "line": 339,
+            "loc": 3,
+            "qualified_name": "_aio_negpip_turbo_fingerprint"
+          },
+          {
+            "async": false,
+            "end_line": 358,
+            "kind": "function",
+            "line": 344,
+            "loc": 15,
+            "qualified_name": "_aio_negpip_mode"
+          },
+          {
+            "async": false,
+            "end_line": 389,
+            "kind": "function",
+            "line": 361,
+            "loc": 29,
+            "qualified_name": "_aio_negpip_cache_signature"
+          },
+          {
+            "async": false,
+            "end_line": 428,
+            "kind": "function",
+            "line": 392,
+            "loc": 37,
+            "qualified_name": "_aio_negpip_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 445,
+            "kind": "function",
+            "line": 431,
+            "loc": 15,
+            "qualified_name": "apply_aio_negpip"
+          }
+        ],
         "is_package": false,
         "loc": 448,
         "module": "easyuse_anima.aio.negpip",
@@ -71094,6 +73068,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 27,
+            "kind": "function",
+            "line": 24,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 35,
+            "kind": "function",
+            "line": 30,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 38,
+            "loc": 10,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 114,
+            "kind": "function",
+            "line": 50,
+            "loc": 65,
+            "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "function",
+            "line": 117,
+            "loc": 12,
+            "qualified_name": "_aio_image_saver_additional_hashes"
+          },
+          {
+            "async": false,
+            "end_line": 144,
+            "kind": "function",
+            "line": 131,
+            "loc": 14,
+            "qualified_name": "_aio_lora_metadata_name"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "function",
+            "line": 147,
+            "loc": 17,
+            "qualified_name": "_aio_prompt_with_lora_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 184,
+            "kind": "function",
+            "line": 166,
+            "loc": 19,
+            "qualified_name": "_save_image_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 196,
+            "kind": "function",
+            "line": 187,
+            "loc": 10,
+            "qualified_name": "_aio_save_filename_prefix"
+          },
+          {
+            "async": false,
+            "end_line": 300,
+            "kind": "function",
+            "line": 199,
+            "loc": 102,
+            "qualified_name": "_save_image_with_image_saver"
+          }
+        ],
         "is_package": false,
         "loc": 303,
         "module": "easyuse_anima.aio.output",
@@ -71106,6 +73162,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "function",
+            "line": 11,
+            "loc": 14,
+            "qualified_name": "_normalize_aio_hash_bundles"
+          },
+          {
+            "async": false,
+            "end_line": 50,
+            "kind": "function",
+            "line": 27,
+            "loc": 24,
+            "qualified_name": "_normalize_aio_civitai_hash_fetchers"
+          }
+        ],
         "is_package": false,
         "loc": 53,
         "module": "easyuse_anima.aio.output_settings",
@@ -71118,6 +73192,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 9,
+            "kind": "method",
+            "line": 9,
+            "loc": 1,
+            "qualified_name": "AIOFirstPassCachePort.get"
+          },
+          {
+            "async": false,
+            "end_line": 11,
+            "kind": "method",
+            "line": 11,
+            "loc": 1,
+            "qualified_name": "AIOFirstPassCachePort.put"
+          }
+        ],
         "is_package": false,
         "loc": 14,
         "module": "easyuse_anima.aio.ports",
@@ -71130,6 +73222,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 17,
+            "loc": 23,
+            "qualified_name": "_resize_image_to_size_if_needed"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 42,
+            "loc": 45,
+            "qualified_name": "_aio_final_fit_size"
+          },
+          {
+            "async": false,
+            "end_line": 138,
+            "kind": "function",
+            "line": 89,
+            "loc": 50,
+            "qualified_name": "_apply_aio_final_fit"
+          },
+          {
+            "async": false,
+            "end_line": 185,
+            "kind": "function",
+            "line": 141,
+            "loc": 45,
+            "qualified_name": "_run_aio_postprocess_stage"
+          }
+        ],
         "is_package": false,
         "loc": 188,
         "module": "easyuse_anima.aio.postprocess",
@@ -71142,6 +73268,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 34,
+            "kind": "function",
+            "line": 31,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 37,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 45,
+            "loc": 11,
+            "qualified_name": "_aio_preview_base_directory"
+          },
+          {
+            "async": false,
+            "end_line": 70,
+            "kind": "function",
+            "line": 58,
+            "loc": 13,
+            "qualified_name": "_aio_preview_file_size_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 73,
+            "loc": 24,
+            "qualified_name": "_tag_aio_preview_images"
+          },
+          {
+            "async": false,
+            "end_line": 126,
+            "kind": "function",
+            "line": 99,
+            "loc": 28,
+            "qualified_name": "_send_aio_preview_event"
+          },
+          {
+            "async": false,
+            "end_line": 233,
+            "kind": "function",
+            "line": 129,
+            "loc": 105,
+            "qualified_name": "_save_aio_temp_preview_image"
+          }
+        ],
         "is_package": false,
         "loc": 236,
         "module": "easyuse_anima.aio.preview",
@@ -71154,6 +73338,144 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 38,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "function",
+            "line": 44,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "function",
+            "line": 52,
+            "loc": 31,
+            "qualified_name": "_normalize_aio_input_settings"
+          },
+          {
+            "async": false,
+            "end_line": 89,
+            "kind": "function",
+            "line": 85,
+            "loc": 5,
+            "qualified_name": "_comfy_diffusion_model_names"
+          },
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 92,
+            "loc": 5,
+            "qualified_name": "_comfy_text_encoder_names"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 99,
+            "loc": 6,
+            "qualified_name": "_comfy_vae_names"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 107,
+            "loc": 5,
+            "qualified_name": "_comfy_clip_loader_types"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "function",
+            "line": 114,
+            "loc": 15,
+            "qualified_name": "_preferred_name_default"
+          },
+          {
+            "async": false,
+            "end_line": 132,
+            "kind": "function",
+            "line": 131,
+            "loc": 2,
+            "qualified_name": "_preferred_checkpoint_default"
+          },
+          {
+            "async": false,
+            "end_line": 138,
+            "kind": "function",
+            "line": 135,
+            "loc": 4,
+            "qualified_name": "_preferred_clip_type_default"
+          },
+          {
+            "async": false,
+            "end_line": 149,
+            "kind": "function",
+            "line": 141,
+            "loc": 9,
+            "qualified_name": "_load_checkpoint_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "function",
+            "line": 152,
+            "loc": 12,
+            "qualified_name": "_load_diffusion_model_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 177,
+            "kind": "function",
+            "line": 166,
+            "loc": 12,
+            "qualified_name": "_load_vae_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 201,
+            "kind": "function",
+            "line": 180,
+            "loc": 22,
+            "qualified_name": "_load_clip_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 230,
+            "kind": "function",
+            "line": 204,
+            "loc": 27,
+            "qualified_name": "_load_upscale_model_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 239,
+            "kind": "function",
+            "line": 233,
+            "loc": 7,
+            "qualified_name": "_load_aio_sam3_context"
+          },
+          {
+            "async": false,
+            "end_line": 288,
+            "kind": "function",
+            "line": 242,
+            "loc": 47,
+            "qualified_name": "_load_aio_resources_from_input_context"
+          }
+        ],
         "is_package": false,
         "loc": 291,
         "module": "easyuse_anima.aio.resources",
@@ -71166,6 +73488,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 28,
+            "kind": "function",
+            "line": 25,
+            "loc": 4,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "function",
+            "line": 31,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 39,
+            "loc": 10,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 52,
+            "kind": "function",
+            "line": 51,
+            "loc": 2,
+            "qualified_name": "_new_aio_random_seed"
+          },
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "function",
+            "line": 55,
+            "loc": 5,
+            "qualified_name": "_resolve_aio_runtime_seed"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 62,
+            "loc": 15,
+            "qualified_name": "_generate_empty_latent_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 113,
+            "kind": "function",
+            "line": 79,
+            "loc": 35,
+            "qualified_name": "_sample_latent_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 244,
+            "kind": "function",
+            "line": 116,
+            "loc": 129,
+            "qualified_name": "_sample_latent_with_spectrum_mod_guidance_advanced"
+          },
+          {
+            "async": false,
+            "end_line": 298,
+            "kind": "function",
+            "line": 247,
+            "loc": 52,
+            "qualified_name": "_sample_latent_with_spectrum_spd"
+          },
+          {
+            "async": false,
+            "end_line": 346,
+            "kind": "function",
+            "line": 301,
+            "loc": 46,
+            "qualified_name": "_sample_latent_with_aio_backend"
+          },
+          {
+            "async": false,
+            "end_line": 361,
+            "kind": "function",
+            "line": 349,
+            "loc": 13,
+            "qualified_name": "_decode_latent_with_comfy"
+          },
+          {
+            "async": false,
+            "end_line": 375,
+            "kind": "function",
+            "line": 364,
+            "loc": 12,
+            "qualified_name": "_encode_image_with_comfy_vae"
+          },
+          {
+            "async": false,
+            "end_line": 440,
+            "kind": "function",
+            "line": 378,
+            "loc": 63,
+            "qualified_name": "_aio_stage_sampler_settings"
+          },
+          {
+            "async": false,
+            "end_line": 452,
+            "kind": "function",
+            "line": 443,
+            "loc": 10,
+            "qualified_name": "_aio_highres_effective_backend"
+          }
+        ],
         "is_package": false,
         "loc": 455,
         "module": "easyuse_anima.aio.sampling",
@@ -71178,6 +73614,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 36,
+            "loc": 6,
+            "qualified_name": "_bounded_text"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 44,
+            "loc": 2,
+            "qualified_name": "_torch_module"
+          },
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "function",
+            "line": 48,
+            "loc": 12,
+            "qualified_name": "_input_map"
+          },
+          {
+            "async": false,
+            "end_line": 79,
+            "kind": "function",
+            "line": 62,
+            "loc": 18,
+            "qualified_name": "_choice_values"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 82,
+            "loc": 30,
+            "qualified_name": "_patch_signature_compatible"
+          },
+          {
+            "async": false,
+            "end_line": 174,
+            "kind": "function",
+            "line": 114,
+            "loc": 61,
+            "qualified_name": "_kj_contract"
+          },
+          {
+            "async": false,
+            "end_line": 234,
+            "kind": "function",
+            "line": 177,
+            "loc": 58,
+            "qualified_name": "_accelerator_environment"
+          },
+          {
+            "async": false,
+            "end_line": 312,
+            "kind": "function",
+            "line": 237,
+            "loc": 76,
+            "qualified_name": "collect_torch_compile_diagnostics"
+          }
+        ],
         "is_package": false,
         "loc": 320,
         "module": "easyuse_anima.aio.torch_compile_diagnostics",
@@ -71190,6 +73692,80 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 24,
+            "loc": 2,
+            "qualified_name": "_mapping"
+          },
+          {
+            "async": false,
+            "end_line": 35,
+            "kind": "function",
+            "line": 28,
+            "loc": 8,
+            "qualified_name": "_enabled_section"
+          },
+          {
+            "async": false,
+            "end_line": 106,
+            "kind": "function",
+            "line": 38,
+            "loc": 69,
+            "qualified_name": "classify_torch_compile_workload"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 109,
+            "loc": 8,
+            "qualified_name": "classify_torch_compile_vram"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "function",
+            "line": 119,
+            "loc": 6,
+            "qualified_name": "_choice_values"
+          },
+          {
+            "async": false,
+            "end_line": 131,
+            "kind": "function",
+            "line": 127,
+            "loc": 5,
+            "qualified_name": "_supported_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 137,
+            "kind": "function",
+            "line": 134,
+            "loc": 4,
+            "qualified_name": "_string_list"
+          },
+          {
+            "async": false,
+            "end_line": 149,
+            "kind": "function",
+            "line": 140,
+            "loc": 10,
+            "qualified_name": "_profile"
+          },
+          {
+            "async": false,
+            "end_line": 275,
+            "kind": "function",
+            "line": 152,
+            "loc": 124,
+            "qualified_name": "recommend_torch_compile"
+          }
+        ],
         "is_package": false,
         "loc": 283,
         "module": "easyuse_anima.aio.torch_compile_recommendation",
@@ -71202,6 +73778,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 12,
+            "loc": 14,
+            "qualified_name": "_aio_usdu_auto_tile_dimension"
+          },
+          {
+            "async": false,
+            "end_line": 89,
+            "kind": "function",
+            "line": 28,
+            "loc": 62,
+            "qualified_name": "_aio_usdu_tile_plan"
+          }
+        ],
         "is_package": false,
         "loc": 92,
         "module": "easyuse_anima.aio.usdu",
@@ -71214,6 +73808,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.api",
@@ -71226,6 +73821,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "method",
+            "line": 9,
+            "loc": 13,
+            "qualified_name": "ApiContractError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 24,
+            "loc": 7,
+            "qualified_name": "_field_error"
+          }
+        ],
         "is_package": false,
         "loc": 33,
         "module": "easyuse_anima.api.errors",
@@ -71238,6 +73851,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 13,
+            "loc": 13,
+            "qualified_name": "file_io_limiter"
+          },
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "function",
+            "line": 28,
+            "loc": 10,
+            "qualified_name": "release_file_io_slot"
+          },
+          {
+            "async": true,
+            "end_line": 50,
+            "kind": "function",
+            "line": 40,
+            "loc": 11,
+            "qualified_name": "run_file_io"
+          }
+        ],
         "is_package": false,
         "loc": 58,
         "module": "easyuse_anima.api.file_io",
@@ -71250,6 +73889,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": true,
+            "end_line": 25,
+            "kind": "function",
+            "line": 10,
+            "loc": 16,
+            "qualified_name": "parse_json_object"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 28,
+            "loc": 15,
+            "qualified_name": "json_object"
+          },
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 45,
+            "loc": 18,
+            "qualified_name": "json_string"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 65,
+            "loc": 12,
+            "qualified_name": "json_boolean"
+          },
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 79,
+            "loc": 18,
+            "qualified_name": "json_integer"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 99,
+            "loc": 18,
+            "qualified_name": "json_uuid_string"
+          }
+        ],
         "is_package": false,
         "loc": 126,
         "module": "easyuse_anima.api.requests",
@@ -71262,6 +73951,112 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "function",
+            "line": 34,
+            "loc": 16,
+            "qualified_name": "error_payload"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 52,
+            "loc": 4,
+            "qualified_name": "create_request_id"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 58,
+            "loc": 7,
+            "qualified_name": "attach_request_id_header"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 67,
+            "loc": 20,
+            "qualified_name": "correlate_response"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 89,
+            "loc": 16,
+            "qualified_name": "build_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 92,
+            "loc": 11,
+            "qualified_name": "build_error_response._error_response"
+          },
+          {
+            "async": false,
+            "end_line": 118,
+            "kind": "function",
+            "line": 107,
+            "loc": 12,
+            "qualified_name": "build_contract_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 110,
+            "loc": 7,
+            "qualified_name": "build_contract_error_response._contract_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 195,
+            "kind": "function",
+            "line": 121,
+            "loc": 75,
+            "qualified_name": "build_profile_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 193,
+            "kind": "function",
+            "line": 152,
+            "loc": 42,
+            "qualified_name": "build_profile_error_response._profile_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 235,
+            "kind": "function",
+            "line": 198,
+            "loc": 38,
+            "qualified_name": "build_request_correlator"
+          },
+          {
+            "async": false,
+            "end_line": 233,
+            "kind": "function",
+            "line": 209,
+            "loc": 25,
+            "qualified_name": "build_request_correlator._request_correlated"
+          },
+          {
+            "async": true,
+            "end_line": 230,
+            "kind": "function",
+            "line": 210,
+            "loc": 21,
+            "qualified_name": "build_request_correlator._request_correlated.correlated_handler"
+          }
+        ],
         "is_package": false,
         "loc": 244,
         "module": "easyuse_anima.api.responses",
@@ -71274,6 +74069,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 39,
+            "loc": 7,
+            "qualified_name": "build_route_definitions"
+          },
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 48,
+            "loc": 15,
+            "qualified_name": "build_prompt_routes_resolver"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 51,
+            "loc": 10,
+            "qualified_name": "build_prompt_routes_resolver._get_prompt_routes"
+          },
+          {
+            "async": false,
+            "end_line": 93,
+            "kind": "function",
+            "line": 65,
+            "loc": 29,
+            "qualified_name": "build_route_registrar"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 77,
+            "loc": 15,
+            "qualified_name": "build_route_registrar.register_routes"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 96,
+            "loc": 7,
+            "qualified_name": "build_route_signature"
+          },
+          {
+            "async": false,
+            "end_line": 131,
+            "kind": "function",
+            "line": 105,
+            "loc": 27,
+            "qualified_name": "register_route_definitions"
+          }
+        ],
         "is_package": false,
         "loc": 138,
         "module": "easyuse_anima.api.router",
@@ -71286,6 +74139,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.api.routes",
@@ -71298,6 +74152,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 4,
+            "loc": 93,
+            "qualified_name": "build_aio_profile_mutation_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 49,
+            "kind": "function",
+            "line": 23,
+            "loc": 27,
+            "qualified_name": "build_aio_profile_mutation_handlers.delete_aio_profile_handler"
+          },
+          {
+            "async": true,
+            "end_line": 94,
+            "kind": "function",
+            "line": 51,
+            "loc": 44,
+            "qualified_name": "build_aio_profile_mutation_handlers.rename_aio_profile_handler"
+          }
+        ],
         "is_package": false,
         "loc": 99,
         "module": "easyuse_anima.api.routes.aio_profile_mutations",
@@ -71310,6 +74190,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 4,
+            "loc": 57,
+            "qualified_name": "build_aio_torch_compile_recommend_handler"
+          },
+          {
+            "async": true,
+            "end_line": 58,
+            "kind": "function",
+            "line": 17,
+            "loc": 42,
+            "qualified_name": "build_aio_torch_compile_recommend_handler.aio_torch_compile_recommend_handler"
+          }
+        ],
         "is_package": false,
         "loc": 63,
         "module": "easyuse_anima.api.routes.aio_torch_compile",
@@ -71322,6 +74220,112 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 28,
+            "kind": "method",
+            "line": 21,
+            "loc": 8,
+            "qualified_name": "_SearchAutocomplete.__call__"
+          },
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "method",
+            "line": 32,
+            "loc": 7,
+            "qualified_name": "_ClassifyPromptText.__call__"
+          },
+          {
+            "async": false,
+            "end_line": 158,
+            "kind": "function",
+            "line": 41,
+            "loc": 118,
+            "qualified_name": "build_autocomplete_payloads"
+          },
+          {
+            "async": false,
+            "end_line": 90,
+            "kind": "function",
+            "line": 64,
+            "loc": 27,
+            "qualified_name": "build_autocomplete_payloads._autocomplete_status_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 99,
+            "kind": "function",
+            "line": 92,
+            "loc": 8,
+            "qualified_name": "build_autocomplete_payloads._public_autocomplete_status"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 101,
+            "loc": 11,
+            "qualified_name": "build_autocomplete_payloads._public_autocomplete_payload"
+          },
+          {
+            "async": false,
+            "end_line": 138,
+            "kind": "function",
+            "line": 113,
+            "loc": 26,
+            "qualified_name": "build_autocomplete_payloads._search_autocomplete_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "function",
+            "line": 140,
+            "loc": 11,
+            "qualified_name": "build_autocomplete_payloads._classify_prompt_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "function",
+            "line": 161,
+            "loc": 31,
+            "qualified_name": "build_autocomplete_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 173,
+            "kind": "function",
+            "line": 170,
+            "loc": 4,
+            "qualified_name": "build_autocomplete_handlers.autocomplete_status_handler"
+          },
+          {
+            "async": true,
+            "end_line": 189,
+            "kind": "function",
+            "line": 175,
+            "loc": 15,
+            "qualified_name": "build_autocomplete_handlers.autocomplete_handler"
+          },
+          {
+            "async": false,
+            "end_line": 224,
+            "kind": "function",
+            "line": 194,
+            "loc": 31,
+            "qualified_name": "build_classify_prompt_handler"
+          },
+          {
+            "async": true,
+            "end_line": 222,
+            "kind": "function",
+            "line": 207,
+            "loc": 16,
+            "qualified_name": "build_classify_prompt_handler.classify_prompt_handler"
+          }
+        ],
         "is_package": false,
         "loc": 230,
         "module": "easyuse_anima.api.routes.autocomplete",
@@ -71334,6 +74338,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "function",
+            "line": 4,
+            "loc": 26,
+            "qualified_name": "build_long_text_settings_payloads"
+          },
+          {
+            "async": false,
+            "end_line": 17,
+            "kind": "function",
+            "line": 12,
+            "loc": 6,
+            "qualified_name": "build_long_text_settings_payloads._get_long_text_settings_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "function",
+            "line": 19,
+            "loc": 6,
+            "qualified_name": "build_long_text_settings_payloads._save_long_text_settings_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 32,
+            "loc": 29,
+            "qualified_name": "build_long_text_settings_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 48,
+            "kind": "function",
+            "line": 45,
+            "loc": 4,
+            "qualified_name": "build_long_text_settings_handlers.get_long_text_settings_handler"
+          },
+          {
+            "async": true,
+            "end_line": 58,
+            "kind": "function",
+            "line": 50,
+            "loc": 9,
+            "qualified_name": "build_long_text_settings_handlers.save_long_text_settings_handler"
+          }
+        ],
         "is_package": false,
         "loc": 63,
         "module": "easyuse_anima.api.routes.long_text_settings",
@@ -71346,6 +74400,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 15,
+            "kind": "function",
+            "line": 4,
+            "loc": 12,
+            "qualified_name": "build_loras_handler"
+          },
+          {
+            "async": true,
+            "end_line": 13,
+            "kind": "function",
+            "line": 12,
+            "loc": 2,
+            "qualified_name": "build_loras_handler.loras_handler"
+          }
+        ],
         "is_package": false,
         "loc": 18,
         "module": "easyuse_anima.api.routes.lora_catalog",
@@ -71358,6 +74430,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 44,
+            "kind": "function",
+            "line": 6,
+            "loc": 39,
+            "qualified_name": "build_lora_preview_path_resolver"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 17,
+            "loc": 26,
+            "qualified_name": "build_lora_preview_path_resolver._resolve_lora_preview_path"
+          },
+          {
+            "async": false,
+            "end_line": 69,
+            "kind": "function",
+            "line": 47,
+            "loc": 23,
+            "qualified_name": "build_lora_preview_handler"
+          },
+          {
+            "async": true,
+            "end_line": 67,
+            "kind": "function",
+            "line": 57,
+            "loc": 11,
+            "qualified_name": "build_lora_preview_handler.lora_preview_handler"
+          }
+        ],
         "is_package": false,
         "loc": 72,
         "module": "easyuse_anima.api.routes.lora_preview",
@@ -71370,6 +74476,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 26,
+            "kind": "function",
+            "line": 4,
+            "loc": 23,
+            "qualified_name": "build_lora_profile_fix_handler"
+          },
+          {
+            "async": true,
+            "end_line": 24,
+            "kind": "function",
+            "line": 16,
+            "loc": 9,
+            "qualified_name": "build_lora_profile_fix_handler.fix_lora_profile_handler"
+          }
+        ],
         "is_package": false,
         "loc": 29,
         "module": "easyuse_anima.api.routes.lora_profile_fix",
@@ -71382,6 +74506,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "function",
+            "line": 4,
+            "loc": 26,
+            "qualified_name": "build_profile_list_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 20,
+            "kind": "function",
+            "line": 15,
+            "loc": 6,
+            "qualified_name": "build_profile_list_handlers.lora_profiles_handler"
+          },
+          {
+            "async": true,
+            "end_line": 27,
+            "kind": "function",
+            "line": 22,
+            "loc": 6,
+            "qualified_name": "build_profile_list_handlers.aio_profiles_handler"
+          }
+        ],
         "is_package": false,
         "loc": 32,
         "module": "easyuse_anima.api.routes.profile_lists",
@@ -71394,6 +74544,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "function",
+            "line": 4,
+            "loc": 33,
+            "qualified_name": "build_profile_load_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 24,
+            "kind": "function",
+            "line": 16,
+            "loc": 9,
+            "qualified_name": "build_profile_load_handlers.load_lora_profile_handler"
+          },
+          {
+            "async": true,
+            "end_line": 34,
+            "kind": "function",
+            "line": 26,
+            "loc": 9,
+            "qualified_name": "build_profile_load_handlers.load_aio_profile_handler"
+          }
+        ],
         "is_package": false,
         "loc": 39,
         "module": "easyuse_anima.api.routes.profile_loads",
@@ -71406,6 +74582,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 88,
+            "kind": "function",
+            "line": 4,
+            "loc": 85,
+            "qualified_name": "build_profile_save_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 54,
+            "kind": "function",
+            "line": 23,
+            "loc": 32,
+            "qualified_name": "build_profile_save_handlers.save_lora_profile_handler"
+          },
+          {
+            "async": true,
+            "end_line": 86,
+            "kind": "function",
+            "line": 56,
+            "loc": 31,
+            "qualified_name": "build_profile_save_handlers.save_aio_profile_handler"
+          }
+        ],
         "is_package": false,
         "loc": 91,
         "module": "easyuse_anima.api.routes.profile_saves",
@@ -71418,6 +74620,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "function",
+            "line": 4,
+            "loc": 11,
+            "qualified_name": "build_settings_payloads"
+          },
+          {
+            "async": false,
+            "end_line": 8,
+            "kind": "function",
+            "line": 7,
+            "loc": 2,
+            "qualified_name": "build_settings_payloads._get_settings_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 12,
+            "kind": "function",
+            "line": 10,
+            "loc": 3,
+            "qualified_name": "build_settings_payloads._save_setting_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 52,
+            "kind": "function",
+            "line": 17,
+            "loc": 36,
+            "qualified_name": "build_settings_handlers"
+          },
+          {
+            "async": true,
+            "end_line": 34,
+            "kind": "function",
+            "line": 32,
+            "loc": 3,
+            "qualified_name": "build_settings_handlers.get_settings_handler"
+          },
+          {
+            "async": true,
+            "end_line": 50,
+            "kind": "function",
+            "line": 36,
+            "loc": 15,
+            "qualified_name": "build_settings_handlers.set_setting_handler"
+          }
+        ],
         "is_package": false,
         "loc": 55,
         "module": "easyuse_anima.api.routes.settings",
@@ -71430,6 +74682,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 62,
+            "loc": 43,
+            "qualified_name": "_build_translation_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 79,
+            "loc": 24,
+            "qualified_name": "_build_translation_error_response._prompt_translation_error_response"
+          },
+          {
+            "async": false,
+            "end_line": 151,
+            "kind": "function",
+            "line": 107,
+            "loc": 45,
+            "qualified_name": "build_translation_runtime"
+          },
+          {
+            "async": false,
+            "end_line": 137,
+            "kind": "function",
+            "line": 133,
+            "loc": 5,
+            "qualified_name": "build_translation_runtime._translate_prompt_sync"
+          },
+          {
+            "async": true,
+            "end_line": 144,
+            "kind": "function",
+            "line": 139,
+            "loc": 6,
+            "qualified_name": "build_translation_runtime._translate_prompt_for_route"
+          },
+          {
+            "async": false,
+            "end_line": 179,
+            "kind": "function",
+            "line": 154,
+            "loc": 26,
+            "qualified_name": "build_translate_prompt_handler"
+          },
+          {
+            "async": true,
+            "end_line": 177,
+            "kind": "function",
+            "line": 167,
+            "loc": 11,
+            "qualified_name": "build_translate_prompt_handler.translate_prompt_handler"
+          }
+        ],
         "is_package": false,
         "loc": 182,
         "module": "easyuse_anima.api.routes.translation",
@@ -71442,6 +74752,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "method",
+            "line": 11,
+            "loc": 14,
+            "qualified_name": "PromptTranslationRouteExecutor.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "method",
+            "line": 26,
+            "loc": 4,
+            "qualified_name": "PromptTranslationRouteExecutor.has_in_flight"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "method",
+            "line": 31,
+            "loc": 15,
+            "qualified_name": "PromptTranslationRouteExecutor.submit"
+          },
+          {
+            "async": false,
+            "end_line": 50,
+            "kind": "method",
+            "line": 47,
+            "loc": 4,
+            "qualified_name": "PromptTranslationRouteExecutor._release"
+          },
+          {
+            "async": true,
+            "end_line": 68,
+            "kind": "method",
+            "line": 52,
+            "loc": 17,
+            "qualified_name": "PromptTranslationRouteExecutor.execute"
+          },
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "method",
+            "line": 70,
+            "loc": 9,
+            "qualified_name": "PromptTranslationRouteExecutor.shutdown"
+          }
+        ],
         "is_package": false,
         "loc": 81,
         "module": "easyuse_anima.api.routes.translation_execution",
@@ -71454,6 +74814,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 32,
+            "kind": "function",
+            "line": 4,
+            "loc": 29,
+            "qualified_name": "build_wildcards_payload"
+          },
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 12,
+            "loc": 19,
+            "qualified_name": "build_wildcards_payload._wildcards_payload_sync"
+          },
+          {
+            "async": false,
+            "end_line": 46,
+            "kind": "function",
+            "line": 35,
+            "loc": 12,
+            "qualified_name": "build_wildcards_handler"
+          },
+          {
+            "async": true,
+            "end_line": 44,
+            "kind": "function",
+            "line": 43,
+            "loc": 2,
+            "qualified_name": "build_wildcards_handler.get_wildcards_handler"
+          }
+        ],
         "is_package": false,
         "loc": 49,
         "module": "easyuse_anima.api.routes.wildcards",
@@ -71466,6 +74860,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.autocomplete",
@@ -71478,6 +74873,144 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 52,
+            "loc": 10,
+            "qualified_name": "_token_base"
+          },
+          {
+            "async": false,
+            "end_line": 69,
+            "kind": "function",
+            "line": 64,
+            "loc": 6,
+            "qualified_name": "_is_artist_request"
+          },
+          {
+            "async": false,
+            "end_line": 73,
+            "kind": "function",
+            "line": 72,
+            "loc": 2,
+            "qualified_name": "_is_weighted_token"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "function",
+            "line": 76,
+            "loc": 7,
+            "qualified_name": "_is_escaped"
+          },
+          {
+            "async": false,
+            "end_line": 95,
+            "kind": "function",
+            "line": 85,
+            "loc": 11,
+            "qualified_name": "_has_unbalanced_parentheses"
+          },
+          {
+            "async": false,
+            "end_line": 117,
+            "kind": "function",
+            "line": 98,
+            "loc": 20,
+            "qualified_name": "_top_level_colon"
+          },
+          {
+            "async": false,
+            "end_line": 131,
+            "kind": "function",
+            "line": 120,
+            "loc": 12,
+            "qualified_name": "_artist_mix_group_inner"
+          },
+          {
+            "async": false,
+            "end_line": 143,
+            "kind": "function",
+            "line": 134,
+            "loc": 10,
+            "qualified_name": "_has_invalid_weight_syntax"
+          },
+          {
+            "async": false,
+            "end_line": 153,
+            "kind": "function",
+            "line": 146,
+            "loc": 8,
+            "qualified_name": "_plain_parenthesized_inner"
+          },
+          {
+            "async": false,
+            "end_line": 179,
+            "kind": "function",
+            "line": 156,
+            "loc": 24,
+            "qualified_name": "_classification_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 186,
+            "kind": "function",
+            "line": 182,
+            "loc": 5,
+            "qualified_name": "_classification_tokens_from_prompt_text"
+          },
+          {
+            "async": false,
+            "end_line": 195,
+            "kind": "function",
+            "line": 189,
+            "loc": 7,
+            "qualified_name": "_classification_tokens_from_artist_group"
+          },
+          {
+            "async": false,
+            "end_line": 222,
+            "kind": "function",
+            "line": 198,
+            "loc": 25,
+            "qualified_name": "_next_prompt_syntax_range"
+          },
+          {
+            "async": false,
+            "end_line": 253,
+            "kind": "function",
+            "line": 225,
+            "loc": 29,
+            "qualified_name": "_classification_tokens_from_chunk"
+          },
+          {
+            "async": false,
+            "end_line": 293,
+            "kind": "function",
+            "line": 256,
+            "loc": 38,
+            "qualified_name": "_token_section"
+          },
+          {
+            "async": false,
+            "end_line": 385,
+            "kind": "function",
+            "line": 296,
+            "loc": 90,
+            "qualified_name": "_classify_prompt_text_from_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 396,
+            "kind": "function",
+            "line": 388,
+            "loc": 9,
+            "qualified_name": "classify_prompt_text"
+          }
+        ],
         "is_package": false,
         "loc": 399,
         "module": "easyuse_anima.autocomplete.classification",
@@ -71490,6 +75023,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 99,
         "module": "easyuse_anima.autocomplete.contracts",
@@ -71502,6 +75036,248 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 171,
+            "kind": "method",
+            "line": 165,
+            "loc": 7,
+            "qualified_name": "_AutocompleteSnapshotStore.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 175,
+            "kind": "method",
+            "line": 173,
+            "loc": 3,
+            "qualified_name": "_AutocompleteSnapshotStore.clear"
+          },
+          {
+            "async": false,
+            "end_line": 185,
+            "kind": "method",
+            "line": 177,
+            "loc": 9,
+            "qualified_name": "_AutocompleteSnapshotStore.cached_snapshot_for_key"
+          },
+          {
+            "async": false,
+            "end_line": 237,
+            "kind": "method",
+            "line": 187,
+            "loc": 51,
+            "qualified_name": "_AutocompleteSnapshotStore.snapshot_for_key"
+          },
+          {
+            "async": false,
+            "end_line": 251,
+            "kind": "function",
+            "line": 243,
+            "loc": 9,
+            "qualified_name": "resolve_autocomplete_source"
+          },
+          {
+            "async": false,
+            "end_line": 272,
+            "kind": "function",
+            "line": 254,
+            "loc": 19,
+            "qualified_name": "available_autocomplete_sources"
+          },
+          {
+            "async": false,
+            "end_line": 280,
+            "kind": "function",
+            "line": 275,
+            "loc": 6,
+            "qualified_name": "_normalize"
+          },
+          {
+            "async": false,
+            "end_line": 287,
+            "kind": "function",
+            "line": 283,
+            "loc": 5,
+            "qualified_name": "_display_description"
+          },
+          {
+            "async": false,
+            "end_line": 305,
+            "kind": "function",
+            "line": 290,
+            "loc": 16,
+            "qualified_name": "_category_from_description"
+          },
+          {
+            "async": false,
+            "end_line": 312,
+            "kind": "function",
+            "line": 308,
+            "loc": 5,
+            "qualified_name": "_safe_count"
+          },
+          {
+            "async": false,
+            "end_line": 321,
+            "kind": "function",
+            "line": 315,
+            "loc": 7,
+            "qualified_name": "_source_kind_from_path"
+          },
+          {
+            "async": false,
+            "end_line": 334,
+            "kind": "function",
+            "line": 324,
+            "loc": 11,
+            "qualified_name": "_normalize_category"
+          },
+          {
+            "async": false,
+            "end_line": 360,
+            "kind": "function",
+            "line": 337,
+            "loc": 24,
+            "qualified_name": "_entry_from_parts"
+          },
+          {
+            "async": false,
+            "end_line": 367,
+            "kind": "function",
+            "line": 363,
+            "loc": 5,
+            "qualified_name": "_looks_like_header"
+          },
+          {
+            "async": false,
+            "end_line": 404,
+            "kind": "function",
+            "line": 370,
+            "loc": 35,
+            "qualified_name": "_load_entries"
+          },
+          {
+            "async": false,
+            "end_line": 425,
+            "kind": "function",
+            "line": 407,
+            "loc": 19,
+            "qualified_name": "_cache_key_from_resolved_path"
+          },
+          {
+            "async": false,
+            "end_line": 429,
+            "kind": "function",
+            "line": 428,
+            "loc": 2,
+            "qualified_name": "_cache_key"
+          },
+          {
+            "async": false,
+            "end_line": 438,
+            "kind": "function",
+            "line": 432,
+            "loc": 7,
+            "qualified_name": "_build_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 442,
+            "kind": "function",
+            "line": 441,
+            "loc": 2,
+            "qualified_name": "_await_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 446,
+            "kind": "function",
+            "line": 445,
+            "loc": 2,
+            "qualified_name": "_snapshot_for_key"
+          },
+          {
+            "async": false,
+            "end_line": 463,
+            "kind": "function",
+            "line": 449,
+            "loc": 15,
+            "qualified_name": "_snapshot_with_owner"
+          },
+          {
+            "async": false,
+            "end_line": 470,
+            "kind": "function",
+            "line": 466,
+            "loc": 5,
+            "qualified_name": "_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 474,
+            "kind": "function",
+            "line": 473,
+            "loc": 2,
+            "qualified_name": "_entries"
+          },
+          {
+            "async": false,
+            "end_line": 478,
+            "kind": "function",
+            "line": 477,
+            "loc": 2,
+            "qualified_name": "_entry_map"
+          },
+          {
+            "async": false,
+            "end_line": 492,
+            "kind": "function",
+            "line": 481,
+            "loc": 12,
+            "qualified_name": "_status_from_key"
+          },
+          {
+            "async": false,
+            "end_line": 499,
+            "kind": "function",
+            "line": 495,
+            "loc": 5,
+            "qualified_name": "_snapshot_status"
+          },
+          {
+            "async": false,
+            "end_line": 505,
+            "kind": "function",
+            "line": 502,
+            "loc": 4,
+            "qualified_name": "_cached_snapshot_for_key"
+          },
+          {
+            "async": false,
+            "end_line": 520,
+            "kind": "function",
+            "line": 508,
+            "loc": 13,
+            "qualified_name": "_builtin_manifest_entry_count"
+          },
+          {
+            "async": false,
+            "end_line": 546,
+            "kind": "function",
+            "line": 523,
+            "loc": 24,
+            "qualified_name": "_autocomplete_status_with_owner"
+          },
+          {
+            "async": false,
+            "end_line": 556,
+            "kind": "function",
+            "line": 549,
+            "loc": 8,
+            "qualified_name": "autocomplete_status"
+          }
+        ],
         "is_package": false,
         "loc": 573,
         "module": "easyuse_anima.autocomplete.dataset",
@@ -71514,6 +75290,200 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "method",
+            "line": 46,
+            "loc": 4,
+            "qualified_name": "AutocompleteIndexSource.identity"
+          },
+          {
+            "async": false,
+            "end_line": 79,
+            "kind": "method",
+            "line": 77,
+            "loc": 3,
+            "qualified_name": "AutocompleteIndexUnavailable.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "method",
+            "line": 83,
+            "loc": 3,
+            "qualified_name": "_InvalidAutocompleteIndex.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 89,
+            "kind": "function",
+            "line": 88,
+            "loc": 2,
+            "qualified_name": "_index_path"
+          },
+          {
+            "async": false,
+            "end_line": 94,
+            "kind": "function",
+            "line": 92,
+            "loc": 3,
+            "qualified_name": "_is_locked_error"
+          },
+          {
+            "async": false,
+            "end_line": 120,
+            "kind": "function",
+            "line": 97,
+            "loc": 24,
+            "qualified_name": "_readonly_connection"
+          },
+          {
+            "async": false,
+            "end_line": 164,
+            "kind": "function",
+            "line": 123,
+            "loc": 42,
+            "qualified_name": "_read_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 173,
+            "kind": "function",
+            "line": 167,
+            "loc": 7,
+            "qualified_name": "_prefix_upper_bound"
+          },
+          {
+            "async": false,
+            "end_line": 182,
+            "kind": "function",
+            "line": 176,
+            "loc": 7,
+            "qualified_name": "_glob_pattern"
+          },
+          {
+            "async": false,
+            "end_line": 190,
+            "kind": "function",
+            "line": 185,
+            "loc": 6,
+            "qualified_name": "_category_clause"
+          },
+          {
+            "async": false,
+            "end_line": 221,
+            "kind": "function",
+            "line": 193,
+            "loc": 29,
+            "qualified_name": "_fetch_tier"
+          },
+          {
+            "async": false,
+            "end_line": 334,
+            "kind": "function",
+            "line": 224,
+            "loc": 111,
+            "qualified_name": "_query_rows"
+          },
+          {
+            "async": false,
+            "end_line": 356,
+            "kind": "function",
+            "line": 337,
+            "loc": 20,
+            "qualified_name": "_query_index"
+          },
+          {
+            "async": false,
+            "end_line": 380,
+            "kind": "function",
+            "line": 359,
+            "loc": 22,
+            "qualified_name": "_create_schema"
+          },
+          {
+            "async": false,
+            "end_line": 474,
+            "kind": "function",
+            "line": 383,
+            "loc": 92,
+            "qualified_name": "_build_index"
+          },
+          {
+            "async": false,
+            "end_line": 497,
+            "kind": "function",
+            "line": 477,
+            "loc": 21,
+            "qualified_name": "_query_or_invalid"
+          },
+          {
+            "async": false,
+            "end_line": 507,
+            "kind": "function",
+            "line": 500,
+            "loc": 8,
+            "qualified_name": "_default_autocomplete_index_dir"
+          },
+          {
+            "async": false,
+            "end_line": 516,
+            "kind": "method",
+            "line": 513,
+            "loc": 4,
+            "qualified_name": "_AutocompleteIndexStore.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 520,
+            "kind": "method",
+            "line": 518,
+            "loc": 3,
+            "qualified_name": "_AutocompleteIndexStore.root"
+          },
+          {
+            "async": false,
+            "end_line": 524,
+            "kind": "method",
+            "line": 522,
+            "loc": 3,
+            "qualified_name": "_AutocompleteIndexStore.close"
+          },
+          {
+            "async": false,
+            "end_line": 536,
+            "kind": "method",
+            "line": 526,
+            "loc": 11,
+            "qualified_name": "_AutocompleteIndexStore._index_lock"
+          },
+          {
+            "async": false,
+            "end_line": 556,
+            "kind": "method",
+            "line": 538,
+            "loc": 19,
+            "qualified_name": "_AutocompleteIndexStore.search"
+          },
+          {
+            "async": false,
+            "end_line": 658,
+            "kind": "method",
+            "line": 558,
+            "loc": 101,
+            "qualified_name": "_AutocompleteIndexStore._search_at_root"
+          },
+          {
+            "async": false,
+            "end_line": 684,
+            "kind": "function",
+            "line": 666,
+            "loc": 19,
+            "qualified_name": "search_autocomplete_index"
+          }
+        ],
         "is_package": false,
         "loc": 684,
         "module": "easyuse_anima.autocomplete.index",
@@ -71526,6 +75496,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 17,
+            "kind": "method",
+            "line": 17,
+            "loc": 1,
+            "qualified_name": "AutocompletePort.resolve_source"
+          },
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "method",
+            "line": 19,
+            "loc": 4,
+            "qualified_name": "AutocompletePort.available_sources"
+          },
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "method",
+            "line": 24,
+            "loc": 1,
+            "qualified_name": "AutocompletePort.status"
+          },
+          {
+            "async": false,
+            "end_line": 32,
+            "kind": "method",
+            "line": 26,
+            "loc": 7,
+            "qualified_name": "AutocompletePort.search"
+          },
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "method",
+            "line": 34,
+            "loc": 6,
+            "qualified_name": "AutocompletePort.classify"
+          }
+        ],
         "is_package": false,
         "loc": 42,
         "module": "easyuse_anima.autocomplete.ports",
@@ -71538,6 +75550,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 36,
+            "loc": 13,
+            "qualified_name": "_autocomplete_match_score"
+          },
+          {
+            "async": false,
+            "end_line": 69,
+            "kind": "function",
+            "line": 51,
+            "loc": 19,
+            "qualified_name": "_top_autocomplete_matches"
+          },
+          {
+            "async": false,
+            "end_line": 63,
+            "kind": "function",
+            "line": 57,
+            "loc": 7,
+            "qualified_name": "_top_autocomplete_matches.matches"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 72,
+            "loc": 5,
+            "qualified_name": "_index_source"
+          },
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "function",
+            "line": 79,
+            "loc": 3,
+            "qualified_name": "_validate_index_source"
+          },
+          {
+            "async": false,
+            "end_line": 96,
+            "kind": "function",
+            "line": 84,
+            "loc": 13,
+            "qualified_name": "_fallback_index_diagnostics"
+          },
+          {
+            "async": false,
+            "end_line": 196,
+            "kind": "function",
+            "line": 99,
+            "loc": 98,
+            "qualified_name": "_search_autocomplete_diagnostics_with_owners"
+          },
+          {
+            "async": false,
+            "end_line": 212,
+            "kind": "function",
+            "line": 199,
+            "loc": 14,
+            "qualified_name": "_search_autocomplete_with_diagnostics"
+          },
+          {
+            "async": false,
+            "end_line": 241,
+            "kind": "function",
+            "line": 215,
+            "loc": 27,
+            "qualified_name": "_search_autocomplete_with_owners"
+          },
+          {
+            "async": false,
+            "end_line": 258,
+            "kind": "function",
+            "line": 244,
+            "loc": 15,
+            "qualified_name": "search_autocomplete"
+          }
+        ],
         "is_package": false,
         "loc": 261,
         "module": "easyuse_anima.autocomplete.search",
@@ -71550,6 +75644,80 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "method",
+            "line": 30,
+            "loc": 8,
+            "qualified_name": "_AutocompleteService.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "method",
+            "line": 39,
+            "loc": 3,
+            "qualified_name": "_AutocompleteService.snapshots"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "method",
+            "line": 43,
+            "loc": 3,
+            "qualified_name": "_AutocompleteService.index_store"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "method",
+            "line": 47,
+            "loc": 2,
+            "qualified_name": "_AutocompleteService.resolve_source"
+          },
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "method",
+            "line": 50,
+            "loc": 5,
+            "qualified_name": "_AutocompleteService.available_sources"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "method",
+            "line": 56,
+            "loc": 5,
+            "qualified_name": "_AutocompleteService._snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 70,
+            "kind": "method",
+            "line": 62,
+            "loc": 9,
+            "qualified_name": "_AutocompleteService.status"
+          },
+          {
+            "async": false,
+            "end_line": 88,
+            "kind": "method",
+            "line": 72,
+            "loc": 17,
+            "qualified_name": "_AutocompleteService.search"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "method",
+            "line": 90,
+            "loc": 13,
+            "qualified_name": "_AutocompleteService.classify"
+          }
+        ],
         "is_package": false,
         "loc": 105,
         "module": "easyuse_anima.autocomplete.service",
@@ -71562,6 +75730,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 100,
+            "kind": "method",
+            "line": 99,
+            "loc": 2,
+            "qualified_name": "_SystemClock.monotonic"
+          },
+          {
+            "async": false,
+            "end_line": 114,
+            "kind": "function",
+            "line": 103,
+            "loc": 12,
+            "qualified_name": "_load_runtime_config"
+          },
+          {
+            "async": false,
+            "end_line": 118,
+            "kind": "function",
+            "line": 117,
+            "loc": 2,
+            "qualified_name": "_missing_comfy_nodes"
+          },
+          {
+            "async": false,
+            "end_line": 133,
+            "kind": "function",
+            "line": 121,
+            "loc": 13,
+            "qualified_name": "build_settings_route_group"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "function",
+            "line": 136,
+            "loc": 15,
+            "qualified_name": "build_wildcard_autocomplete_route_group"
+          },
+          {
+            "async": false,
+            "end_line": 162,
+            "kind": "function",
+            "line": 153,
+            "loc": 10,
+            "qualified_name": "build_translation_route_handler"
+          },
+          {
+            "async": false,
+            "end_line": 203,
+            "kind": "function",
+            "line": 165,
+            "loc": 39,
+            "qualified_name": "build_translation_route_runtime"
+          },
+          {
+            "async": false,
+            "end_line": 217,
+            "kind": "function",
+            "line": 206,
+            "loc": 12,
+            "qualified_name": "build_aio_torch_compile_route_handler"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "function",
+            "line": 220,
+            "loc": 13,
+            "qualified_name": "build_lora_read_route_group"
+          },
+          {
+            "async": false,
+            "end_line": 247,
+            "kind": "function",
+            "line": 235,
+            "loc": 13,
+            "qualified_name": "build_profile_list_route_group"
+          },
+          {
+            "async": false,
+            "end_line": 268,
+            "kind": "function",
+            "line": 250,
+            "loc": 19,
+            "qualified_name": "build_profile_route_group"
+          },
+          {
+            "async": false,
+            "end_line": 401,
+            "kind": "function",
+            "line": 271,
+            "loc": 131,
+            "qualified_name": "initialize"
+          },
+          {
+            "async": false,
+            "end_line": 316,
+            "kind": "function",
+            "line": 310,
+            "loc": 7,
+            "qualified_name": "initialize.restore_translation_facade"
+          },
+          {
+            "async": false,
+            "end_line": 419,
+            "kind": "function",
+            "line": 404,
+            "loc": 16,
+            "qualified_name": "shutdown"
+          }
+        ],
         "is_package": false,
         "loc": 422,
         "module": "easyuse_anima.bootstrap",
@@ -71574,6 +75856,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.common",
@@ -71586,6 +75869,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 8,
+            "kind": "function",
+            "line": 7,
+            "loc": 2,
+            "qualified_name": "_stable_change_key"
+          },
+          {
+            "async": false,
+            "end_line": 12,
+            "kind": "function",
+            "line": 11,
+            "loc": 2,
+            "qualified_name": "_json_clone"
+          },
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 15,
+            "loc": 11,
+            "qualified_name": "_json_object"
+          }
+        ],
         "is_package": false,
         "loc": 28,
         "module": "easyuse_anima.common.serialization",
@@ -71598,6 +75907,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 9,
+            "kind": "function",
+            "line": 4,
+            "loc": 6,
+            "qualified_name": "_single_value"
+          },
+          {
+            "async": false,
+            "end_line": 18,
+            "kind": "function",
+            "line": 12,
+            "loc": 7,
+            "qualified_name": "_as_bool"
+          },
+          {
+            "async": false,
+            "end_line": 28,
+            "kind": "function",
+            "line": 21,
+            "loc": 8,
+            "qualified_name": "_as_int"
+          },
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "function",
+            "line": 31,
+            "loc": 8,
+            "qualified_name": "_as_float"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 41,
+            "loc": 8,
+            "qualified_name": "_choice"
+          }
+        ],
         "is_package": false,
         "loc": 51,
         "module": "easyuse_anima.common.values",
@@ -71610,6 +75961,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 42,
         "module": "easyuse_anima.errors",
@@ -71622,6 +75974,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.image",
@@ -71634,6 +75987,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 17,
+            "kind": "method",
+            "line": 15,
+            "loc": 3,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "method",
+            "line": 19,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.__getattr__"
+          },
+          {
+            "async": false,
+            "end_line": 40,
+            "kind": "method",
+            "line": 24,
+            "loc": 17,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.touch_scaled_size"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "method",
+            "line": 42,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.post_upscale"
+          },
+          {
+            "async": false,
+            "end_line": 50,
+            "kind": "method",
+            "line": 47,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.get_skip_sampling"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "method",
+            "line": 52,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.post_encode"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "method",
+            "line": 57,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.get_custom_sampler"
+          },
+          {
+            "async": false,
+            "end_line": 65,
+            "kind": "method",
+            "line": 62,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.set_steps"
+          },
+          {
+            "async": false,
+            "end_line": 70,
+            "kind": "method",
+            "line": 67,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.cycle_latent"
+          },
+          {
+            "async": false,
+            "end_line": 77,
+            "kind": "method",
+            "line": 72,
+            "loc": 6,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.pre_ksample"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "method",
+            "line": 79,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.get_custom_noise"
+          },
+          {
+            "async": false,
+            "end_line": 87,
+            "kind": "method",
+            "line": 84,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.pre_decode"
+          },
+          {
+            "async": false,
+            "end_line": 92,
+            "kind": "method",
+            "line": 89,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.post_decode"
+          },
+          {
+            "async": false,
+            "end_line": 97,
+            "kind": "method",
+            "line": 94,
+            "loc": 4,
+            "qualified_name": "_EasyUseAnimaAlignedDetailerHook.post_paste"
+          }
+        ],
         "is_package": false,
         "loc": 100,
         "module": "easyuse_anima.image.detailer",
@@ -71646,6 +76113,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 16,
+            "kind": "function",
+            "line": 8,
+            "loc": 9,
+            "qualified_name": "_alignment_value"
+          },
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "function",
+            "line": 19,
+            "loc": 4,
+            "qualified_name": "_align_up"
+          },
+          {
+            "async": false,
+            "end_line": 32,
+            "kind": "function",
+            "line": 25,
+            "loc": 8,
+            "qualified_name": "_align_nearest"
+          },
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "function",
+            "line": 35,
+            "loc": 4,
+            "qualified_name": "_align_down"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 41,
+            "loc": 5,
+            "qualified_name": "_image_tensor_size"
+          },
+          {
+            "async": false,
+            "end_line": 94,
+            "kind": "function",
+            "line": 48,
+            "loc": 47,
+            "qualified_name": "_aligned_size_near_scale"
+          }
+        ],
         "is_package": false,
         "loc": 97,
         "module": "easyuse_anima.image.geometry",
@@ -71658,6 +76175,112 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "function",
+            "line": 13,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "function",
+            "line": 17,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 25,
+            "loc": 6,
+            "qualified_name": "_find_comfy_node_mapping_class"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 33,
+            "loc": 29,
+            "qualified_name": "_find_impact_detailer_class"
+          },
+          {
+            "async": false,
+            "end_line": 80,
+            "kind": "function",
+            "line": 64,
+            "loc": 17,
+            "qualified_name": "_find_sam3_detect_class"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 83,
+            "loc": 41,
+            "qualified_name": "_find_impact_mask_to_segs_class"
+          },
+          {
+            "async": false,
+            "end_line": 139,
+            "kind": "function",
+            "line": 126,
+            "loc": 14,
+            "qualified_name": "_format_sam3_detection_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "function",
+            "line": 142,
+            "loc": 7,
+            "qualified_name": "_sam3_context"
+          },
+          {
+            "async": false,
+            "end_line": 154,
+            "kind": "function",
+            "line": 151,
+            "loc": 4,
+            "qualified_name": "_context_value"
+          },
+          {
+            "async": false,
+            "end_line": 167,
+            "kind": "function",
+            "line": 157,
+            "loc": 11,
+            "qualified_name": "_empty_mask_for_image"
+          },
+          {
+            "async": false,
+            "end_line": 171,
+            "kind": "function",
+            "line": 170,
+            "loc": 2,
+            "qualified_name": "_empty_segs_for_image"
+          },
+          {
+            "async": false,
+            "end_line": 178,
+            "kind": "function",
+            "line": 174,
+            "loc": 5,
+            "qualified_name": "_segs_has_items"
+          },
+          {
+            "async": false,
+            "end_line": 189,
+            "kind": "function",
+            "line": 181,
+            "loc": 9,
+            "qualified_name": "_call_impact_detailer"
+          }
+        ],
         "is_package": false,
         "loc": 192,
         "module": "easyuse_anima.image.sam3",
@@ -71670,6 +76293,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "function",
+            "line": 15,
+            "loc": 5,
+            "qualified_name": "_scale_by_value"
+          },
+          {
+            "async": false,
+            "end_line": 26,
+            "kind": "function",
+            "line": 22,
+            "loc": 5,
+            "qualified_name": "_max_long_edge_value"
+          },
+          {
+            "async": false,
+            "end_line": 122,
+            "kind": "function",
+            "line": 29,
+            "loc": 94,
+            "qualified_name": "_image_scale_by_multiple_size"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "function",
+            "line": 125,
+            "loc": 24,
+            "qualified_name": "_normalize_image_scale_options"
+          }
+        ],
         "is_package": false,
         "loc": 154,
         "module": "easyuse_anima.image.scaling",
@@ -71682,6 +76339,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.infrastructure",
@@ -71694,6 +76352,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.infrastructure.comfy",
@@ -71706,6 +76365,80 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "function",
+            "line": 10,
+            "loc": 5,
+            "qualified_name": "_comfy_max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 33,
+            "kind": "function",
+            "line": 17,
+            "loc": 17,
+            "qualified_name": "_comfy_sampler_names"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 36,
+            "loc": 25,
+            "qualified_name": "_comfy_scheduler_names"
+          },
+          {
+            "async": false,
+            "end_line": 79,
+            "kind": "function",
+            "line": 63,
+            "loc": 17,
+            "qualified_name": "_impact_core_module"
+          },
+          {
+            "async": false,
+            "end_line": 94,
+            "kind": "function",
+            "line": 82,
+            "loc": 13,
+            "qualified_name": "_impact_scheduler_names"
+          },
+          {
+            "async": false,
+            "end_line": 115,
+            "kind": "function",
+            "line": 97,
+            "loc": 19,
+            "qualified_name": "_find_comfy_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 130,
+            "kind": "function",
+            "line": 118,
+            "loc": 13,
+            "qualified_name": "_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 147,
+            "kind": "function",
+            "line": 133,
+            "loc": 15,
+            "qualified_name": "_require_any_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 164,
+            "kind": "function",
+            "line": 150,
+            "loc": 15,
+            "qualified_name": "_find_loaded_node_class"
+          }
+        ],
         "is_package": false,
         "loc": 167,
         "module": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -71718,6 +76451,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 18,
+            "kind": "function",
+            "line": 10,
+            "loc": 9,
+            "qualified_name": "_node_output_tuple"
+          },
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 21,
+            "loc": 27,
+            "qualified_name": "_call_with_supported_kwargs"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 50,
+            "loc": 12,
+            "qualified_name": "_common_upscale_image"
+          },
+          {
+            "async": false,
+            "end_line": 79,
+            "kind": "function",
+            "line": 64,
+            "loc": 16,
+            "qualified_name": "_encode_with_comfy_clip"
+          }
+        ],
         "is_package": false,
         "loc": 82,
         "module": "easyuse_anima.infrastructure.comfy.invocation",
@@ -71730,6 +76497,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "method",
+            "line": 19,
+            "loc": 1,
+            "qualified_name": "ComfyHostProvider.max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "method",
+            "line": 21,
+            "loc": 1,
+            "qualified_name": "ComfyHostProvider.find_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 23,
+            "kind": "method",
+            "line": 23,
+            "loc": 1,
+            "qualified_name": "ComfyHostProvider.find_node_mapping_class"
+          },
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "method",
+            "line": 25,
+            "loc": 1,
+            "qualified_name": "ComfyHostProvider.find_loaded_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "function",
+            "line": 28,
+            "loc": 2,
+            "qualified_name": "_loaded_comfy_nodes"
+          },
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "method",
+            "line": 35,
+            "loc": 5,
+            "qualified_name": "DefaultComfyHostProvider.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "method",
+            "line": 41,
+            "loc": 5,
+            "qualified_name": "DefaultComfyHostProvider._comfy_nodes"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "method",
+            "line": 47,
+            "loc": 2,
+            "qualified_name": "DefaultComfyHostProvider.max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 51,
+            "kind": "method",
+            "line": 50,
+            "loc": 2,
+            "qualified_name": "DefaultComfyHostProvider.find_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "method",
+            "line": 53,
+            "loc": 6,
+            "qualified_name": "DefaultComfyHostProvider.find_node_mapping_class"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "method",
+            "line": 60,
+            "loc": 2,
+            "qualified_name": "DefaultComfyHostProvider.find_loaded_node_class"
+          }
+        ],
         "is_package": false,
         "loc": 64,
         "module": "easyuse_anima.infrastructure.comfy.provider",
@@ -71742,6 +76599,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "function",
+            "line": 10,
+            "loc": 10,
+            "qualified_name": "_comfy_checkpoint_names"
+          },
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "function",
+            "line": 22,
+            "loc": 10,
+            "qualified_name": "_folder_path_names"
+          },
+          {
+            "async": false,
+            "end_line": 77,
+            "kind": "function",
+            "line": 34,
+            "loc": 44,
+            "qualified_name": "_comfy_resource_file_revision"
+          },
+          {
+            "async": false,
+            "end_line": 84,
+            "kind": "function",
+            "line": 80,
+            "loc": 5,
+            "qualified_name": "_comfy_diffusion_model_names"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 87,
+            "loc": 5,
+            "qualified_name": "_comfy_text_encoder_names"
+          },
+          {
+            "async": false,
+            "end_line": 108,
+            "kind": "function",
+            "line": 94,
+            "loc": 15,
+            "qualified_name": "_comfy_vae_names"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "function",
+            "line": 111,
+            "loc": 14,
+            "qualified_name": "_comfy_clip_loader_types"
+          }
+        ],
         "is_package": false,
         "loc": 127,
         "module": "easyuse_anima.infrastructure.comfy.resources",
@@ -71754,6 +76669,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "function",
+            "line": 18,
+            "loc": 2,
+            "qualified_name": "_default_max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 23,
+            "kind": "function",
+            "line": 22,
+            "loc": 2,
+            "qualified_name": "_default_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 27,
+            "kind": "function",
+            "line": 26,
+            "loc": 2,
+            "qualified_name": "_default_node_mapping_class"
+          },
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "function",
+            "line": 30,
+            "loc": 2,
+            "qualified_name": "_default_loaded_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 44,
+            "kind": "function",
+            "line": 34,
+            "loc": 11,
+            "qualified_name": "_default_require_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 57,
+            "kind": "function",
+            "line": 47,
+            "loc": 11,
+            "qualified_name": "_default_require_any_custom_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 65,
+            "kind": "function",
+            "line": 60,
+            "loc": 6,
+            "qualified_name": "_default_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "function",
+            "line": 68,
+            "loc": 61,
+            "qualified_name": "resolve_comfy_host_helper"
+          }
+        ],
         "is_package": false,
         "loc": 131,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
@@ -71766,6 +76747,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.infrastructure.filesystem",
@@ -71778,6 +76760,168 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 29,
+            "loc": 2,
+            "qualified_name": "_resolved_path"
+          },
+          {
+            "async": false,
+            "end_line": 34,
+            "kind": "function",
+            "line": 33,
+            "loc": 2,
+            "qualified_name": "_path_lock_key"
+          },
+          {
+            "async": false,
+            "end_line": 44,
+            "kind": "function",
+            "line": 37,
+            "loc": 8,
+            "qualified_name": "_path_lock"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 47,
+            "loc": 14,
+            "qualified_name": "_locked_paths"
+          },
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "function",
+            "line": 63,
+            "loc": 16,
+            "qualified_name": "_fsync_directory"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 81,
+            "loc": 5,
+            "qualified_name": "_unlink_if_present"
+          },
+          {
+            "async": false,
+            "end_line": 118,
+            "kind": "method",
+            "line": 103,
+            "loc": 16,
+            "qualified_name": "AtomicJsonStore.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 125,
+            "kind": "method",
+            "line": 120,
+            "loc": 6,
+            "qualified_name": "AtomicJsonStore.locked"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "method",
+            "line": 127,
+            "loc": 2,
+            "qualified_name": "AtomicJsonStore._read_path"
+          },
+          {
+            "async": false,
+            "end_line": 146,
+            "kind": "method",
+            "line": 130,
+            "loc": 17,
+            "qualified_name": "AtomicJsonStore._read_unlocked"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "method",
+            "line": 148,
+            "loc": 3,
+            "qualified_name": "AtomicJsonStore.read"
+          },
+          {
+            "async": false,
+            "end_line": 172,
+            "kind": "method",
+            "line": 152,
+            "loc": 21,
+            "qualified_name": "AtomicJsonStore._write_temp"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "method",
+            "line": 174,
+            "loc": 18,
+            "qualified_name": "AtomicJsonStore._backup_primary_unlocked"
+          },
+          {
+            "async": false,
+            "end_line": 203,
+            "kind": "method",
+            "line": 193,
+            "loc": 11,
+            "qualified_name": "AtomicJsonStore._write_bytes_unlocked"
+          },
+          {
+            "async": false,
+            "end_line": 210,
+            "kind": "method",
+            "line": 205,
+            "loc": 6,
+            "qualified_name": "AtomicJsonStore._encode"
+          },
+          {
+            "async": false,
+            "end_line": 221,
+            "kind": "method",
+            "line": 212,
+            "loc": 10,
+            "qualified_name": "AtomicJsonStore.write"
+          },
+          {
+            "async": false,
+            "end_line": 237,
+            "kind": "method",
+            "line": 223,
+            "loc": 15,
+            "qualified_name": "AtomicJsonStore.update"
+          },
+          {
+            "async": false,
+            "end_line": 261,
+            "kind": "method",
+            "line": 239,
+            "loc": 23,
+            "qualified_name": "AtomicJsonStore.delete"
+          },
+          {
+            "async": false,
+            "end_line": 402,
+            "kind": "method",
+            "line": 263,
+            "loc": 140,
+            "qualified_name": "AtomicJsonStore.replace_from"
+          },
+          {
+            "async": false,
+            "end_line": 412,
+            "kind": "function",
+            "line": 405,
+            "loc": 8,
+            "qualified_name": "create_atomic_json_store"
+          }
+        ],
         "is_package": false,
         "loc": 415,
         "module": "easyuse_anima.infrastructure.filesystem.atomic_json",
@@ -71790,6 +76934,16 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "function",
+            "line": 14,
+            "loc": 25,
+            "qualified_name": "_resolve_user_data_dir"
+          }
+        ],
         "is_package": false,
         "loc": 49,
         "module": "easyuse_anima.infrastructure.filesystem.paths",
@@ -71802,6 +76956,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.lora",
@@ -71814,6 +76969,152 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "method",
+            "line": 13,
+            "loc": 2,
+            "qualified_name": "_RuntimeLoggerProxy.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 17,
+            "kind": "method",
+            "line": 16,
+            "loc": 2,
+            "qualified_name": "_RuntimeLoggerProxy.__getattr__"
+          },
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "function",
+            "line": 20,
+            "loc": 2,
+            "qualified_name": "_resolve_logger"
+          },
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 27,
+            "loc": 4,
+            "qualified_name": "_prompt_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 40,
+            "kind": "function",
+            "line": 33,
+            "loc": 8,
+            "qualified_name": "_apply_lora_syntax_format"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "function",
+            "line": 43,
+            "loc": 16,
+            "qualified_name": "_fallback_lora_path"
+          },
+          {
+            "async": false,
+            "end_line": 87,
+            "kind": "function",
+            "line": 61,
+            "loc": 27,
+            "qualified_name": "_lora_stack_name"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 90,
+            "loc": 13,
+            "qualified_name": "_dedupe_text_values"
+          },
+          {
+            "async": false,
+            "end_line": 118,
+            "kind": "function",
+            "line": 105,
+            "loc": 14,
+            "qualified_name": "_trigger_words_from_value"
+          },
+          {
+            "async": false,
+            "end_line": 127,
+            "kind": "function",
+            "line": 121,
+            "loc": 7,
+            "qualified_name": "_metadata_json_paths_for_lora"
+          },
+          {
+            "async": false,
+            "end_line": 142,
+            "kind": "function",
+            "line": 130,
+            "loc": 13,
+            "qualified_name": "_load_lora_manager_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 158,
+            "kind": "function",
+            "line": 145,
+            "loc": 14,
+            "qualified_name": "_lora_manager_trigger_words_from_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "function",
+            "line": 161,
+            "loc": 3,
+            "qualified_name": "_get_lora_manager_trigger_words"
+          },
+          {
+            "async": false,
+            "end_line": 184,
+            "kind": "function",
+            "line": 166,
+            "loc": 19,
+            "qualified_name": "_get_lora_info"
+          },
+          {
+            "async": false,
+            "end_line": 205,
+            "kind": "function",
+            "line": 187,
+            "loc": 19,
+            "qualified_name": "_lora_combo_values"
+          },
+          {
+            "async": false,
+            "end_line": 226,
+            "kind": "function",
+            "line": 208,
+            "loc": 19,
+            "qualified_name": "_lora_model_exists"
+          },
+          {
+            "async": false,
+            "end_line": 238,
+            "kind": "function",
+            "line": 229,
+            "loc": 10,
+            "qualified_name": "_missing_lora_display_name"
+          },
+          {
+            "async": false,
+            "end_line": 252,
+            "kind": "function",
+            "line": 241,
+            "loc": 12,
+            "qualified_name": "_raise_missing_loras"
+          }
+        ],
         "is_package": false,
         "loc": 255,
         "module": "easyuse_anima.lora.metadata",
@@ -71826,6 +77127,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "function",
+            "line": 11,
+            "loc": 4,
+            "qualified_name": "_correct_builder_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 18,
+            "kind": "function",
+            "line": 17,
+            "loc": 2,
+            "qualified_name": "_profile_key"
+          },
+          {
+            "async": false,
+            "end_line": 24,
+            "kind": "function",
+            "line": 21,
+            "loc": 4,
+            "qualified_name": "_wrap_profile_index"
+          },
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 27,
+            "loc": 15,
+            "qualified_name": "_load_profile_data"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 44,
+            "loc": 12,
+            "qualified_name": "_get_loras_list"
+          },
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "function",
+            "line": 58,
+            "loc": 2,
+            "qualified_name": "_correct_style_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 62,
+            "loc": 3,
+            "qualified_name": "_format_strength"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 67,
+            "loc": 19,
+            "qualified_name": "_select_profile_values"
+          }
+        ],
         "is_package": false,
         "loc": 88,
         "module": "easyuse_anima.lora.preset",
@@ -71838,6 +77205,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.naia",
@@ -71850,6 +77218,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 40,
+            "loc": 6,
+            "qualified_name": "_clean_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 48,
+            "loc": 15,
+            "qualified_name": "_fit_to_1mp"
+          },
+          {
+            "async": false,
+            "end_line": 66,
+            "kind": "function",
+            "line": 65,
+            "loc": 2,
+            "qualified_name": "_is_local_naia_host"
+          },
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "function",
+            "line": 69,
+            "loc": 13,
+            "qualified_name": "_build_naia_random_url"
+          },
+          {
+            "async": false,
+            "end_line": 110,
+            "kind": "function",
+            "line": 84,
+            "loc": 27,
+            "qualified_name": "_post_random"
+          },
+          {
+            "async": false,
+            "end_line": 132,
+            "kind": "function",
+            "line": 113,
+            "loc": 20,
+            "qualified_name": "_parse_random_response"
+          }
+        ],
         "is_package": false,
         "loc": 134,
         "module": "easyuse_anima.naia.client",
@@ -71862,6 +77280,120 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "function",
+            "line": 79,
+            "loc": 3,
+            "qualified_name": "_ratio_label"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 84,
+            "loc": 2,
+            "qualified_name": "_resolution_label"
+          },
+          {
+            "async": false,
+            "end_line": 90,
+            "kind": "function",
+            "line": 88,
+            "loc": 3,
+            "qualified_name": "_sorted_resolution_options"
+          },
+          {
+            "async": false,
+            "end_line": 97,
+            "kind": "function",
+            "line": 93,
+            "loc": 5,
+            "qualified_name": "_normalize_resolution_bucket"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 100,
+            "loc": 5,
+            "qualified_name": "_snap_resolution_32"
+          },
+          {
+            "async": false,
+            "end_line": 109,
+            "kind": "function",
+            "line": 107,
+            "loc": 3,
+            "qualified_name": "_resolve_naia_resolution_scale"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 112,
+            "loc": 5,
+            "qualified_name": "_resolve_naia_resolution_max_long_edge"
+          },
+          {
+            "async": false,
+            "end_line": 125,
+            "kind": "function",
+            "line": 119,
+            "loc": 7,
+            "qualified_name": "_resolve_naia_resolution_mode"
+          },
+          {
+            "async": false,
+            "end_line": 130,
+            "kind": "function",
+            "line": 128,
+            "loc": 3,
+            "qualified_name": "_resolve_naia_resolution_bucket"
+          },
+          {
+            "async": false,
+            "end_line": 140,
+            "kind": "function",
+            "line": 133,
+            "loc": 8,
+            "qualified_name": "_snap_scaled_resolution_32"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "function",
+            "line": 143,
+            "loc": 21,
+            "qualified_name": "_scale_naia_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 180,
+            "kind": "function",
+            "line": 166,
+            "loc": 15,
+            "qualified_name": "_fit_naia_resolution_to_bucket"
+          },
+          {
+            "async": false,
+            "end_line": 190,
+            "kind": "function",
+            "line": 183,
+            "loc": 8,
+            "qualified_name": "_resolve_naia_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 214,
+            "kind": "function",
+            "line": 193,
+            "loc": 22,
+            "qualified_name": "_advanced_resolution_from_selection"
+          }
+        ],
         "is_package": false,
         "loc": 216,
         "module": "easyuse_anima.naia.resolution",
@@ -71874,6 +77406,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.nodes",
@@ -71886,6 +77419,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 56,
+            "kind": "function",
+            "line": 51,
+            "loc": 6,
+            "qualified_name": "_aio_input_settings_json"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 59,
+            "loc": 6,
+            "qualified_name": "_aio_generation_settings_json"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "method",
+            "line": 80,
+            "loc": 45,
+            "qualified_name": "EasyUseAnimaInput.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 156,
+            "kind": "method",
+            "line": 131,
+            "loc": 26,
+            "qualified_name": "EasyUseAnimaInput.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 192,
+            "kind": "method",
+            "line": 158,
+            "loc": 35,
+            "qualified_name": "EasyUseAnimaInput.build"
+          },
+          {
+            "async": false,
+            "end_line": 245,
+            "kind": "method",
+            "line": 210,
+            "loc": 36,
+            "qualified_name": "EasyUseAnimaAIOGenerator.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 275,
+            "kind": "method",
+            "line": 253,
+            "loc": 23,
+            "qualified_name": "EasyUseAnimaAIOGenerator.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 316,
+            "kind": "method",
+            "line": 277,
+            "loc": 40,
+            "qualified_name": "EasyUseAnimaAIOGenerator.generate"
+          }
+        ],
         "is_package": false,
         "loc": 319,
         "module": "easyuse_anima.nodes.aio_nodes",
@@ -71898,6 +77497,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "method",
+            "line": 32,
+            "loc": 31,
+            "qualified_name": "EasyUseAnimaImageScaleByMultiple.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 84,
+            "kind": "method",
+            "line": 69,
+            "loc": 16,
+            "qualified_name": "EasyUseAnimaImageScaleByMultiple.upscale"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "method",
+            "line": 99,
+            "loc": 18,
+            "qualified_name": "EasyUseAnimaDetailerAlignHook.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 125,
+            "kind": "method",
+            "line": 123,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaDetailerAlignHook.build"
+          }
+        ],
         "is_package": false,
         "loc": 131,
         "module": "easyuse_anima.nodes.image_nodes",
@@ -71910,6 +77543,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "function",
+            "line": 20,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "function",
+            "line": 24,
+            "loc": 6,
+            "qualified_name": "_comfy_max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 170,
+            "kind": "method",
+            "line": 42,
+            "loc": 129,
+            "qualified_name": "_EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 263,
+            "kind": "method",
+            "line": 177,
+            "loc": 87,
+            "qualified_name": "_EasyUseAnimaImpactDetailerDelegate.doit"
+          }
+        ],
         "is_package": false,
         "loc": 266,
         "module": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -71922,6 +77589,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 10,
+            "kind": "method",
+            "line": 9,
+            "loc": 2,
+            "qualified_name": "_AnyType.__ne__"
+          },
+          {
+            "async": false,
+            "end_line": 15,
+            "kind": "method",
+            "line": 14,
+            "loc": 2,
+            "qualified_name": "_FlexibleOptionalInputType.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 18,
+            "kind": "method",
+            "line": 17,
+            "loc": 2,
+            "qualified_name": "_FlexibleOptionalInputType.__getitem__"
+          },
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "method",
+            "line": 20,
+            "loc": 2,
+            "qualified_name": "_FlexibleOptionalInputType.__contains__"
+          }
+        ],
         "is_package": false,
         "loc": 24,
         "module": "easyuse_anima.nodes.input_types",
@@ -71934,6 +77635,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 73,
+            "kind": "method",
+            "line": 37,
+            "loc": 37,
+            "qualified_name": "EasyUseAnimaLoraPreset.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "method",
+            "line": 80,
+            "loc": 6,
+            "qualified_name": "EasyUseAnimaLoraPreset.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 182,
+            "kind": "method",
+            "line": 87,
+            "loc": 96,
+            "qualified_name": "EasyUseAnimaLoraPreset.build"
+          }
+        ],
         "is_package": false,
         "loc": 185,
         "module": "easyuse_anima.nodes.lora_nodes",
@@ -71946,6 +77673,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 177,
+            "kind": "method",
+            "line": 41,
+            "loc": 137,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 186,
+            "kind": "method",
+            "line": 184,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 269,
+            "kind": "method",
+            "line": 188,
+            "loc": 82,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 284,
+            "kind": "method",
+            "line": 271,
+            "loc": 14,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._cached_tuple"
+          },
+          {
+            "async": false,
+            "end_line": 288,
+            "kind": "method",
+            "line": 286,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._widget_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 332,
+            "kind": "method",
+            "line": 290,
+            "loc": 43,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._make_signature"
+          },
+          {
+            "async": false,
+            "end_line": 361,
+            "kind": "method",
+            "line": 334,
+            "loc": 28,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._make_request_body"
+          },
+          {
+            "async": false,
+            "end_line": 381,
+            "kind": "method",
+            "line": 363,
+            "loc": 19,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._apply_overrides"
+          },
+          {
+            "async": false,
+            "end_line": 426,
+            "kind": "method",
+            "line": 383,
+            "loc": 44,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._update_metadata_cache"
+          },
+          {
+            "async": false,
+            "end_line": 437,
+            "kind": "method",
+            "line": 428,
+            "loc": 10,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt._ui"
+          },
+          {
+            "async": false,
+            "end_line": 575,
+            "kind": "method",
+            "line": 439,
+            "loc": 137,
+            "qualified_name": "EasyUseAnimaNAIARandomPrompt.request"
+          }
+        ],
         "is_package": false,
         "loc": 577,
         "module": "easyuse_anima.nodes.naia_nodes",
@@ -71958,6 +77775,152 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 213,
+            "kind": "method",
+            "line": 126,
+            "loc": 88,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 222,
+            "kind": "method",
+            "line": 220,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced._widget_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 275,
+            "kind": "method",
+            "line": 224,
+            "loc": 52,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 324,
+            "kind": "method",
+            "line": 277,
+            "loc": 48,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced._update_metadata_fields"
+          },
+          {
+            "async": false,
+            "end_line": 342,
+            "kind": "method",
+            "line": 326,
+            "loc": 17,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced._ui"
+          },
+          {
+            "async": false,
+            "end_line": 514,
+            "kind": "method",
+            "line": 344,
+            "loc": 171,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvanced.build"
+          },
+          {
+            "async": false,
+            "end_line": 592,
+            "kind": "method",
+            "line": 528,
+            "loc": 65,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvancedV2.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 688,
+            "kind": "method",
+            "line": 594,
+            "loc": 95,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvancedV2.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 767,
+            "kind": "method",
+            "line": 690,
+            "loc": 78,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvancedV2.build"
+          },
+          {
+            "async": false,
+            "end_line": 952,
+            "kind": "method",
+            "line": 769,
+            "loc": 184,
+            "qualified_name": "EasyUseAnimaPromptStudioAdvancedV2._build_with_seed"
+          },
+          {
+            "async": false,
+            "end_line": 1006,
+            "kind": "method",
+            "line": 958,
+            "loc": 49,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 1033,
+            "kind": "method",
+            "line": 1031,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend._widget_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 1058,
+            "kind": "method",
+            "line": 1035,
+            "loc": 24,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 1092,
+            "kind": "method",
+            "line": 1060,
+            "loc": 33,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend._update_metadata_slots"
+          },
+          {
+            "async": false,
+            "end_line": 1110,
+            "kind": "method",
+            "line": 1094,
+            "loc": 17,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend._active_slot_set"
+          },
+          {
+            "async": false,
+            "end_line": 1132,
+            "kind": "method",
+            "line": 1112,
+            "loc": 21,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend._fields_from_slots"
+          },
+          {
+            "async": false,
+            "end_line": 1142,
+            "kind": "method",
+            "line": 1134,
+            "loc": 9,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend._ui"
+          },
+          {
+            "async": false,
+            "end_line": 1206,
+            "kind": "method",
+            "line": 1144,
+            "loc": 63,
+            "qualified_name": "EasyUseAnimaPromptStudioExtend.build"
+          }
+        ],
         "is_package": false,
         "loc": 1208,
         "module": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -71970,6 +77933,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 56,
+            "kind": "function",
+            "line": 55,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 59,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 132,
+            "kind": "method",
+            "line": 80,
+            "loc": 53,
+            "qualified_name": "EasyUseAnimaPromptDataUnpack.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "method",
+            "line": 139,
+            "loc": 12,
+            "qualified_name": "EasyUseAnimaPromptDataUnpack.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 162,
+            "kind": "method",
+            "line": 152,
+            "loc": 11,
+            "qualified_name": "EasyUseAnimaPromptDataUnpack.unpack"
+          },
+          {
+            "async": false,
+            "end_line": 259,
+            "kind": "method",
+            "line": 176,
+            "loc": 84,
+            "qualified_name": "EasyUseAnimaArtistMixConditioning.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 335,
+            "kind": "method",
+            "line": 266,
+            "loc": 70,
+            "qualified_name": "EasyUseAnimaArtistMixConditioning.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 435,
+            "kind": "method",
+            "line": 337,
+            "loc": 99,
+            "qualified_name": "EasyUseAnimaArtistMixConditioning.encode"
+          },
+          {
+            "async": false,
+            "end_line": 539,
+            "kind": "method",
+            "line": 455,
+            "loc": 85,
+            "qualified_name": "EasyUseAnimaPromptDataConditioning.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 615,
+            "kind": "method",
+            "line": 546,
+            "loc": 70,
+            "qualified_name": "EasyUseAnimaPromptDataConditioning.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 682,
+            "kind": "method",
+            "line": 617,
+            "loc": 66,
+            "qualified_name": "EasyUseAnimaPromptDataConditioning.apply"
+          }
+        ],
         "is_package": false,
         "loc": 684,
         "module": "easyuse_anima.nodes.prompt_data_nodes",
@@ -71982,6 +78035,104 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "function",
+            "line": 25,
+            "loc": 30,
+            "qualified_name": "_correct_prompt_with_report"
+          },
+          {
+            "async": false,
+            "end_line": 89,
+            "kind": "method",
+            "line": 69,
+            "loc": 21,
+            "qualified_name": "EasyUseAnimaPromptCorrector.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "method",
+            "line": 96,
+            "loc": 7,
+            "qualified_name": "EasyUseAnimaPromptCorrector.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 110,
+            "kind": "method",
+            "line": 104,
+            "loc": 7,
+            "qualified_name": "EasyUseAnimaPromptCorrector.correct"
+          },
+          {
+            "async": false,
+            "end_line": 134,
+            "kind": "method",
+            "line": 124,
+            "loc": 11,
+            "qualified_name": "EasyUseAnimaPromptCorrectorSimple.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 147,
+            "kind": "method",
+            "line": 141,
+            "loc": 7,
+            "qualified_name": "EasyUseAnimaPromptCorrectorSimple.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 151,
+            "kind": "method",
+            "line": 149,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaPromptCorrectorSimple.correct"
+          },
+          {
+            "async": false,
+            "end_line": 212,
+            "kind": "method",
+            "line": 168,
+            "loc": 45,
+            "qualified_name": "EasyUseAnimaPromptBuilder.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 231,
+            "kind": "method",
+            "line": 224,
+            "loc": 8,
+            "qualified_name": "EasyUseAnimaPromptBuilder.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 295,
+            "kind": "method",
+            "line": 233,
+            "loc": 63,
+            "qualified_name": "EasyUseAnimaPromptBuilder.build"
+          },
+          {
+            "async": false,
+            "end_line": 349,
+            "kind": "method",
+            "line": 305,
+            "loc": 45,
+            "qualified_name": "EasyUseAnimaPromptStudio.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 383,
+            "kind": "method",
+            "line": 353,
+            "loc": 31,
+            "qualified_name": "EasyUseAnimaPromptStudio.build"
+          }
+        ],
         "is_package": false,
         "loc": 391,
         "module": "easyuse_anima.nodes.prompt_nodes",
@@ -71994,6 +78145,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "function",
+            "line": 77,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 81,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "method",
+            "line": 105,
+            "loc": 61,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 186,
+            "kind": "method",
+            "line": 184,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional._widget_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 230,
+            "kind": "method",
+            "line": 188,
+            "loc": 43,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 279,
+            "kind": "method",
+            "line": 232,
+            "loc": 48,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional._update_metadata_fields"
+          },
+          {
+            "async": false,
+            "end_line": 297,
+            "kind": "method",
+            "line": 281,
+            "loc": 17,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional._ui"
+          },
+          {
+            "async": false,
+            "end_line": 401,
+            "kind": "method",
+            "line": 299,
+            "loc": 103,
+            "qualified_name": "EasyUseAnimaPromptStudioRegional.build"
+          },
+          {
+            "async": false,
+            "end_line": 439,
+            "kind": "method",
+            "line": 416,
+            "loc": 24,
+            "qualified_name": "EasyUseAnimaRegionalConditioning.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 463,
+            "kind": "method",
+            "line": 446,
+            "loc": 18,
+            "qualified_name": "EasyUseAnimaRegionalConditioning.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 510,
+            "kind": "method",
+            "line": 465,
+            "loc": 46,
+            "qualified_name": "EasyUseAnimaRegionalConditioning.encode"
+          }
+        ],
         "is_package": false,
         "loc": 513,
         "module": "easyuse_anima.nodes.regional_nodes",
@@ -72006,6 +78247,64 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "function",
+            "line": 30,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 34,
+            "loc": 6,
+            "qualified_name": "_comfy_max_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 42,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 75,
+            "kind": "method",
+            "line": 65,
+            "loc": 11,
+            "qualified_name": "EasyUseAnimaSAM3Context.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 84,
+            "kind": "method",
+            "line": 82,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaSAM3Context.load"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "method",
+            "line": 101,
+            "loc": 91,
+            "qualified_name": "EasyUseAnimaSAM3Detailer.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 323,
+            "kind": "method",
+            "line": 198,
+            "loc": 126,
+            "qualified_name": "EasyUseAnimaSAM3Detailer.doit"
+          }
+        ],
         "is_package": false,
         "loc": 326,
         "module": "easyuse_anima.nodes.sam3_nodes",
@@ -72018,6 +78317,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 66,
+            "kind": "method",
+            "line": 51,
+            "loc": 16,
+            "qualified_name": "AioSeedExecution.ui_payload"
+          },
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "function",
+            "line": 77,
+            "loc": 2,
+            "qualified_name": "_new_aio_compatibility_seed"
+          },
+          {
+            "async": false,
+            "end_line": 87,
+            "kind": "function",
+            "line": 81,
+            "loc": 7,
+            "qualified_name": "_aio_fallback_execution_seed"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 90,
+            "loc": 15,
+            "qualified_name": "_aio_fallback_next_seed"
+          },
+          {
+            "async": false,
+            "end_line": 127,
+            "kind": "function",
+            "line": 107,
+            "loc": 21,
+            "qualified_name": "_aio_compatibility_execution"
+          },
+          {
+            "async": false,
+            "end_line": 144,
+            "kind": "function",
+            "line": 130,
+            "loc": 15,
+            "qualified_name": "_normalize_aio_seed_request"
+          },
+          {
+            "async": false,
+            "end_line": 195,
+            "kind": "function",
+            "line": 147,
+            "loc": 49,
+            "qualified_name": "aio_seed_execution"
+          },
+          {
+            "async": false,
+            "end_line": 241,
+            "kind": "function",
+            "line": 198,
+            "loc": 44,
+            "qualified_name": "prompt_studio_seed_execution"
+          }
+        ],
         "is_package": false,
         "loc": 252,
         "module": "easyuse_anima.nodes.seed_adapters",
@@ -72030,6 +78395,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 99,
+            "kind": "method",
+            "line": 47,
+            "loc": 53,
+            "qualified_name": "EasyUseAnimaWildcard.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 108,
+            "kind": "method",
+            "line": 106,
+            "loc": 3,
+            "qualified_name": "EasyUseAnimaWildcard._widget_input_names"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "method",
+            "line": 110,
+            "loc": 7,
+            "qualified_name": "EasyUseAnimaWildcard.IS_CHANGED"
+          },
+          {
+            "async": false,
+            "end_line": 160,
+            "kind": "method",
+            "line": 118,
+            "loc": 43,
+            "qualified_name": "EasyUseAnimaWildcard._update_metadata_cache"
+          },
+          {
+            "async": false,
+            "end_line": 180,
+            "kind": "method",
+            "line": 162,
+            "loc": 19,
+            "qualified_name": "EasyUseAnimaWildcard._ui"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "method",
+            "line": 182,
+            "loc": 51,
+            "qualified_name": "EasyUseAnimaWildcard.generate"
+          }
+        ],
         "is_package": false,
         "loc": 234,
         "module": "easyuse_anima.nodes.wildcard_nodes",
@@ -72042,6 +78457,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.profiles",
@@ -72054,6 +78470,112 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 67,
+            "kind": "function",
+            "line": 60,
+            "loc": 8,
+            "qualified_name": "_current_aio_profile_repository"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 70,
+            "loc": 7,
+            "qualified_name": "_sanitize_aio_profile_name"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 79,
+            "loc": 7,
+            "qualified_name": "_aio_profile_path"
+          },
+          {
+            "async": false,
+            "end_line": 107,
+            "kind": "function",
+            "line": 88,
+            "loc": 20,
+            "qualified_name": "_find_aio_profile_path"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 110,
+            "loc": 14,
+            "qualified_name": "_normalize_aio_profile_payload"
+          },
+          {
+            "async": false,
+            "end_line": 136,
+            "kind": "function",
+            "line": 126,
+            "loc": 11,
+            "qualified_name": "_list_aio_profiles"
+          },
+          {
+            "async": false,
+            "end_line": 142,
+            "kind": "function",
+            "line": 139,
+            "loc": 4,
+            "qualified_name": "_validate_aio_profile_size"
+          },
+          {
+            "async": false,
+            "end_line": 203,
+            "kind": "function",
+            "line": 145,
+            "loc": 59,
+            "qualified_name": "_save_aio_profile"
+          },
+          {
+            "async": false,
+            "end_line": 220,
+            "kind": "function",
+            "line": 206,
+            "loc": 15,
+            "qualified_name": "_normalize_stored_aio_profile_payload"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "function",
+            "line": 223,
+            "loc": 10,
+            "qualified_name": "_load_aio_profile"
+          },
+          {
+            "async": false,
+            "end_line": 269,
+            "kind": "function",
+            "line": 235,
+            "loc": 35,
+            "qualified_name": "_delete_aio_profile"
+          },
+          {
+            "async": false,
+            "end_line": 369,
+            "kind": "function",
+            "line": 272,
+            "loc": 98,
+            "qualified_name": "_rename_aio_profile"
+          },
+          {
+            "async": false,
+            "end_line": 389,
+            "kind": "function",
+            "line": 372,
+            "loc": 18,
+            "qualified_name": "_rename_aio_profile_payload"
+          }
+        ],
         "is_package": false,
         "loc": 392,
         "module": "easyuse_anima.profiles.aio",
@@ -72066,6 +78588,104 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 25,
+            "kind": "function",
+            "line": 22,
+            "loc": 4,
+            "qualified_name": "normalize_profile_filename_identity"
+          },
+          {
+            "async": false,
+            "end_line": 33,
+            "kind": "function",
+            "line": 28,
+            "loc": 6,
+            "qualified_name": "legacy_profile_id"
+          },
+          {
+            "async": false,
+            "end_line": 63,
+            "kind": "function",
+            "line": 36,
+            "loc": 28,
+            "qualified_name": "read_profile_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 88,
+            "kind": "function",
+            "line": 66,
+            "loc": 23,
+            "qualified_name": "build_profile_document"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "function",
+            "line": 91,
+            "loc": 14,
+            "qualified_name": "interpret_profile_document"
+          },
+          {
+            "async": false,
+            "end_line": 120,
+            "kind": "function",
+            "line": 107,
+            "loc": 14,
+            "qualified_name": "create_profile_document"
+          },
+          {
+            "async": false,
+            "end_line": 141,
+            "kind": "function",
+            "line": 123,
+            "loc": 19,
+            "qualified_name": "update_profile_document"
+          },
+          {
+            "async": false,
+            "end_line": 163,
+            "kind": "function",
+            "line": 144,
+            "loc": 20,
+            "qualified_name": "rename_profile_document"
+          },
+          {
+            "async": false,
+            "end_line": 168,
+            "kind": "function",
+            "line": 166,
+            "loc": 3,
+            "qualified_name": "_validate_profile_kind"
+          },
+          {
+            "async": false,
+            "end_line": 177,
+            "kind": "function",
+            "line": 171,
+            "loc": 7,
+            "qualified_name": "_parse_profile_id"
+          },
+          {
+            "async": false,
+            "end_line": 183,
+            "kind": "function",
+            "line": 180,
+            "loc": 4,
+            "qualified_name": "_parse_revision"
+          },
+          {
+            "async": false,
+            "end_line": 189,
+            "kind": "function",
+            "line": 186,
+            "loc": 4,
+            "qualified_name": "_parse_profile_name"
+          }
+        ],
         "is_package": false,
         "loc": 192,
         "module": "easyuse_anima.profiles.contract",
@@ -72078,6 +78698,184 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 40,
+            "loc": 6,
+            "qualified_name": "_current_lora_profile_repository"
+          },
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "function",
+            "line": 48,
+            "loc": 2,
+            "qualified_name": "_sanitize_lora_profile_name"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "function",
+            "line": 52,
+            "loc": 7,
+            "qualified_name": "_lora_profile_path"
+          },
+          {
+            "async": false,
+            "end_line": 80,
+            "kind": "function",
+            "line": 61,
+            "loc": 20,
+            "qualified_name": "_find_lora_profile_path"
+          },
+          {
+            "async": false,
+            "end_line": 88,
+            "kind": "function",
+            "line": 83,
+            "loc": 6,
+            "qualified_name": "_as_lora_profile_count"
+          },
+          {
+            "async": false,
+            "end_line": 97,
+            "kind": "function",
+            "line": 91,
+            "loc": 7,
+            "qualified_name": "_as_lora_profile_index"
+          },
+          {
+            "async": false,
+            "end_line": 120,
+            "kind": "function",
+            "line": 100,
+            "loc": 21,
+            "qualified_name": "_normalize_lora_profile_data"
+          },
+          {
+            "async": false,
+            "end_line": 135,
+            "kind": "function",
+            "line": 123,
+            "loc": 13,
+            "qualified_name": "_normalize_lora_profile_payload"
+          },
+          {
+            "async": false,
+            "end_line": 150,
+            "kind": "function",
+            "line": 138,
+            "loc": 13,
+            "qualified_name": "_list_lora_profiles"
+          },
+          {
+            "async": false,
+            "end_line": 161,
+            "kind": "function",
+            "line": 153,
+            "loc": 9,
+            "qualified_name": "_clear_folder_paths_cache"
+          },
+          {
+            "async": false,
+            "end_line": 187,
+            "kind": "function",
+            "line": 164,
+            "loc": 24,
+            "qualified_name": "_list_loras"
+          },
+          {
+            "async": false,
+            "end_line": 213,
+            "kind": "function",
+            "line": 190,
+            "loc": 24,
+            "qualified_name": "_lora_full_path"
+          },
+          {
+            "async": false,
+            "end_line": 228,
+            "kind": "function",
+            "line": 216,
+            "loc": 13,
+            "qualified_name": "_dedupe_text_values"
+          },
+          {
+            "async": false,
+            "end_line": 233,
+            "kind": "function",
+            "line": 231,
+            "loc": 3,
+            "qualified_name": "_lora_file_key"
+          },
+          {
+            "async": false,
+            "end_line": 248,
+            "kind": "function",
+            "line": 236,
+            "loc": 13,
+            "qualified_name": "_put_unique"
+          },
+          {
+            "async": false,
+            "end_line": 253,
+            "kind": "function",
+            "line": 251,
+            "loc": 3,
+            "qualified_name": "_lora_path_exists"
+          },
+          {
+            "async": false,
+            "end_line": 266,
+            "kind": "function",
+            "line": 256,
+            "loc": 11,
+            "qualified_name": "_build_lora_fix_index"
+          },
+          {
+            "async": false,
+            "end_line": 272,
+            "kind": "function",
+            "line": 269,
+            "loc": 4,
+            "qualified_name": "_resolve_lora_for_fix"
+          },
+          {
+            "async": false,
+            "end_line": 294,
+            "kind": "function",
+            "line": 275,
+            "loc": 20,
+            "qualified_name": "_apply_lora_fix"
+          },
+          {
+            "async": false,
+            "end_line": 352,
+            "kind": "function",
+            "line": 297,
+            "loc": 56,
+            "qualified_name": "_fix_lora_profile_payload"
+          },
+          {
+            "async": false,
+            "end_line": 403,
+            "kind": "function",
+            "line": 355,
+            "loc": 49,
+            "qualified_name": "_save_lora_profile"
+          },
+          {
+            "async": false,
+            "end_line": 438,
+            "kind": "function",
+            "line": 406,
+            "loc": 33,
+            "qualified_name": "_load_lora_profile"
+          }
+        ],
         "is_package": false,
         "loc": 441,
         "module": "easyuse_anima.profiles.lora",
@@ -72090,6 +78888,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 34,
+            "kind": "method",
+            "line": 22,
+            "loc": 13,
+            "qualified_name": "ProfileMutationError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 44,
+            "kind": "method",
+            "line": 38,
+            "loc": 7,
+            "qualified_name": "ProfilePreconditionRequiredError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "method",
+            "line": 48,
+            "loc": 7,
+            "qualified_name": "ProfileIdentityMismatchError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "method",
+            "line": 58,
+            "loc": 7,
+            "qualified_name": "ProfileRevisionConflictError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 74,
+            "kind": "method",
+            "line": 70,
+            "loc": 5,
+            "qualified_name": "DirectoryMutationCoordinator.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "method",
+            "line": 76,
+            "loc": 3,
+            "qualified_name": "DirectoryMutationCoordinator._key"
+          },
+          {
+            "async": false,
+            "end_line": 87,
+            "kind": "method",
+            "line": 80,
+            "loc": 8,
+            "qualified_name": "DirectoryMutationCoordinator._lock"
+          },
+          {
+            "async": false,
+            "end_line": 93,
+            "kind": "method",
+            "line": 89,
+            "loc": 5,
+            "qualified_name": "DirectoryMutationCoordinator.locked"
+          },
+          {
+            "async": false,
+            "end_line": 113,
+            "kind": "function",
+            "line": 96,
+            "loc": 18,
+            "qualified_name": "require_profile_precondition"
+          },
+          {
+            "async": false,
+            "end_line": 145,
+            "kind": "function",
+            "line": 116,
+            "loc": 30,
+            "qualified_name": "verify_profile_precondition"
+          }
+        ],
         "is_package": false,
         "loc": 151,
         "module": "easyuse_anima.profiles.mutation",
@@ -72102,6 +78982,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 53,
+            "kind": "method",
+            "line": 47,
+            "loc": 7,
+            "qualified_name": "_ProfileRepository.store"
+          },
+          {
+            "async": false,
+            "end_line": 56,
+            "kind": "method",
+            "line": 55,
+            "loc": 2,
+            "qualified_name": "_ProfileRepository.locked"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 59,
+            "loc": 2,
+            "qualified_name": "_windows_profile_filename_identity"
+          },
+          {
+            "async": false,
+            "end_line": 73,
+            "kind": "function",
+            "line": 63,
+            "loc": 11,
+            "qualified_name": "_sanitize_profile_name"
+          },
+          {
+            "async": false,
+            "end_line": 84,
+            "kind": "function",
+            "line": 76,
+            "loc": 9,
+            "qualified_name": "_read_profile_json"
+          },
+          {
+            "async": false,
+            "end_line": 109,
+            "kind": "function",
+            "line": 87,
+            "loc": 23,
+            "qualified_name": "_profile_list_item"
+          }
+        ],
         "is_package": false,
         "loc": 112,
         "module": "easyuse_anima.profiles.repository",
@@ -72114,6 +79044,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.prompt",
@@ -72126,6 +79057,216 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 154,
+            "kind": "function",
+            "line": 144,
+            "loc": 11,
+            "qualified_name": "_normalize_prompt_studio_wildcard_seed_control"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "function",
+            "line": 157,
+            "loc": 9,
+            "qualified_name": "_translate_prompt_fields"
+          },
+          {
+            "async": false,
+            "end_line": 225,
+            "kind": "function",
+            "line": 168,
+            "loc": 58,
+            "qualified_name": "_advanced_default_fields"
+          },
+          {
+            "async": false,
+            "end_line": 233,
+            "kind": "function",
+            "line": 228,
+            "loc": 6,
+            "qualified_name": "_advanced_fields_json"
+          },
+          {
+            "async": false,
+            "end_line": 237,
+            "kind": "function",
+            "line": 236,
+            "loc": 2,
+            "qualified_name": "_as_advanced_height"
+          },
+          {
+            "async": false,
+            "end_line": 296,
+            "kind": "function",
+            "line": 240,
+            "loc": 57,
+            "qualified_name": "_normalize_advanced_fields"
+          },
+          {
+            "async": false,
+            "end_line": 300,
+            "kind": "function",
+            "line": 299,
+            "loc": 2,
+            "qualified_name": "_clone_advanced_fields"
+          },
+          {
+            "async": false,
+            "end_line": 308,
+            "kind": "function",
+            "line": 303,
+            "loc": 6,
+            "qualified_name": "_advanced_field_socket_name"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 311,
+            "loc": 10,
+            "qualified_name": "_advanced_field_input_values"
+          },
+          {
+            "async": false,
+            "end_line": 336,
+            "kind": "function",
+            "line": 323,
+            "loc": 14,
+            "qualified_name": "_apply_advanced_field_inputs"
+          },
+          {
+            "async": false,
+            "end_line": 344,
+            "kind": "function",
+            "line": 339,
+            "loc": 6,
+            "qualified_name": "_advanced_enabled_naia_panes"
+          },
+          {
+            "async": false,
+            "end_line": 348,
+            "kind": "function",
+            "line": 347,
+            "loc": 2,
+            "qualified_name": "_advanced_has_enabled_naia"
+          },
+          {
+            "async": false,
+            "end_line": 352,
+            "kind": "function",
+            "line": 351,
+            "loc": 2,
+            "qualified_name": "_advanced_uses_naia_resolution"
+          },
+          {
+            "async": false,
+            "end_line": 366,
+            "kind": "function",
+            "line": 355,
+            "loc": 12,
+            "qualified_name": "_set_naia_field_text"
+          },
+          {
+            "async": false,
+            "end_line": 384,
+            "kind": "function",
+            "line": 369,
+            "loc": 16,
+            "qualified_name": "_advanced_naia_field_updates"
+          },
+          {
+            "async": false,
+            "end_line": 416,
+            "kind": "function",
+            "line": 387,
+            "loc": 30,
+            "qualified_name": "_advanced_pane_parts"
+          },
+          {
+            "async": false,
+            "end_line": 427,
+            "kind": "function",
+            "line": 419,
+            "loc": 9,
+            "qualified_name": "_advanced_enabled_pane_fields"
+          },
+          {
+            "async": false,
+            "end_line": 468,
+            "kind": "function",
+            "line": 430,
+            "loc": 39,
+            "qualified_name": "_correct_advanced_field_sequence"
+          },
+          {
+            "async": false,
+            "end_line": 448,
+            "kind": "function",
+            "line": 439,
+            "loc": 10,
+            "qualified_name": "_correct_advanced_field_sequence.flush_pending"
+          },
+          {
+            "async": false,
+            "end_line": 528,
+            "kind": "function",
+            "line": 471,
+            "loc": 58,
+            "qualified_name": "_build_advanced_prompts"
+          },
+          {
+            "async": false,
+            "end_line": 575,
+            "kind": "function",
+            "line": 531,
+            "loc": 45,
+            "qualified_name": "_expand_advanced_wildcard_fields"
+          },
+          {
+            "async": false,
+            "end_line": 593,
+            "kind": "function",
+            "line": 578,
+            "loc": 16,
+            "qualified_name": "_advanced_prompt_data_fields"
+          },
+          {
+            "async": false,
+            "end_line": 606,
+            "kind": "function",
+            "line": 596,
+            "loc": 11,
+            "qualified_name": "_advanced_artist_field_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 644,
+            "kind": "function",
+            "line": 609,
+            "loc": 36,
+            "qualified_name": "_advanced_fields_with_artist_override"
+          },
+          {
+            "async": false,
+            "end_line": 658,
+            "kind": "function",
+            "line": 647,
+            "loc": 12,
+            "qualified_name": "_advanced_prompt_with_artist_override"
+          },
+          {
+            "async": false,
+            "end_line": 887,
+            "kind": "function",
+            "line": 661,
+            "loc": 227,
+            "qualified_name": "_build_advanced_prompt_data"
+          }
+        ],
         "is_package": false,
         "loc": 890,
         "module": "easyuse_anima.prompt.advanced",
@@ -72138,6 +79279,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 26,
         "module": "easyuse_anima.prompt.anima",
@@ -72150,6 +79292,104 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "function",
+            "line": 25,
+            "loc": 7,
+            "qualified_name": "_is_escaped"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 34,
+            "loc": 12,
+            "qualified_name": "_outer_parens_span"
+          },
+          {
+            "async": false,
+            "end_line": 52,
+            "kind": "function",
+            "line": 48,
+            "loc": 5,
+            "qualified_name": "_last_unescaped_colon"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "function",
+            "line": 55,
+            "loc": 22,
+            "qualified_name": "_prompt_syntax"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 79,
+            "loc": 7,
+            "qualified_name": "_escape_literal_parentheses"
+          },
+          {
+            "async": false,
+            "end_line": 98,
+            "kind": "function",
+            "line": 88,
+            "loc": 11,
+            "qualified_name": "_is_natural_language_token"
+          },
+          {
+            "async": false,
+            "end_line": 106,
+            "kind": "function",
+            "line": 101,
+            "loc": 6,
+            "qualified_name": "_render_token"
+          },
+          {
+            "async": false,
+            "end_line": 122,
+            "kind": "function",
+            "line": 109,
+            "loc": 14,
+            "qualified_name": "_render_prompt_token"
+          },
+          {
+            "async": false,
+            "end_line": 126,
+            "kind": "function",
+            "line": 125,
+            "loc": 2,
+            "qualified_name": "_tag_key_set"
+          },
+          {
+            "async": false,
+            "end_line": 143,
+            "kind": "function",
+            "line": 129,
+            "loc": 15,
+            "qualified_name": "_classify_with_artist_options"
+          },
+          {
+            "async": false,
+            "end_line": 217,
+            "kind": "function",
+            "line": 146,
+            "loc": 72,
+            "qualified_name": "inspect_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 275,
+            "kind": "function",
+            "line": 220,
+            "loc": 56,
+            "qualified_name": "correct_prompt"
+          }
+        ],
         "is_package": false,
         "loc": 275,
         "module": "easyuse_anima.prompt.anima.correction",
@@ -72162,6 +79402,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "method",
+            "line": 20,
+            "loc": 3,
+            "qualified_name": "PromptKnowledgeBase.empty"
+          },
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "method",
+            "line": 24,
+            "loc": 14,
+            "qualified_name": "PromptKnowledgeBase.lookup"
+          },
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 40,
+            "loc": 8,
+            "qualified_name": "load_knowledge_base"
+          }
+        ],
         "is_package": false,
         "loc": 47,
         "module": "easyuse_anima.prompt.anima.knowledge",
@@ -72174,6 +79440,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 59,
         "module": "easyuse_anima.prompt.anima.models",
@@ -72186,6 +79453,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 15,
+            "kind": "function",
+            "line": 11,
+            "loc": 5,
+            "qualified_name": "_normalize_pony_score_tag"
+          },
+          {
+            "async": false,
+            "end_line": 34,
+            "kind": "function",
+            "line": 18,
+            "loc": 17,
+            "qualified_name": "normalize_tag"
+          },
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 37,
+            "loc": 5,
+            "qualified_name": "lookup_key"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 44,
+            "loc": 5,
+            "qualified_name": "render_artist_tag"
+          }
+        ],
         "is_package": false,
         "loc": 48,
         "module": "easyuse_anima.prompt.anima.normalize",
@@ -72198,6 +79499,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 134,
+            "kind": "function",
+            "line": 128,
+            "loc": 7,
+            "qualified_name": "builtin_tag_section"
+          },
+          {
+            "async": false,
+            "end_line": 154,
+            "kind": "function",
+            "line": 137,
+            "loc": 18,
+            "qualified_name": "classify_tag"
+          },
+          {
+            "async": false,
+            "end_line": 158,
+            "kind": "function",
+            "line": 157,
+            "loc": 2,
+            "qualified_name": "section_sort_key"
+          }
+        ],
         "is_package": false,
         "loc": 158,
         "module": "easyuse_anima.prompt.anima.ordering",
@@ -72210,6 +79537,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "function",
+            "line": 18,
+            "loc": 19,
+            "qualified_name": "parse_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 39,
+            "loc": 7,
+            "qualified_name": "_is_escaped"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 48,
+            "loc": 14,
+            "qualified_name": "_split_prompt_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 69,
+            "kind": "function",
+            "line": 64,
+            "loc": 6,
+            "qualified_name": "_split_sentence_count_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 73,
+            "kind": "function",
+            "line": 72,
+            "loc": 2,
+            "qualified_name": "render_tags"
+          }
+        ],
         "is_package": false,
         "loc": 73,
         "module": "easyuse_anima.prompt.anima.parser",
@@ -72222,6 +79591,416 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 115,
+            "kind": "function",
+            "line": 114,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 118,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 129,
+            "kind": "function",
+            "line": 126,
+            "loc": 4,
+            "qualified_name": "_advanced_enabled_pane_fields"
+          },
+          {
+            "async": false,
+            "end_line": 135,
+            "kind": "function",
+            "line": 132,
+            "loc": 4,
+            "qualified_name": "_advanced_prompt_with_artist_override"
+          },
+          {
+            "async": false,
+            "end_line": 141,
+            "kind": "function",
+            "line": 138,
+            "loc": 4,
+            "qualified_name": "_normalize_advanced_fields"
+          },
+          {
+            "async": false,
+            "end_line": 189,
+            "kind": "function",
+            "line": 143,
+            "loc": 47,
+            "qualified_name": "_split_artist_mix_items"
+          },
+          {
+            "async": false,
+            "end_line": 208,
+            "kind": "function",
+            "line": 191,
+            "loc": 18,
+            "qualified_name": "_split_artist_mix_blocks"
+          },
+          {
+            "async": false,
+            "end_line": 221,
+            "kind": "function",
+            "line": 210,
+            "loc": 12,
+            "qualified_name": "_parse_artist_mix_group"
+          },
+          {
+            "async": false,
+            "end_line": 229,
+            "kind": "function",
+            "line": 223,
+            "loc": 7,
+            "qualified_name": "_artist_group_token"
+          },
+          {
+            "async": false,
+            "end_line": 243,
+            "kind": "function",
+            "line": 231,
+            "loc": 13,
+            "qualified_name": "_join_artist_mix_source_prompts"
+          },
+          {
+            "async": false,
+            "end_line": 253,
+            "kind": "function",
+            "line": 245,
+            "loc": 9,
+            "qualified_name": "_artist_mix_inline_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 285,
+            "kind": "function",
+            "line": 255,
+            "loc": 31,
+            "qualified_name": "_parse_artist_mix_entries"
+          },
+          {
+            "async": false,
+            "end_line": 291,
+            "kind": "function",
+            "line": 287,
+            "loc": 5,
+            "qualified_name": "_parse_artist_mix_items"
+          },
+          {
+            "async": false,
+            "end_line": 305,
+            "kind": "function",
+            "line": 293,
+            "loc": 13,
+            "qualified_name": "_artist_tags_from_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 311,
+            "kind": "function",
+            "line": 307,
+            "loc": 5,
+            "qualified_name": "_bounded_artist_mix_float"
+          },
+          {
+            "async": false,
+            "end_line": 314,
+            "kind": "function",
+            "line": 313,
+            "loc": 2,
+            "qualified_name": "_bounded_artist_mix_int"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 316,
+            "loc": 5,
+            "qualified_name": "_normalize_artist_mix_mode"
+          },
+          {
+            "async": false,
+            "end_line": 324,
+            "kind": "function",
+            "line": 322,
+            "loc": 3,
+            "qualified_name": "_normalize_artist_tag_position"
+          },
+          {
+            "async": false,
+            "end_line": 333,
+            "kind": "function",
+            "line": 326,
+            "loc": 8,
+            "qualified_name": "_artist_mix_mode_tooltip"
+          },
+          {
+            "async": false,
+            "end_line": 353,
+            "kind": "function",
+            "line": 335,
+            "loc": 19,
+            "qualified_name": "_coalesce_artist_mix_items"
+          },
+          {
+            "async": false,
+            "end_line": 362,
+            "kind": "function",
+            "line": 355,
+            "loc": 8,
+            "qualified_name": "_artist_mix_prompt_tags"
+          },
+          {
+            "async": false,
+            "end_line": 386,
+            "kind": "function",
+            "line": 364,
+            "loc": 23,
+            "qualified_name": "_artist_prompt_with_position"
+          },
+          {
+            "async": false,
+            "end_line": 392,
+            "kind": "function",
+            "line": 388,
+            "loc": 5,
+            "qualified_name": "_normalized_artist_weights"
+          },
+          {
+            "async": false,
+            "end_line": 395,
+            "kind": "function",
+            "line": 394,
+            "loc": 2,
+            "qualified_name": "_equal_artist_weights"
+          },
+          {
+            "async": false,
+            "end_line": 402,
+            "kind": "function",
+            "line": 397,
+            "loc": 6,
+            "qualified_name": "_normalize_weight_values"
+          },
+          {
+            "async": false,
+            "end_line": 409,
+            "kind": "function",
+            "line": 404,
+            "loc": 6,
+            "qualified_name": "_interpolate_artist_weights"
+          },
+          {
+            "async": false,
+            "end_line": 423,
+            "kind": "function",
+            "line": 411,
+            "loc": 13,
+            "qualified_name": "_copy_conditioning_metadata"
+          },
+          {
+            "async": false,
+            "end_line": 437,
+            "kind": "function",
+            "line": 425,
+            "loc": 13,
+            "qualified_name": "_pad_conditioning_tensor"
+          },
+          {
+            "async": false,
+            "end_line": 494,
+            "kind": "function",
+            "line": 439,
+            "loc": 56,
+            "qualified_name": "_blend_conditionings"
+          },
+          {
+            "async": false,
+            "end_line": 512,
+            "kind": "function",
+            "line": 496,
+            "loc": 17,
+            "qualified_name": "_encoded_artist_conditionings"
+          },
+          {
+            "async": false,
+            "end_line": 604,
+            "kind": "function",
+            "line": 514,
+            "loc": 91,
+            "qualified_name": "_artist_delta_rms_from_encoded"
+          },
+          {
+            "async": false,
+            "end_line": 615,
+            "kind": "function",
+            "line": 606,
+            "loc": 10,
+            "qualified_name": "_fallback_artist_average_or_exact"
+          },
+          {
+            "async": false,
+            "end_line": 656,
+            "kind": "function",
+            "line": 617,
+            "loc": 40,
+            "qualified_name": "_encode_artist_delta_rms"
+          },
+          {
+            "async": false,
+            "end_line": 664,
+            "kind": "function",
+            "line": 658,
+            "loc": 7,
+            "qualified_name": "_conditionings_with_values"
+          },
+          {
+            "async": false,
+            "end_line": 669,
+            "kind": "function",
+            "line": 666,
+            "loc": 4,
+            "qualified_name": "_conditionings_with_range"
+          },
+          {
+            "async": false,
+            "end_line": 672,
+            "kind": "function",
+            "line": 671,
+            "loc": 2,
+            "qualified_name": "_conditionings_with_strength"
+          },
+          {
+            "async": false,
+            "end_line": 675,
+            "kind": "function",
+            "line": 674,
+            "loc": 2,
+            "qualified_name": "_mark_artist_mix_conditioning"
+          },
+          {
+            "async": false,
+            "end_line": 681,
+            "kind": "function",
+            "line": 677,
+            "loc": 5,
+            "qualified_name": "_prompt_data_positive_fields"
+          },
+          {
+            "async": false,
+            "end_line": 694,
+            "kind": "function",
+            "line": 683,
+            "loc": 12,
+            "qualified_name": "_prompt_data_artist_base_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 731,
+            "kind": "function",
+            "line": 696,
+            "loc": 36,
+            "qualified_name": "_artist_variant_prompt_from_prompt_data"
+          },
+          {
+            "async": false,
+            "end_line": 870,
+            "kind": "function",
+            "line": 733,
+            "loc": 138,
+            "qualified_name": "_prompt_data_artist_mix_config"
+          },
+          {
+            "async": false,
+            "end_line": 902,
+            "kind": "function",
+            "line": 872,
+            "loc": 31,
+            "qualified_name": "_encode_artist_exact"
+          },
+          {
+            "async": false,
+            "end_line": 930,
+            "kind": "function",
+            "line": 904,
+            "loc": 27,
+            "qualified_name": "_encode_artist_average"
+          },
+          {
+            "async": false,
+            "end_line": 989,
+            "kind": "function",
+            "line": 932,
+            "loc": 58,
+            "qualified_name": "_encode_artist_hybrid"
+          },
+          {
+            "async": false,
+            "end_line": 1016,
+            "kind": "function",
+            "line": 991,
+            "loc": 26,
+            "qualified_name": "_artist_conditioning_feature"
+          },
+          {
+            "async": false,
+            "end_line": 1049,
+            "kind": "function",
+            "line": 1018,
+            "loc": 32,
+            "qualified_name": "_greedy_cluster_encoded_artists"
+          },
+          {
+            "async": false,
+            "end_line": 1180,
+            "kind": "function",
+            "line": 1051,
+            "loc": 130,
+            "qualified_name": "_encode_artist_clustered"
+          },
+          {
+            "async": false,
+            "end_line": 1205,
+            "kind": "function",
+            "line": 1182,
+            "loc": 24,
+            "qualified_name": "_encode_artist_composite_exact"
+          },
+          {
+            "async": false,
+            "end_line": 1234,
+            "kind": "function",
+            "line": 1207,
+            "loc": 28,
+            "qualified_name": "_encode_artist_average_late_exact"
+          },
+          {
+            "async": false,
+            "end_line": 1291,
+            "kind": "function",
+            "line": 1236,
+            "loc": 56,
+            "qualified_name": "_encode_artist_scheduled_average"
+          },
+          {
+            "async": false,
+            "end_line": 1509,
+            "kind": "function",
+            "line": 1293,
+            "loc": 217,
+            "qualified_name": "_encode_prompt_data_positive_conditioning"
+          }
+        ],
         "is_package": false,
         "loc": 1511,
         "module": "easyuse_anima.prompt.artist_mix",
@@ -72234,6 +80013,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "function",
+            "line": 30,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 34,
+            "loc": 6,
+            "qualified_name": "_find_loaded_node_class"
+          },
+          {
+            "async": false,
+            "end_line": 43,
+            "kind": "function",
+            "line": 42,
+            "loc": 2,
+            "qualified_name": "_runtime_logger"
+          },
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "function",
+            "line": 46,
+            "loc": 9,
+            "qualified_name": "_find_spectrum_anima_mod_guidance_class"
+          },
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 56,
+            "loc": 7,
+            "qualified_name": "_resolve_anima_mod_guidance_enabled"
+          },
+          {
+            "async": false,
+            "end_line": 68,
+            "kind": "function",
+            "line": 64,
+            "loc": 5,
+            "qualified_name": "_normalize_anima_mod_guidance_profile"
+          },
+          {
+            "async": false,
+            "end_line": 83,
+            "kind": "function",
+            "line": 70,
+            "loc": 14,
+            "qualified_name": "_warn_old_spectrum_anima_mod_guidance_once"
+          },
+          {
+            "async": false,
+            "end_line": 138,
+            "kind": "function",
+            "line": 85,
+            "loc": 54,
+            "qualified_name": "_apply_spectrum_anima_mod_guidance"
+          }
+        ],
         "is_package": false,
         "loc": 140,
         "module": "easyuse_anima.prompt.conditioning",
@@ -72246,6 +80091,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 189,
         "module": "easyuse_anima.prompt.contracts",
@@ -72258,6 +80104,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 16,
+            "kind": "function",
+            "line": 10,
+            "loc": 7,
+            "qualified_name": "_split_tag_text"
+          },
+          {
+            "async": false,
+            "end_line": 23,
+            "kind": "function",
+            "line": 19,
+            "loc": 5,
+            "qualified_name": "_translate_prompt_text"
+          },
+          {
+            "async": false,
+            "end_line": 32,
+            "kind": "function",
+            "line": 26,
+            "loc": 7,
+            "qualified_name": "_prompt_translation_change_key"
+          }
+        ],
         "is_package": false,
         "loc": 35,
         "module": "easyuse_anima.prompt.correction",
@@ -72270,6 +80142,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "function",
+            "line": 44,
+            "loc": 11,
+            "qualified_name": "_normalize_prompt_data"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "function",
+            "line": 56,
+            "loc": 3,
+            "qualified_name": "_prompt_data_nested"
+          },
+          {
+            "async": false,
+            "end_line": 95,
+            "kind": "function",
+            "line": 60,
+            "loc": 36,
+            "qualified_name": "_prompt_data_output"
+          },
+          {
+            "async": false,
+            "end_line": 114,
+            "kind": "function",
+            "line": 97,
+            "loc": 18,
+            "qualified_name": "_prompt_data_input_default"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 116,
+            "loc": 8,
+            "qualified_name": "_prompt_data_json_safe"
+          },
+          {
+            "async": false,
+            "end_line": 140,
+            "kind": "function",
+            "line": 125,
+            "loc": 16,
+            "qualified_name": "_prompt_data_parameter_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 157,
+            "kind": "function",
+            "line": 142,
+            "loc": 16,
+            "qualified_name": "_advanced_outputs_from_prompt_data"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "function",
+            "line": 159,
+            "loc": 7,
+            "qualified_name": "_copy_prompt_data_for_update"
+          },
+          {
+            "async": false,
+            "end_line": 228,
+            "kind": "function",
+            "line": 167,
+            "loc": 62,
+            "qualified_name": "_set_prompt_data_output"
+          },
+          {
+            "async": false,
+            "end_line": 239,
+            "kind": "function",
+            "line": 230,
+            "loc": 10,
+            "qualified_name": "_apply_prompt_data_overrides"
+          }
+        ],
         "is_package": false,
         "loc": 241,
         "module": "easyuse_anima.prompt.data",
@@ -72282,6 +80236,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 35,
+            "kind": "function",
+            "line": 24,
+            "loc": 12,
+            "qualified_name": "_prompt_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 38,
+            "loc": 5,
+            "qualified_name": "_join_prompt_tokens"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 45,
+            "loc": 11,
+            "qualified_name": "_correct_builder_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "function",
+            "line": 58,
+            "loc": 3,
+            "qualified_name": "_metadata_filter_key"
+          },
+          {
+            "async": false,
+            "end_line": 68,
+            "kind": "function",
+            "line": 63,
+            "loc": 6,
+            "qualified_name": "_metadata_filter_keys"
+          },
+          {
+            "async": false,
+            "end_line": 83,
+            "kind": "function",
+            "line": 71,
+            "loc": 13,
+            "qualified_name": "_filter_metadata_prompt"
+          }
+        ],
         "is_package": false,
         "loc": 86,
         "module": "easyuse_anima.prompt.fields",
@@ -72294,6 +80298,152 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 40,
+            "loc": 9,
+            "qualified_name": "_regional_default_fields"
+          },
+          {
+            "async": false,
+            "end_line": 56,
+            "kind": "function",
+            "line": 51,
+            "loc": 6,
+            "qualified_name": "_regional_fields_json"
+          },
+          {
+            "async": false,
+            "end_line": 75,
+            "kind": "function",
+            "line": 59,
+            "loc": 17,
+            "qualified_name": "_normalize_mask_ids"
+          },
+          {
+            "async": false,
+            "end_line": 129,
+            "kind": "function",
+            "line": 78,
+            "loc": 52,
+            "qualified_name": "_normalize_regional_fields"
+          },
+          {
+            "async": false,
+            "end_line": 139,
+            "kind": "function",
+            "line": 132,
+            "loc": 8,
+            "qualified_name": "_clone_regional_fields"
+          },
+          {
+            "async": false,
+            "end_line": 155,
+            "kind": "function",
+            "line": 142,
+            "loc": 14,
+            "qualified_name": "_apply_regional_field_inputs"
+          },
+          {
+            "async": false,
+            "end_line": 182,
+            "kind": "function",
+            "line": 158,
+            "loc": 25,
+            "qualified_name": "_regional_default_config"
+          },
+          {
+            "async": false,
+            "end_line": 205,
+            "kind": "function",
+            "line": 185,
+            "loc": 21,
+            "qualified_name": "_normalize_mask_geometry"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "function",
+            "line": 208,
+            "loc": 25,
+            "qualified_name": "_normalize_regional_mask"
+          },
+          {
+            "async": false,
+            "end_line": 279,
+            "kind": "function",
+            "line": 235,
+            "loc": 45,
+            "qualified_name": "_normalize_regional_config"
+          },
+          {
+            "async": false,
+            "end_line": 287,
+            "kind": "function",
+            "line": 282,
+            "loc": 6,
+            "qualified_name": "_regional_config_json"
+          },
+          {
+            "async": false,
+            "end_line": 296,
+            "kind": "function",
+            "line": 290,
+            "loc": 7,
+            "qualified_name": "_regional_field_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 438,
+            "kind": "function",
+            "line": 299,
+            "loc": 140,
+            "qualified_name": "_build_regional_outputs"
+          },
+          {
+            "async": false,
+            "end_line": 451,
+            "kind": "function",
+            "line": 441,
+            "loc": 11,
+            "qualified_name": "_parse_json_object"
+          },
+          {
+            "async": false,
+            "end_line": 458,
+            "kind": "function",
+            "line": 454,
+            "loc": 5,
+            "qualified_name": "_regional_payload_canvas"
+          },
+          {
+            "async": false,
+            "end_line": 470,
+            "kind": "function",
+            "line": 461,
+            "loc": 10,
+            "qualified_name": "_conditioning_set_values"
+          },
+          {
+            "async": false,
+            "end_line": 509,
+            "kind": "function",
+            "line": 473,
+            "loc": 37,
+            "qualified_name": "_regional_union_mask_for_ids"
+          },
+          {
+            "async": false,
+            "end_line": 553,
+            "kind": "function",
+            "line": 512,
+            "loc": 42,
+            "qualified_name": "_regional_mask_bounds_area"
+          }
+        ],
         "is_package": false,
         "loc": 556,
         "module": "easyuse_anima.prompt.regional",
@@ -72306,6 +80456,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 73,
         "module": "easyuse_anima.registration",
@@ -72318,6 +80469,72 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 31,
+            "kind": "method",
+            "line": 31,
+            "loc": 1,
+            "qualified_name": "Clock.monotonic"
+          },
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "method",
+            "line": 37,
+            "loc": 1,
+            "qualified_name": "RuntimeResource.close"
+          },
+          {
+            "async": false,
+            "end_line": 51,
+            "kind": "method",
+            "line": 45,
+            "loc": 7,
+            "qualified_name": "_RuntimeCleanupPlan.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 67,
+            "kind": "method",
+            "line": 53,
+            "loc": 15,
+            "qualified_name": "_RuntimeCleanupPlan.close"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "method",
+            "line": 88,
+            "loc": 4,
+            "qualified_name": "RuntimeServices.close"
+          },
+          {
+            "async": false,
+            "end_line": 110,
+            "kind": "function",
+            "line": 97,
+            "loc": 14,
+            "qualified_name": "install_runtime"
+          },
+          {
+            "async": false,
+            "end_line": 119,
+            "kind": "function",
+            "line": 113,
+            "loc": 7,
+            "qualified_name": "get_runtime"
+          },
+          {
+            "async": false,
+            "end_line": 130,
+            "kind": "function",
+            "line": 122,
+            "loc": 9,
+            "qualified_name": "_detach_runtime"
+          }
+        ],
         "is_package": false,
         "loc": 140,
         "module": "easyuse_anima.runtime",
@@ -72330,6 +80547,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 7,
         "module": "easyuse_anima.seed",
@@ -72342,6 +80560,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 27,
+            "loc": 19,
+            "qualified_name": "_scrub_reserved_wildcard_next_seed"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 48,
+            "loc": 76,
+            "qualified_name": "_consume_reserved_wildcard_next_seed"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "function",
+            "line": 79,
+            "loc": 4,
+            "qualified_name": "_consume_reserved_wildcard_next_seed.reserved_seed"
+          }
+        ],
         "is_package": false,
         "loc": 126,
         "module": "easyuse_anima.seed.compatibility",
@@ -72354,6 +80598,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "function",
+            "line": 34,
+            "loc": 4,
+            "qualified_name": "_require_text"
+          },
+          {
+            "async": false,
+            "end_line": 51,
+            "kind": "function",
+            "line": 40,
+            "loc": 12,
+            "qualified_name": "_normalize_node_id"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 54,
+            "loc": 8,
+            "qualified_name": "_require_list_index"
+          },
+          {
+            "async": false,
+            "end_line": 72,
+            "kind": "function",
+            "line": 64,
+            "loc": 9,
+            "qualified_name": "_encoded_identity"
+          },
+          {
+            "async": false,
+            "end_line": 99,
+            "kind": "method",
+            "line": 83,
+            "loc": 17,
+            "qualified_name": "SeedExecutionContext.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 119,
+            "kind": "method",
+            "line": 109,
+            "loc": 11,
+            "qualified_name": "SeedExecutionIdentity.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 123,
+            "kind": "function",
+            "line": 122,
+            "loc": 2,
+            "qualified_name": "_import_host_module"
+          },
+          {
+            "async": false,
+            "end_line": 144,
+            "kind": "function",
+            "line": 126,
+            "loc": 19,
+            "qualified_name": "read_comfy_execution_context"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "function",
+            "line": 147,
+            "loc": 2,
+            "qualified_name": "_new_opaque_request_id"
+          },
+          {
+            "async": false,
+            "end_line": 204,
+            "kind": "function",
+            "line": 151,
+            "loc": 54,
+            "qualified_name": "resolve_seed_execution_identity"
+          }
+        ],
         "is_package": false,
         "loc": 214,
         "module": "easyuse_anima.seed.execution_identity",
@@ -72366,6 +80692,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 29,
+            "kind": "function",
+            "line": 28,
+            "loc": 2,
+            "qualified_name": "_loaded_host_module"
+          },
+          {
+            "async": false,
+            "end_line": 46,
+            "kind": "function",
+            "line": 32,
+            "loc": 15,
+            "qualified_name": "is_comfy_processing_interruption"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 49,
+            "loc": 13,
+            "qualified_name": "_settlement_for_error"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 64,
+            "loc": 23,
+            "qualified_name": "seed_execution_session"
+          }
+        ],
         "is_package": false,
         "loc": 92,
         "module": "easyuse_anima.seed.execution_session",
@@ -72378,6 +80738,88 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 101,
+            "kind": "function",
+            "line": 92,
+            "loc": 10,
+            "qualified_name": "_require_version"
+          },
+          {
+            "async": false,
+            "end_line": 107,
+            "kind": "function",
+            "line": 104,
+            "loc": 4,
+            "qualified_name": "_require_identity"
+          },
+          {
+            "async": false,
+            "end_line": 117,
+            "kind": "function",
+            "line": 110,
+            "loc": 8,
+            "qualified_name": "_require_choice"
+          },
+          {
+            "async": false,
+            "end_line": 130,
+            "kind": "function",
+            "line": 120,
+            "loc": 11,
+            "qualified_name": "_require_concrete_seed"
+          },
+          {
+            "async": false,
+            "end_line": 206,
+            "kind": "method",
+            "line": 147,
+            "loc": 60,
+            "qualified_name": "SeedReservationRequest.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 246,
+            "kind": "method",
+            "line": 220,
+            "loc": 27,
+            "qualified_name": "SeedReservation.__post_init__"
+          },
+          {
+            "async": false,
+            "end_line": 252,
+            "kind": "method",
+            "line": 252,
+            "loc": 1,
+            "qualified_name": "SeedReservationService.reserve"
+          },
+          {
+            "async": false,
+            "end_line": 258,
+            "kind": "method",
+            "line": 254,
+            "loc": 5,
+            "qualified_name": "SeedReservationService.settle"
+          },
+          {
+            "async": false,
+            "end_line": 280,
+            "kind": "function",
+            "line": 261,
+            "loc": 20,
+            "qualified_name": "parse_seed_reservation_request"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 283,
+            "loc": 38,
+            "qualified_name": "parse_legacy_seed_reservation_request"
+          }
+        ],
         "is_package": false,
         "loc": 351,
         "module": "easyuse_anima.seed.reservation",
@@ -72390,6 +80832,208 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 53,
+            "loc": 3,
+            "qualified_name": "_require_positive_configuration"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 58,
+            "loc": 4,
+            "qualified_name": "_require_request"
+          },
+          {
+            "async": false,
+            "end_line": 74,
+            "kind": "function",
+            "line": 64,
+            "loc": 11,
+            "qualified_name": "_require_seed_draw"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "function",
+            "line": 77,
+            "loc": 6,
+            "qualified_name": "_require_generated_id"
+          },
+          {
+            "async": false,
+            "end_line": 90,
+            "kind": "function",
+            "line": 85,
+            "loc": 6,
+            "qualified_name": "_require_settlement_id"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 101,
+            "loc": 2,
+            "qualified_name": "_new_reservation_queue"
+          },
+          {
+            "async": false,
+            "end_line": 125,
+            "kind": "function",
+            "line": 124,
+            "loc": 2,
+            "qualified_name": "_default_reservation_id"
+          },
+          {
+            "async": false,
+            "end_line": 171,
+            "kind": "method",
+            "line": 131,
+            "loc": 41,
+            "qualified_name": "InMemorySeedReservationService.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 235,
+            "kind": "method",
+            "line": 173,
+            "loc": 63,
+            "qualified_name": "InMemorySeedReservationService.reserve"
+          },
+          {
+            "async": false,
+            "end_line": 269,
+            "kind": "method",
+            "line": 237,
+            "loc": 33,
+            "qualified_name": "InMemorySeedReservationService.settle"
+          },
+          {
+            "async": false,
+            "end_line": 279,
+            "kind": "method",
+            "line": 271,
+            "loc": 9,
+            "qualified_name": "InMemorySeedReservationService._require_same_request"
+          },
+          {
+            "async": false,
+            "end_line": 292,
+            "kind": "method",
+            "line": 281,
+            "loc": 12,
+            "qualified_name": "InMemorySeedReservationService._require_same_domain"
+          },
+          {
+            "async": false,
+            "end_line": 312,
+            "kind": "method",
+            "line": 294,
+            "loc": 19,
+            "qualified_name": "InMemorySeedReservationService._capacity_preflight"
+          },
+          {
+            "async": false,
+            "end_line": 369,
+            "kind": "method",
+            "line": 314,
+            "loc": 56,
+            "qualified_name": "InMemorySeedReservationService._select_execution_seed"
+          },
+          {
+            "async": false,
+            "end_line": 390,
+            "kind": "method",
+            "line": 371,
+            "loc": 20,
+            "qualified_name": "InMemorySeedReservationService._select_next_seed"
+          },
+          {
+            "async": false,
+            "end_line": 398,
+            "kind": "method",
+            "line": 392,
+            "loc": 7,
+            "qualified_name": "InMemorySeedReservationService._observed_seed"
+          },
+          {
+            "async": false,
+            "end_line": 406,
+            "kind": "method",
+            "line": 400,
+            "loc": 7,
+            "qualified_name": "InMemorySeedReservationService._execution_basis"
+          },
+          {
+            "async": false,
+            "end_line": 409,
+            "kind": "method",
+            "line": 408,
+            "loc": 2,
+            "qualified_name": "InMemorySeedReservationService._draw_seed"
+          },
+          {
+            "async": false,
+            "end_line": 430,
+            "kind": "method",
+            "line": 411,
+            "loc": 20,
+            "qualified_name": "InMemorySeedReservationService._step_seed"
+          },
+          {
+            "async": false,
+            "end_line": 444,
+            "kind": "method",
+            "line": 432,
+            "loc": 13,
+            "qualified_name": "InMemorySeedReservationService._new_reservation_id"
+          },
+          {
+            "async": false,
+            "end_line": 448,
+            "kind": "method",
+            "line": 446,
+            "loc": 3,
+            "qualified_name": "InMemorySeedReservationService._normalize_reservation_id"
+          },
+          {
+            "async": false,
+            "end_line": 458,
+            "kind": "method",
+            "line": 450,
+            "loc": 9,
+            "qualified_name": "InMemorySeedReservationService._collapse_rejected_tail"
+          },
+          {
+            "async": false,
+            "end_line": 487,
+            "kind": "method",
+            "line": 460,
+            "loc": 28,
+            "qualified_name": "InMemorySeedReservationService._flush_settled_head"
+          },
+          {
+            "async": false,
+            "end_line": 491,
+            "kind": "method",
+            "line": 489,
+            "loc": 3,
+            "qualified_name": "InMemorySeedReservationService._forget_queued_record"
+          },
+          {
+            "async": false,
+            "end_line": 497,
+            "kind": "method",
+            "line": 493,
+            "loc": 5,
+            "qualified_name": "InMemorySeedReservationService._remember_retired_id"
+          }
+        ],
         "is_package": false,
         "loc": 505,
         "module": "easyuse_anima.seed.service",
@@ -72402,6 +81046,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.settings",
@@ -72414,6 +81059,200 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "method",
+            "line": 41,
+            "loc": 7,
+            "qualified_name": "_SettingsRepository.store"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 50,
+            "loc": 6,
+            "qualified_name": "_current_settings_repository"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 58,
+            "loc": 7,
+            "qualified_name": "_read_json_file"
+          },
+          {
+            "async": false,
+            "end_line": 77,
+            "kind": "function",
+            "line": 67,
+            "loc": 11,
+            "qualified_name": "_detect_settings_document_version"
+          },
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "function",
+            "line": 80,
+            "loc": 2,
+            "qualified_name": "_settings_document"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 84,
+            "loc": 8,
+            "qualified_name": "_migrate_settings_document"
+          },
+          {
+            "async": false,
+            "end_line": 102,
+            "kind": "function",
+            "line": 94,
+            "loc": 9,
+            "qualified_name": "_normalize_settings_values"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 105,
+            "loc": 12,
+            "qualified_name": "_normalize_long_text_settings"
+          },
+          {
+            "async": false,
+            "end_line": 120,
+            "kind": "function",
+            "line": 119,
+            "loc": 2,
+            "qualified_name": "_migrate_long_text_settings_document"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "function",
+            "line": 123,
+            "loc": 6,
+            "qualified_name": "load_long_text_settings"
+          },
+          {
+            "async": false,
+            "end_line": 153,
+            "kind": "function",
+            "line": 131,
+            "loc": 23,
+            "qualified_name": "save_long_text_settings"
+          },
+          {
+            "async": false,
+            "end_line": 146,
+            "kind": "function",
+            "line": 138,
+            "loc": 9,
+            "qualified_name": "save_long_text_settings.merge"
+          },
+          {
+            "async": false,
+            "end_line": 174,
+            "kind": "function",
+            "line": 156,
+            "loc": 19,
+            "qualified_name": "_comfy_settings_candidates"
+          },
+          {
+            "async": false,
+            "end_line": 182,
+            "kind": "function",
+            "line": 177,
+            "loc": 6,
+            "qualified_name": "_load_comfy_settings"
+          },
+          {
+            "async": false,
+            "end_line": 192,
+            "kind": "function",
+            "line": 185,
+            "loc": 8,
+            "qualified_name": "_is_korean_locale"
+          },
+          {
+            "async": false,
+            "end_line": 198,
+            "kind": "function",
+            "line": 195,
+            "loc": 4,
+            "qualified_name": "_initial_autocomplete_source"
+          },
+          {
+            "async": false,
+            "end_line": 232,
+            "kind": "function",
+            "line": 201,
+            "loc": 32,
+            "qualified_name": "_initialize_autocomplete_source"
+          },
+          {
+            "async": false,
+            "end_line": 220,
+            "kind": "function",
+            "line": 215,
+            "loc": 6,
+            "qualified_name": "_initialize_autocomplete_source.merge"
+          },
+          {
+            "async": false,
+            "end_line": 240,
+            "kind": "function",
+            "line": 235,
+            "loc": 6,
+            "qualified_name": "_stringify_setting_value"
+          },
+          {
+            "async": false,
+            "end_line": 270,
+            "kind": "function",
+            "line": 243,
+            "loc": 28,
+            "qualified_name": "_apply_prompt_studio_color_settings"
+          },
+          {
+            "async": false,
+            "end_line": 288,
+            "kind": "function",
+            "line": 273,
+            "loc": 16,
+            "qualified_name": "_apply_comfy_settings"
+          },
+          {
+            "async": false,
+            "end_line": 293,
+            "kind": "function",
+            "line": 291,
+            "loc": 3,
+            "qualified_name": "_apply_long_text_settings"
+          },
+          {
+            "async": false,
+            "end_line": 308,
+            "kind": "function",
+            "line": 296,
+            "loc": 13,
+            "qualified_name": "get_settings"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 311,
+            "loc": 10,
+            "qualified_name": "save_setting"
+          }
+        ],
         "is_package": false,
         "loc": 330,
         "module": "easyuse_anima.settings.repository",
@@ -72426,6 +81265,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 242,
         "module": "easyuse_anima.settings.schema",
@@ -72438,6 +81278,216 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 143,
+            "kind": "function",
+            "line": 28,
+            "loc": 116,
+            "qualified_name": "public_settings"
+          },
+          {
+            "async": false,
+            "end_line": 151,
+            "kind": "function",
+            "line": 146,
+            "loc": 6,
+            "qualified_name": "resolve_metadata_filter_words"
+          },
+          {
+            "async": false,
+            "end_line": 159,
+            "kind": "function",
+            "line": 154,
+            "loc": 6,
+            "qualified_name": "resolve_autocomplete_source"
+          },
+          {
+            "async": false,
+            "end_line": 173,
+            "kind": "function",
+            "line": 162,
+            "loc": 12,
+            "qualified_name": "resolve_autocomplete_limit"
+          },
+          {
+            "async": false,
+            "end_line": 184,
+            "kind": "function",
+            "line": 176,
+            "loc": 9,
+            "qualified_name": "resolve_autocomplete_mode"
+          },
+          {
+            "async": false,
+            "end_line": 200,
+            "kind": "function",
+            "line": 187,
+            "loc": 14,
+            "qualified_name": "_resolve_autocomplete_artist_prefix"
+          },
+          {
+            "async": false,
+            "end_line": 214,
+            "kind": "function",
+            "line": 203,
+            "loc": 12,
+            "qualified_name": "resolve_autocomplete_commit_key"
+          },
+          {
+            "async": false,
+            "end_line": 228,
+            "kind": "function",
+            "line": 217,
+            "loc": 12,
+            "qualified_name": "resolve_autocomplete_commit_mode"
+          },
+          {
+            "async": false,
+            "end_line": 240,
+            "kind": "function",
+            "line": 231,
+            "loc": 10,
+            "qualified_name": "_resolve_lora_preset_strength_step"
+          },
+          {
+            "async": false,
+            "end_line": 251,
+            "kind": "function",
+            "line": 243,
+            "loc": 9,
+            "qualified_name": "resolve_lora_preset_strength_button_step"
+          },
+          {
+            "async": false,
+            "end_line": 262,
+            "kind": "function",
+            "line": 254,
+            "loc": 9,
+            "qualified_name": "resolve_lora_preset_strength_drag_step"
+          },
+          {
+            "async": false,
+            "end_line": 280,
+            "kind": "function",
+            "line": 265,
+            "loc": 16,
+            "qualified_name": "resolve_lora_preset_strength_drag_pixels"
+          },
+          {
+            "async": false,
+            "end_line": 294,
+            "kind": "function",
+            "line": 283,
+            "loc": 12,
+            "qualified_name": "resolve_lora_preset_menu_mode"
+          },
+          {
+            "async": false,
+            "end_line": 304,
+            "kind": "function",
+            "line": 297,
+            "loc": 8,
+            "qualified_name": "resolve_prompt_studio_font_family"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 307,
+            "loc": 14,
+            "qualified_name": "resolve_prompt_studio_font_size"
+          },
+          {
+            "async": false,
+            "end_line": 332,
+            "kind": "function",
+            "line": 323,
+            "loc": 10,
+            "qualified_name": "resolve_prompt_translation_provider"
+          },
+          {
+            "async": false,
+            "end_line": 345,
+            "kind": "function",
+            "line": 335,
+            "loc": 11,
+            "qualified_name": "resolve_prompt_translation_source"
+          },
+          {
+            "async": false,
+            "end_line": 358,
+            "kind": "function",
+            "line": 348,
+            "loc": 11,
+            "qualified_name": "resolve_prompt_translation_target"
+          },
+          {
+            "async": false,
+            "end_line": 369,
+            "kind": "function",
+            "line": 361,
+            "loc": 9,
+            "qualified_name": "resolve_prompt_translation_settings"
+          },
+          {
+            "async": false,
+            "end_line": 379,
+            "kind": "function",
+            "line": 372,
+            "loc": 8,
+            "qualified_name": "_resolve_settings_bool"
+          },
+          {
+            "async": false,
+            "end_line": 388,
+            "kind": "function",
+            "line": 382,
+            "loc": 7,
+            "qualified_name": "resolve_naia_port"
+          },
+          {
+            "async": false,
+            "end_line": 404,
+            "kind": "function",
+            "line": 391,
+            "loc": 14,
+            "qualified_name": "resolve_naia_resolution_mode"
+          },
+          {
+            "async": false,
+            "end_line": 420,
+            "kind": "function",
+            "line": 407,
+            "loc": 14,
+            "qualified_name": "resolve_naia_resolution_bucket"
+          },
+          {
+            "async": false,
+            "end_line": 434,
+            "kind": "function",
+            "line": 423,
+            "loc": 12,
+            "qualified_name": "resolve_naia_resolution_scale"
+          },
+          {
+            "async": false,
+            "end_line": 454,
+            "kind": "function",
+            "line": 437,
+            "loc": 18,
+            "qualified_name": "resolve_naia_resolution_max_long_edge"
+          },
+          {
+            "async": false,
+            "end_line": 481,
+            "kind": "function",
+            "line": 457,
+            "loc": 25,
+            "qualified_name": "resolve_naia_settings"
+          }
+        ],
         "is_package": false,
         "loc": 508,
         "module": "easyuse_anima.settings.service",
@@ -72450,6 +81500,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.translation",
@@ -72462,6 +81513,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "method",
+            "line": 47,
+            "loc": 3,
+            "qualified_name": "PromptTranslationError.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 104,
+            "kind": "method",
+            "line": 102,
+            "loc": 3,
+            "qualified_name": "TranslationProvider.translate"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 107,
+            "loc": 5,
+            "qualified_name": "normalize_prompt_translation_provider"
+          },
+          {
+            "async": false,
+            "end_line": 116,
+            "kind": "function",
+            "line": 114,
+            "loc": 3,
+            "qualified_name": "normalize_prompt_translation_language"
+          }
+        ],
         "is_package": false,
         "loc": 146,
         "module": "easyuse_anima.translation.contracts",
@@ -72474,6 +81559,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 14,
+            "kind": "function",
+            "line": 8,
+            "loc": 7,
+            "qualified_name": "_is_escaped"
+          },
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "function",
+            "line": 17,
+            "loc": 21,
+            "qualified_name": "iter_prompt_translation_markers"
+          },
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "function",
+            "line": 40,
+            "loc": 2,
+            "qualified_name": "has_prompt_translation_markers"
+          }
+        ],
         "is_package": false,
         "loc": 48,
         "module": "easyuse_anima.translation.markers",
@@ -72486,6 +81597,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 15,
+            "kind": "method",
+            "line": 11,
+            "loc": 5,
+            "qualified_name": "PromptTranslationPort.translate_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 17,
+            "kind": "method",
+            "line": 17,
+            "loc": 1,
+            "qualified_name": "PromptTranslationPort.close"
+          }
+        ],
         "is_package": false,
         "loc": 20,
         "module": "easyuse_anima.translation.ports",
@@ -72498,6 +81627,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "method",
+            "line": 16,
+            "loc": 7,
+            "qualified_name": "_TranslationProviderRegistry.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 40,
+            "kind": "method",
+            "line": 24,
+            "loc": 17,
+            "qualified_name": "_TranslationProviderRegistry.get"
+          }
+        ],
         "is_package": false,
         "loc": 43,
         "module": "easyuse_anima.translation.provider_registry",
@@ -72510,6 +81657,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.translation.providers",
@@ -72522,6 +81670,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 22,
+            "kind": "method",
+            "line": 22,
+            "loc": 1,
+            "qualified_name": "_TranslatorClient.translate"
+          },
+          {
+            "async": false,
+            "end_line": 28,
+            "kind": "function",
+            "line": 25,
+            "loc": 4,
+            "qualified_name": "_looks_like_timeout"
+          },
+          {
+            "async": false,
+            "end_line": 43,
+            "kind": "method",
+            "line": 34,
+            "loc": 10,
+            "qualified_name": "GoogleTranslationProvider.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 53,
+            "kind": "method",
+            "line": 45,
+            "loc": 9,
+            "qualified_name": "GoogleTranslationProvider._create_translator"
+          },
+          {
+            "async": false,
+            "end_line": 76,
+            "kind": "method",
+            "line": 55,
+            "loc": 22,
+            "qualified_name": "GoogleTranslationProvider.translate"
+          }
+        ],
         "is_package": false,
         "loc": 79,
         "module": "easyuse_anima.translation.providers.google",
@@ -72534,6 +81724,152 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 44,
+            "kind": "function",
+            "line": 43,
+            "loc": 2,
+            "qualified_name": "get_translation_provider"
+          },
+          {
+            "async": false,
+            "end_line": 71,
+            "kind": "function",
+            "line": 47,
+            "loc": 25,
+            "qualified_name": "google_translate_text"
+          },
+          {
+            "async": false,
+            "end_line": 86,
+            "kind": "function",
+            "line": 74,
+            "loc": 13,
+            "qualified_name": "_translate_segment"
+          },
+          {
+            "async": false,
+            "end_line": 112,
+            "kind": "method",
+            "line": 99,
+            "loc": 14,
+            "qualified_name": "BoundedTranslationCache.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "method",
+            "line": 114,
+            "loc": 11,
+            "qualified_name": "BoundedTranslationCache.get"
+          },
+          {
+            "async": false,
+            "end_line": 136,
+            "kind": "method",
+            "line": 126,
+            "loc": 11,
+            "qualified_name": "BoundedTranslationCache.put"
+          },
+          {
+            "async": false,
+            "end_line": 140,
+            "kind": "method",
+            "line": 138,
+            "loc": 3,
+            "qualified_name": "BoundedTranslationCache.clear"
+          },
+          {
+            "async": false,
+            "end_line": 144,
+            "kind": "method",
+            "line": 142,
+            "loc": 3,
+            "qualified_name": "BoundedTranslationCache.__len__"
+          },
+          {
+            "async": false,
+            "end_line": 178,
+            "kind": "method",
+            "line": 148,
+            "loc": 31,
+            "qualified_name": "PromptTranslationService.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 198,
+            "kind": "method",
+            "line": 180,
+            "loc": 19,
+            "qualified_name": "PromptTranslationService._single_flight"
+          },
+          {
+            "async": false,
+            "end_line": 225,
+            "kind": "method",
+            "line": 200,
+            "loc": 26,
+            "qualified_name": "PromptTranslationService._validate_markers"
+          },
+          {
+            "async": false,
+            "end_line": 247,
+            "kind": "method",
+            "line": 227,
+            "loc": 21,
+            "qualified_name": "PromptTranslationService._translate_cached"
+          },
+          {
+            "async": false,
+            "end_line": 300,
+            "kind": "method",
+            "line": 249,
+            "loc": 52,
+            "qualified_name": "PromptTranslationService.translate_prompt"
+          },
+          {
+            "async": false,
+            "end_line": 303,
+            "kind": "method",
+            "line": 302,
+            "loc": 2,
+            "qualified_name": "PromptTranslationService.close"
+          },
+          {
+            "async": false,
+            "end_line": 318,
+            "kind": "function",
+            "line": 311,
+            "loc": 8,
+            "qualified_name": "_install_default_translation_service"
+          },
+          {
+            "async": false,
+            "end_line": 332,
+            "kind": "function",
+            "line": 321,
+            "loc": 12,
+            "qualified_name": "_restore_default_translation_service"
+          },
+          {
+            "async": false,
+            "end_line": 341,
+            "kind": "function",
+            "line": 335,
+            "loc": 7,
+            "qualified_name": "strip_prompt_translation_markers"
+          },
+          {
+            "async": false,
+            "end_line": 350,
+            "kind": "function",
+            "line": 344,
+            "loc": 7,
+            "qualified_name": "translate_prompt_markers"
+          }
+        ],
         "is_package": false,
         "loc": 360,
         "module": "easyuse_anima.translation.service",
@@ -72546,6 +81882,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.wildcard",
@@ -72558,6 +81895,256 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 43,
+            "loc": 20,
+            "qualified_name": "_split_unescaped"
+          },
+          {
+            "async": false,
+            "end_line": 71,
+            "kind": "function",
+            "line": 65,
+            "loc": 7,
+            "qualified_name": "_parse_dynamic_options"
+          },
+          {
+            "async": false,
+            "end_line": 90,
+            "kind": "function",
+            "line": 74,
+            "loc": 17,
+            "qualified_name": "_parse_count_spec"
+          },
+          {
+            "async": false,
+            "end_line": 94,
+            "kind": "method",
+            "line": 94,
+            "loc": 1,
+            "qualified_name": "_WildcardOptionLookup.options_for"
+          },
+          {
+            "async": false,
+            "end_line": 105,
+            "kind": "function",
+            "line": 97,
+            "loc": 9,
+            "qualified_name": "_utf8_width"
+          },
+          {
+            "async": false,
+            "end_line": 109,
+            "kind": "function",
+            "line": 108,
+            "loc": 2,
+            "qualified_name": "_utf8_length"
+          },
+          {
+            "async": false,
+            "end_line": 148,
+            "kind": "method",
+            "line": 119,
+            "loc": 30,
+            "qualified_name": "_ExpansionText.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 129,
+            "kind": "function",
+            "line": 124,
+            "loc": 6,
+            "qualified_name": "_ExpansionText.__init__.flush_pending"
+          },
+          {
+            "async": false,
+            "end_line": 152,
+            "kind": "method",
+            "line": 150,
+            "loc": 3,
+            "qualified_name": "_ExpansionText.from_text"
+          },
+          {
+            "async": false,
+            "end_line": 173,
+            "kind": "method",
+            "line": 154,
+            "loc": 20,
+            "qualified_name": "_ExpansionText.slice_segments"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "method",
+            "line": 175,
+            "loc": 17,
+            "qualified_name": "_ExpansionText.key_stack_for_span"
+          },
+          {
+            "async": false,
+            "end_line": 205,
+            "kind": "method",
+            "line": 200,
+            "loc": 6,
+            "qualified_name": "_Replacement.char_count"
+          },
+          {
+            "async": false,
+            "end_line": 214,
+            "kind": "method",
+            "line": 207,
+            "loc": 8,
+            "qualified_name": "_Replacement.byte_count"
+          },
+          {
+            "async": false,
+            "end_line": 219,
+            "kind": "method",
+            "line": 216,
+            "loc": 4,
+            "qualified_name": "_Replacement.materialize"
+          },
+          {
+            "async": false,
+            "end_line": 229,
+            "kind": "method",
+            "line": 223,
+            "loc": 7,
+            "qualified_name": "_ExpansionState.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 233,
+            "kind": "method",
+            "line": 231,
+            "loc": 3,
+            "qualified_name": "_ExpansionState.begin_pass"
+          },
+          {
+            "async": false,
+            "end_line": 237,
+            "kind": "method",
+            "line": 235,
+            "loc": 3,
+            "qualified_name": "_ExpansionState.stop"
+          },
+          {
+            "async": false,
+            "end_line": 257,
+            "kind": "method",
+            "line": 239,
+            "loc": 19,
+            "qualified_name": "_ExpansionState.candidate"
+          },
+          {
+            "async": false,
+            "end_line": 294,
+            "kind": "method",
+            "line": 259,
+            "loc": 36,
+            "qualified_name": "_ExpansionState._replacement_limit_reason"
+          },
+          {
+            "async": false,
+            "end_line": 337,
+            "kind": "method",
+            "line": 296,
+            "loc": 42,
+            "qualified_name": "_ExpansionState.replace_matches"
+          },
+          {
+            "async": false,
+            "end_line": 353,
+            "kind": "function",
+            "line": 340,
+            "loc": 14,
+            "qualified_name": "_expand_multiselect_options"
+          },
+          {
+            "async": false,
+            "end_line": 404,
+            "kind": "function",
+            "line": 356,
+            "loc": 49,
+            "qualified_name": "_replace_dynamic"
+          },
+          {
+            "async": false,
+            "end_line": 402,
+            "kind": "function",
+            "line": 362,
+            "loc": 41,
+            "qualified_name": "_replace_dynamic.replace"
+          },
+          {
+            "async": false,
+            "end_line": 430,
+            "kind": "function",
+            "line": 407,
+            "loc": 24,
+            "qualified_name": "_replace_quantified_wildcards"
+          },
+          {
+            "async": false,
+            "end_line": 428,
+            "kind": "function",
+            "line": 413,
+            "loc": 16,
+            "qualified_name": "_replace_quantified_wildcards.replace"
+          },
+          {
+            "async": false,
+            "end_line": 451,
+            "kind": "function",
+            "line": 433,
+            "loc": 19,
+            "qualified_name": "_replace_file_wildcards"
+          },
+          {
+            "async": false,
+            "end_line": 449,
+            "kind": "function",
+            "line": 439,
+            "loc": 11,
+            "qualified_name": "_replace_file_wildcards.replace"
+          },
+          {
+            "async": false,
+            "end_line": 460,
+            "kind": "function",
+            "line": 454,
+            "loc": 7,
+            "qualified_name": "has_wildcard_syntax"
+          },
+          {
+            "async": false,
+            "end_line": 472,
+            "kind": "function",
+            "line": 463,
+            "loc": 10,
+            "qualified_name": "_bounded_output_prefix"
+          },
+          {
+            "async": false,
+            "end_line": 480,
+            "kind": "function",
+            "line": 475,
+            "loc": 6,
+            "qualified_name": "_expansion_state_signature"
+          },
+          {
+            "async": false,
+            "end_line": 595,
+            "kind": "function",
+            "line": 491,
+            "loc": 105,
+            "qualified_name": "_expand_snapshot_texts"
+          }
+        ],
         "is_package": false,
         "loc": 595,
         "module": "easyuse_anima.wildcard.expansion",
@@ -72570,6 +82157,56 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 19,
+            "kind": "method",
+            "line": 16,
+            "loc": 4,
+            "qualified_name": "_WildcardLibrary.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 23,
+            "kind": "method",
+            "line": 21,
+            "loc": 3,
+            "qualified_name": "_WildcardLibrary._record_used"
+          },
+          {
+            "async": false,
+            "end_line": 27,
+            "kind": "method",
+            "line": 25,
+            "loc": 3,
+            "qualified_name": "_WildcardLibrary._record_missing"
+          },
+          {
+            "async": false,
+            "end_line": 38,
+            "kind": "method",
+            "line": 29,
+            "loc": 10,
+            "qualified_name": "_WildcardLibrary.options_for"
+          },
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "method",
+            "line": 40,
+            "loc": 10,
+            "qualified_name": "_WildcardLibrary._options_for_normalized_key"
+          },
+          {
+            "async": false,
+            "end_line": 63,
+            "kind": "method",
+            "line": 51,
+            "loc": 13,
+            "qualified_name": "_WildcardLibrary._options_for_pattern"
+          }
+        ],
         "is_package": false,
         "loc": 63,
         "module": "easyuse_anima.wildcard.library",
@@ -72582,6 +82219,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 37,
+            "loc": 3,
+            "qualified_name": "normalize_wildcard_mode"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 42,
+            "loc": 7,
+            "qualified_name": "normalize_prompt_studio_wildcard_mode"
+          }
+        ],
         "is_package": false,
         "loc": 62,
         "module": "easyuse_anima.wildcard.mode",
@@ -72594,6 +82249,32 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 43,
+            "loc": 6,
+            "qualified_name": "_bounded_int"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "function",
+            "line": 51,
+            "loc": 8,
+            "qualified_name": "_bounded_float"
+          },
+          {
+            "async": false,
+            "end_line": 108,
+            "kind": "method",
+            "line": 68,
+            "loc": 41,
+            "qualified_name": "WildcardExpansionBudget.__post_init__"
+          }
+        ],
         "is_package": false,
         "loc": 118,
         "module": "easyuse_anima.wildcard.models",
@@ -72606,6 +82287,16 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 21,
+            "kind": "method",
+            "line": 15,
+            "loc": 7,
+            "qualified_name": "WildcardSnapshotPort.snapshot_for_roots"
+          }
+        ],
         "is_package": false,
         "loc": 24,
         "module": "easyuse_anima.wildcard.ports",
@@ -72618,6 +82309,24 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 34,
+            "loc": 6,
+            "qualified_name": "normalize_seed"
+          },
+          {
+            "async": false,
+            "end_line": 62,
+            "kind": "function",
+            "line": 42,
+            "loc": 21,
+            "qualified_name": "next_seed"
+          }
+        ],
         "is_package": false,
         "loc": 62,
         "module": "easyuse_anima.wildcard.seed",
@@ -72630,6 +82339,40 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 27,
+            "kind": "method",
+            "line": 18,
+            "loc": 10,
+            "qualified_name": "_Selector.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 37,
+            "kind": "method",
+            "line": 29,
+            "loc": 9,
+            "qualified_name": "_Selector.count_from_range"
+          },
+          {
+            "async": false,
+            "end_line": 41,
+            "kind": "method",
+            "line": 39,
+            "loc": 3,
+            "qualified_name": "_Selector.choose_one"
+          },
+          {
+            "async": false,
+            "end_line": 75,
+            "kind": "method",
+            "line": 43,
+            "loc": 33,
+            "qualified_name": "_Selector.choose_many"
+          }
+        ],
         "is_package": false,
         "loc": 75,
         "module": "easyuse_anima.wildcard.selector",
@@ -72642,6 +82385,96 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 39,
+            "kind": "function",
+            "line": 34,
+            "loc": 6,
+            "qualified_name": "_wildcard_snapshot"
+          },
+          {
+            "async": false,
+            "end_line": 48,
+            "kind": "function",
+            "line": 42,
+            "loc": 7,
+            "qualified_name": "_load_wildcard_map_with"
+          },
+          {
+            "async": false,
+            "end_line": 55,
+            "kind": "function",
+            "line": 51,
+            "loc": 5,
+            "qualified_name": "_load_wildcard_map"
+          },
+          {
+            "async": false,
+            "end_line": 67,
+            "kind": "function",
+            "line": 58,
+            "loc": 10,
+            "qualified_name": "_list_wildcards_with"
+          },
+          {
+            "async": false,
+            "end_line": 78,
+            "kind": "function",
+            "line": 70,
+            "loc": 9,
+            "qualified_name": "list_wildcards"
+          },
+          {
+            "async": false,
+            "end_line": 90,
+            "kind": "function",
+            "line": 81,
+            "loc": 10,
+            "qualified_name": "_wildcard_sources_signature_with"
+          },
+          {
+            "async": false,
+            "end_line": 101,
+            "kind": "function",
+            "line": 93,
+            "loc": 9,
+            "qualified_name": "wildcard_sources_signature"
+          },
+          {
+            "async": false,
+            "end_line": 113,
+            "kind": "method",
+            "line": 105,
+            "loc": 9,
+            "qualified_name": "_WildcardLibrary.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 157,
+            "kind": "function",
+            "line": 116,
+            "loc": 42,
+            "qualified_name": "_expand_wildcard_texts_with"
+          },
+          {
+            "async": false,
+            "end_line": 183,
+            "kind": "function",
+            "line": 160,
+            "loc": 24,
+            "qualified_name": "expand_wildcard_texts"
+          },
+          {
+            "async": false,
+            "end_line": 201,
+            "kind": "function",
+            "line": 186,
+            "loc": 16,
+            "qualified_name": "expand_wildcards"
+          }
+        ],
         "is_package": false,
         "loc": 201,
         "module": "easyuse_anima.wildcard.service",
@@ -72654,6 +82487,48 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "method",
+            "line": 30,
+            "loc": 13,
+            "qualified_name": "_WildcardSnapshot.public_signature"
+          },
+          {
+            "async": false,
+            "end_line": 50,
+            "kind": "method",
+            "line": 46,
+            "loc": 5,
+            "qualified_name": "_WildcardSnapshotStore.__init__"
+          },
+          {
+            "async": false,
+            "end_line": 54,
+            "kind": "method",
+            "line": 52,
+            "loc": 3,
+            "qualified_name": "_WildcardSnapshotStore.clear"
+          },
+          {
+            "async": false,
+            "end_line": 99,
+            "kind": "method",
+            "line": 56,
+            "loc": 44,
+            "qualified_name": "_WildcardSnapshotStore.snapshot_for_roots"
+          },
+          {
+            "async": false,
+            "end_line": 128,
+            "kind": "function",
+            "line": 102,
+            "loc": 27,
+            "qualified_name": "_build_wildcard_snapshot"
+          }
+        ],
         "is_package": false,
         "loc": 131,
         "module": "easyuse_anima.wildcard.snapshot",
@@ -72666,6 +82541,160 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 53,
+            "kind": "method",
+            "line": 51,
+            "loc": 3,
+            "qualified_name": "_WildcardSourceFile.cache_key"
+          },
+          {
+            "async": false,
+            "end_line": 68,
+            "kind": "method",
+            "line": 62,
+            "loc": 7,
+            "qualified_name": "_WildcardSourceState.cache_key"
+          },
+          {
+            "async": false,
+            "end_line": 72,
+            "kind": "function",
+            "line": 71,
+            "loc": 2,
+            "qualified_name": "default_wildcard_root"
+          },
+          {
+            "async": false,
+            "end_line": 82,
+            "kind": "function",
+            "line": 75,
+            "loc": 8,
+            "qualified_name": "ensure_default_wildcard_root"
+          },
+          {
+            "async": false,
+            "end_line": 91,
+            "kind": "function",
+            "line": 85,
+            "loc": 7,
+            "qualified_name": "parse_wildcard_extra_paths"
+          },
+          {
+            "async": false,
+            "end_line": 103,
+            "kind": "function",
+            "line": 94,
+            "loc": 10,
+            "qualified_name": "_comfy_base_path"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 106,
+            "loc": 6,
+            "qualified_name": "_resolve_path"
+          },
+          {
+            "async": false,
+            "end_line": 140,
+            "kind": "function",
+            "line": 114,
+            "loc": 27,
+            "qualified_name": "resolve_wildcard_roots"
+          },
+          {
+            "async": false,
+            "end_line": 152,
+            "kind": "function",
+            "line": 143,
+            "loc": 10,
+            "qualified_name": "_normalize_wildcard_key"
+          },
+          {
+            "async": false,
+            "end_line": 159,
+            "kind": "function",
+            "line": 155,
+            "loc": 5,
+            "qualified_name": "_read_text_file"
+          },
+          {
+            "async": false,
+            "end_line": 173,
+            "kind": "function",
+            "line": 162,
+            "loc": 12,
+            "qualified_name": "_parse_option"
+          },
+          {
+            "async": false,
+            "end_line": 185,
+            "kind": "function",
+            "line": 176,
+            "loc": 10,
+            "qualified_name": "_options_from_lines"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "function",
+            "line": 188,
+            "loc": 4,
+            "qualified_name": "_stringify_yaml_scalar"
+          },
+          {
+            "async": false,
+            "end_line": 231,
+            "kind": "function",
+            "line": 194,
+            "loc": 38,
+            "qualified_name": "_yaml_entries"
+          },
+          {
+            "async": false,
+            "end_line": 228,
+            "kind": "function",
+            "line": 197,
+            "loc": 32,
+            "qualified_name": "_yaml_entries.collect"
+          },
+          {
+            "async": false,
+            "end_line": 242,
+            "kind": "function",
+            "line": 234,
+            "loc": 9,
+            "qualified_name": "_load_yaml_entries"
+          },
+          {
+            "async": false,
+            "end_line": 261,
+            "kind": "function",
+            "line": 245,
+            "loc": 17,
+            "qualified_name": "_load_wildcard_file"
+          },
+          {
+            "async": false,
+            "end_line": 268,
+            "kind": "function",
+            "line": 264,
+            "loc": 5,
+            "qualified_name": "_wildcard_root_identity"
+          },
+          {
+            "async": false,
+            "end_line": 307,
+            "kind": "function",
+            "line": 271,
+            "loc": 37,
+            "qualified_name": "_scan_wildcard_sources"
+          }
+        ],
         "is_package": false,
         "loc": 307,
         "module": "easyuse_anima.wildcard.sources",
@@ -72678,6 +82707,16 @@
         }
       },
       {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 50,
+            "kind": "function",
+            "line": 10,
+            "loc": 41,
+            "qualified_name": "_get_workflow_node"
+          }
+        ],
         "is_package": false,
         "loc": 50,
         "module": "easyuse_anima.workflow",
@@ -72690,6 +82729,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 1156,
         "module": "nodes",
@@ -72702,6 +82742,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 134,
         "module": "prompt_translation",
@@ -72714,6 +82755,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 145,
         "module": "settings",
@@ -72726,6 +82768,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 29,
         "module": "storage",
@@ -72738,6 +82781,7 @@
         }
       },
       {
+        "functions": [],
         "is_package": false,
         "loc": 209,
         "module": "wildcard_engine",
@@ -94021,7 +104065,7 @@
     ],
     "unreachable_shipped_python_modules": []
   },
-  "schema_version": 2,
+  "schema_version": 3,
   "side_effects": {
     "candidates": [
       {

--- a/tests/fixtures/python_size_complexity_contract.v1.json
+++ b/tests/fixtures/python_size_complexity_contract.v1.json
@@ -1,0 +1,238 @@
+{
+  "schema_version": 1,
+  "thresholds": {
+    "module_lines": 800,
+    "adapter_module_lines": 400,
+    "function_lines": 120
+  },
+  "adapter_paths": {
+    "exact": [
+      "__init__.py",
+      "api.py",
+      "easyuse_anima/bootstrap.py",
+      "easyuse_anima/registration.py",
+      "nodes.py"
+    ],
+    "prefixes": [
+      "easyuse_anima/api/",
+      "easyuse_anima/infrastructure/",
+      "easyuse_anima/nodes/"
+    ]
+  },
+  "module_exceptions": [
+    {
+      "path": "api.py",
+      "baseline_loc": 698,
+      "owner_issue": 188,
+      "decomposition_boundary": "Retire root compatibility groups only after their canonical API aliases and patch seams have direct consumer proof."
+    },
+    {
+      "path": "easyuse_anima/aio/generation_normalization.py",
+      "baseline_loc": 1115,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate versioned settings-section normalizers only with migration default and future-key parity."
+    },
+    {
+      "path": "easyuse_anima/aio/legacy_generation.py",
+      "baseline_loc": 1095,
+      "owner_issue": 188,
+      "decomposition_boundary": "Move legacy stage orchestration only along existing stage-port calls while preserving root monkeypatch seams."
+    },
+    {
+      "path": "easyuse_anima/bootstrap.py",
+      "baseline_loc": 422,
+      "owner_issue": 187,
+      "decomposition_boundary": "E-09 lifecycle lock, initialization, cleanup plan, rollback, and terminal shutdown remain one bootstrap owner."
+    },
+    {
+      "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "baseline_loc": 415,
+      "owner_issue": 188,
+      "decomposition_boundary": "Split filesystem primitives only if lock, compare-and-swap, atomic replace, and recovery ordering remain one transaction contract."
+    },
+    {
+      "path": "easyuse_anima/nodes/naia_nodes.py",
+      "baseline_loc": 577,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate NAIA node schema and request adapters only with unchanged public socket and response identities."
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+      "baseline_loc": 1208,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate Advanced node generations by public node class while preserving shared field, seed, and root alias contracts."
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_data_nodes.py",
+      "baseline_loc": 684,
+      "owner_issue": 188,
+      "decomposition_boundary": "Split Prompt Data node adapters by node class only with workflow field and output tuple parity."
+    },
+    {
+      "path": "easyuse_anima/nodes/regional_nodes.py",
+      "baseline_loc": 513,
+      "owner_issue": 188,
+      "decomposition_boundary": "Split Regional node adapters only across existing node classes with socket and workflow parity."
+    },
+    {
+      "path": "easyuse_anima/prompt/advanced.py",
+      "baseline_loc": 890,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate pure Advanced Prompt Data construction from field normalization without changing serialized output."
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "baseline_loc": 1511,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate Artist Mix tag/config selection from conditioning encoding without duplicating warning or cache ownership."
+    },
+    {
+      "path": "nodes.py",
+      "baseline_loc": 1156,
+      "owner_issue": 188,
+      "decomposition_boundary": "Reduce the root compatibility facade only through canonical node adapters with exact alias and monkeypatch parity."
+    }
+  ],
+  "function_exceptions": [
+    {
+      "path": "easyuse_anima/aio/generation_normalization.py",
+      "qualified_name": "_normalize_aio_dit_corrections_settings",
+      "baseline_loc": 131,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep the DiT correction section validation and default projection as one migration unit."
+    },
+    {
+      "path": "easyuse_anima/aio/generation_normalization.py",
+      "qualified_name": "_normalize_aio_generation_settings",
+      "baseline_loc": 681,
+      "owner_issue": 188,
+      "decomposition_boundary": "Extract settings-section normalizers only with exact version dispatch, defaults, and future-key parity."
+    },
+    {
+      "path": "easyuse_anima/aio/generation_save_output_stage.py",
+      "qualified_name": "AIOSaveOutputStage.run",
+      "baseline_loc": 141,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate save backend dispatch from result assembly only with identical output and disabled-save behavior."
+    },
+    {
+      "path": "easyuse_anima/aio/legacy_generation.py",
+      "qualified_name": "_run_aio_generation_pipeline",
+      "baseline_loc": 385,
+      "owner_issue": 188,
+      "decomposition_boundary": "Move legacy pipeline stages only through existing stage ports while preserving call and error order."
+    },
+    {
+      "path": "easyuse_anima/aio/legacy_generation.py",
+      "qualified_name": "_run_aio_usdu_upscale_stage",
+      "baseline_loc": 154,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep USDU option projection and adapter invocation together until a typed stage request owns both."
+    },
+    {
+      "path": "easyuse_anima/aio/sampling.py",
+      "qualified_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
+      "baseline_loc": 129,
+      "owner_issue": 188,
+      "decomposition_boundary": "Split sampling setup only at the existing Spectrum and mod-guidance adapter boundaries."
+    },
+    {
+      "path": "easyuse_anima/aio/torch_compile_recommendation.py",
+      "qualified_name": "recommend_torch_compile",
+      "baseline_loc": 124,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep recommendation precedence together unless rule groups gain direct table-driven ownership tests."
+    },
+    {
+      "path": "easyuse_anima/bootstrap.py",
+      "qualified_name": "initialize",
+      "baseline_loc": 131,
+      "owner_issue": 187,
+      "decomposition_boundary": "E-09 initialization, rollback, repeated-call identity, and terminal shutdown checks remain serialized by one lock."
+    },
+    {
+      "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "qualified_name": "AtomicJsonStore.replace_from",
+      "baseline_loc": 140,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep validation, expected-revision compare, atomic replacement, and failure cleanup in one transaction."
+    },
+    {
+      "path": "easyuse_anima/nodes/impact_detailer_nodes.py",
+      "qualified_name": "_EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES",
+      "baseline_loc": 129,
+      "owner_issue": 188,
+      "decomposition_boundary": "Extract socket groups only through immutable schema helpers with exact ComfyUI input ordering."
+    },
+    {
+      "path": "easyuse_anima/nodes/naia_nodes.py",
+      "qualified_name": "EasyUseAnimaNAIARandomPrompt.INPUT_TYPES",
+      "baseline_loc": 137,
+      "owner_issue": 188,
+      "decomposition_boundary": "Extract NAIA socket groups only with exact default, choice, and ordering parity."
+    },
+    {
+      "path": "easyuse_anima/nodes/naia_nodes.py",
+      "qualified_name": "EasyUseAnimaNAIARandomPrompt.request",
+      "baseline_loc": 137,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate NAIA request preparation from node result conversion only at the typed client boundary."
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+      "qualified_name": "EasyUseAnimaPromptStudioAdvanced.build",
+      "baseline_loc": 171,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate legacy Advanced node conversion only after shared Prompt Data and seed adapters own the inputs."
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+      "qualified_name": "EasyUseAnimaPromptStudioAdvancedV2._build_with_seed",
+      "baseline_loc": 184,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep seed reservation and Prompt Data node output assembly ordered until a typed request owns both."
+    },
+    {
+      "path": "easyuse_anima/nodes/sam3_nodes.py",
+      "qualified_name": "EasyUseAnimaSAM3Detailer.doit",
+      "baseline_loc": 126,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate SAM3 detection from detailer result assembly only through the canonical image adapter."
+    },
+    {
+      "path": "easyuse_anima/prompt/advanced.py",
+      "qualified_name": "_build_advanced_prompt_data",
+      "baseline_loc": 227,
+      "owner_issue": 188,
+      "decomposition_boundary": "Extract field-family builders only with exact Prompt Data serialization and optional-field parity."
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "qualified_name": "_encode_artist_clustered",
+      "baseline_loc": 130,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate cluster planning from encoding only with deterministic weighting and conditioning parity."
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "qualified_name": "_encode_prompt_data_positive_conditioning",
+      "baseline_loc": 217,
+      "owner_issue": 188,
+      "decomposition_boundary": "Split conditioning branches only with identical cache, warning, and tensor metadata behavior."
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "qualified_name": "_prompt_data_artist_mix_config",
+      "baseline_loc": 138,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep Artist Mix config migration and validation together until a typed config constructor owns both."
+    },
+    {
+      "path": "easyuse_anima/prompt/regional.py",
+      "qualified_name": "_build_regional_outputs",
+      "baseline_loc": 140,
+      "owner_issue": 188,
+      "decomposition_boundary": "Separate regional field projection only with exact region order, masks, and serialized Prompt Data parity."
+    }
+  ]
+}

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -66,6 +66,78 @@ class PythonBackendAnalyzerTests(unittest.TestCase):
 
         self.assertEqual(lf_report, crlf_report)
 
+    def test_function_metrics_include_decorators_methods_nested_and_duplicates(self):
+        report = analyzer.analyze_source_set(
+            {
+                "__init__.py": """\
+def decorator(function):
+    return function
+
+@decorator
+def top():
+    def nested():
+        return 1
+    return nested()
+
+class Owner:
+    @decorator
+    async def method(self):
+        return 2
+
+def top():
+    return 3
+""",
+            }
+        )
+
+        functions = report["inventory"]["modules"][0]["functions"]
+
+        self.assertEqual(
+            functions,
+            [
+                {
+                    "qualified_name": "decorator",
+                    "kind": "function",
+                    "async": False,
+                    "line": 1,
+                    "end_line": 2,
+                    "loc": 2,
+                },
+                {
+                    "qualified_name": "top",
+                    "kind": "function",
+                    "async": False,
+                    "line": 4,
+                    "end_line": 8,
+                    "loc": 5,
+                },
+                {
+                    "qualified_name": "top.nested",
+                    "kind": "function",
+                    "async": False,
+                    "line": 6,
+                    "end_line": 7,
+                    "loc": 2,
+                },
+                {
+                    "qualified_name": "Owner.method",
+                    "kind": "method",
+                    "async": True,
+                    "line": 11,
+                    "end_line": 13,
+                    "loc": 3,
+                },
+                {
+                    "qualified_name": "top#2",
+                    "kind": "function",
+                    "async": False,
+                    "line": 15,
+                    "end_line": 16,
+                    "loc": 2,
+                },
+            ],
+        )
+
     def test_alias_static_relative_and_literal_dynamic_import_edges(self):
         sources = {
             "__init__.py": """\
@@ -689,7 +761,7 @@ ignored/
         expected_text = BASELINE_PATH.read_text(encoding="utf-8")
 
         self.assertEqual(analyzer.render_json(report), expected_text)
-        self.assertEqual(report["schema_version"], 2)
+        self.assertEqual(report["schema_version"], 3)
         self.assertEqual(report["inventory"]["module_count"], 176)
         self.assertEqual(len(report["registry"]["shipped_python_modules"]), 176)
         self.assertEqual(len(report["registry"]["runtime_import_closure"]), 176)

--- a/tests/test_python_quality_contract.py
+++ b/tests/test_python_quality_contract.py
@@ -108,6 +108,15 @@ class PythonQualityContractTests(unittest.TestCase):
         self.assertIn("Pyright execution failed", source)
         self.assertIn("Pyright baseline ratchet failed", source)
 
+    def test_dedicated_runner_invokes_size_complexity_ratchet_once(self):
+        source = (
+            ROOT / "tools" / "check_python_quality.ps1"
+        ).read_text(encoding="utf-8")
+        invocation = '(Join-Path $PSScriptRoot "check_python_size_complexity.py")'
+
+        self.assertEqual(source.count(invocation), 1)
+        self.assertIn("Python size/complexity ratchet failed", source)
+
     def test_project_runner_calls_g01_before_profile_specific_full_tests(self):
         source = (
             ROOT / "tools" / "check_project.ps1"

--- a/tests/test_python_size_complexity.py
+++ b/tests/test_python_size_complexity.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER_PATH = ROOT / "tools" / "check_python_size_complexity.py"
+CONTRACT_PATH = (
+    ROOT / "tests" / "fixtures" / "python_size_complexity_contract.v1.json"
+)
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_python_size_complexity_checker",
+        CHECKER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load checker: {CHECKER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = load_checker()
+
+
+def contract_document(*, modules=(), functions=()):
+    return {
+        "schema_version": 1,
+        "thresholds": {
+            "module_lines": 800,
+            "adapter_module_lines": 400,
+            "function_lines": 120,
+        },
+        "adapter_paths": {
+            "exact": [
+                "__init__.py",
+                "api.py",
+                "easyuse_anima/bootstrap.py",
+                "easyuse_anima/registration.py",
+                "nodes.py",
+            ],
+            "prefixes": [
+                "easyuse_anima/api/",
+                "easyuse_anima/infrastructure/",
+                "easyuse_anima/nodes/",
+            ],
+        },
+        "module_exceptions": list(modules),
+        "function_exceptions": list(functions),
+    }
+
+
+def exception(path, baseline_loc, *, qualified_name=None):
+    record = {
+        "path": path,
+        "baseline_loc": baseline_loc,
+        "owner_issue": 188,
+        "decomposition_boundary": (
+            "split only at the named adapter or service ownership boundary"
+        ),
+    }
+    if qualified_name is not None:
+        record["qualified_name"] = qualified_name
+    return record
+
+
+def function_source(loc):
+    return "def oversized():\n" + "    pass\n" * (loc - 1)
+
+
+class PythonSizeComplexityContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.document = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+        cls.contract = checker.validate_contract(cls.document)
+
+    def test_current_repository_has_zero_size_growth_violations(self):
+        self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
+
+    def test_checked_in_ledger_exactly_freezes_current_overages(self):
+        report = checker.analyzer.analyze_repository(ROOT)
+        exact_paths = self.contract["adapter_paths"]["exact"]
+        prefixes = tuple(self.contract["adapter_paths"]["prefixes"])
+        current_modules = {}
+        current_functions = {}
+        for module in report["inventory"]["modules"]:
+            path = module["path"]
+            module_threshold = (
+                400 if path in exact_paths or path.startswith(prefixes) else 800
+            )
+            if module["loc"] > module_threshold:
+                current_modules[path] = module["loc"]
+            for function in module["functions"]:
+                if function["loc"] > 120:
+                    current_functions[(path, function["qualified_name"])] = function[
+                        "loc"
+                    ]
+
+        ledger_modules = {
+            record["path"]: record["baseline_loc"]
+            for record in self.contract["module_exceptions"]
+        }
+        ledger_functions = {
+            (record["path"], record["qualified_name"]): record["baseline_loc"]
+            for record in self.contract["function_exceptions"]
+        }
+        self.assertEqual(ledger_modules, current_modules)
+        self.assertEqual(ledger_functions, current_functions)
+
+    def test_new_adapter_module_general_module_and_function_overages_fail(self):
+        report = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "api.py": "# adapter\n" * 401,
+                "easyuse_anima/service.py": "# service\n" * 801,
+                "easyuse_anima/small.py": function_source(121),
+            }
+        )
+
+        violations = checker.check_report(
+            report,
+            checker.validate_contract(contract_document()),
+        )
+
+        self.assertEqual(
+            {violation["rule"] for violation in violations},
+            {
+                "unreviewed-function-overage",
+                "unreviewed-module-overage",
+            },
+        )
+        self.assertEqual(
+            {(item["path"], item["symbol"]) for item in violations},
+            {
+                ("api.py", "<module>"),
+                ("easyuse_anima/service.py", "<module>"),
+                ("easyuse_anima/small.py", "oversized"),
+            },
+        )
+
+    def test_reviewed_baseline_decrease_passes_but_growth_fails(self):
+        document = contract_document(
+            functions=[
+                exception(
+                    "easyuse_anima/service.py",
+                    125,
+                    qualified_name="oversized",
+                )
+            ]
+        )
+        contract = checker.validate_contract(document)
+        decreased = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "easyuse_anima/service.py": function_source(124),
+            }
+        )
+        grown = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "easyuse_anima/service.py": function_source(126),
+            }
+        )
+
+        self.assertEqual(checker.check_report(decreased, contract), [])
+        self.assertEqual(
+            checker.check_report(grown, contract),
+            [
+                {
+                    "rule": "function-overage-growth",
+                    "path": "easyuse_anima/service.py",
+                    "symbol": "oversized",
+                    "current_loc": 126,
+                    "baseline_loc": 125,
+                }
+            ],
+        )
+
+    def test_reviewed_module_baseline_decrease_passes_but_growth_fails(self):
+        document = contract_document(
+            modules=[exception("easyuse_anima/service.py", 805)]
+        )
+        contract = checker.validate_contract(document)
+        decreased = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "easyuse_anima/service.py": "# service\n" * 804,
+            }
+        )
+        grown = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "easyuse_anima/service.py": "# service\n" * 806,
+            }
+        )
+
+        self.assertEqual(checker.check_report(decreased, contract), [])
+        self.assertEqual(
+            checker.check_report(grown, contract),
+            [
+                {
+                    "rule": "module-overage-growth",
+                    "path": "easyuse_anima/service.py",
+                    "symbol": "<module>",
+                    "current_loc": 806,
+                    "baseline_loc": 805,
+                }
+            ],
+        )
+
+    def test_path_or_function_rename_requires_same_pr_ledger_update(self):
+        document = contract_document(
+            modules=[exception("easyuse_anima/old.py", 801)],
+            functions=[
+                exception(
+                    "easyuse_anima/old.py",
+                    121,
+                    qualified_name="old_function",
+                )
+            ],
+        )
+        report = checker.analyzer.analyze_source_set(
+            {
+                "__init__.py": "VALUE = 1\n",
+                "easyuse_anima/new.py": function_source(121),
+            }
+        )
+
+        violations = checker.check_report(
+            report,
+            checker.validate_contract(document),
+        )
+
+        self.assertEqual(
+            {violation["rule"] for violation in violations},
+            {
+                "stale-function-exception",
+                "stale-module-exception",
+                "unreviewed-function-overage",
+            },
+        )
+
+    def test_contract_rejects_weaker_thresholds_unsorted_and_ownerless_exceptions(self):
+        mutations = []
+
+        weaker_threshold = contract_document()
+        weaker_threshold["thresholds"]["function_lines"] = 121
+        mutations.append(weaker_threshold)
+
+        unsorted_paths = contract_document()
+        unsorted_paths["adapter_paths"]["exact"].reverse()
+        mutations.append(unsorted_paths)
+
+        missing_adapter = contract_document()
+        missing_adapter["adapter_paths"]["exact"].remove("__init__.py")
+        mutations.append(missing_adapter)
+
+        ownerless = contract_document(
+            functions=[
+                exception(
+                    "easyuse_anima/service.py",
+                    121,
+                    qualified_name="oversized",
+                )
+            ]
+        )
+        ownerless["function_exceptions"][0]["owner_issue"] = 0
+        mutations.append(ownerless)
+
+        vague_boundary = copy.deepcopy(ownerless)
+        vague_boundary["function_exceptions"][0]["owner_issue"] = 188
+        vague_boundary["function_exceptions"][0]["decomposition_boundary"] = "later"
+        mutations.append(vague_boundary)
+
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                with self.assertRaises(checker.ContractError):
+                    checker.validate_contract(mutation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -9,7 +9,7 @@ Deterministic output rules:
 
 * paths are repository-relative POSIX paths;
 * CRLF and bare CR are normalized to LF before parsing and blob hashing;
-* module, edge, state, side-effect, and SCC collections are sorted;
+* module, function, edge, state, side-effect, and SCC collections are sorted;
 * JSON object keys are sorted and the rendered document ends with one LF;
 * no absolute paths, user names, object ids, timestamps, or runtime values are
   included.
@@ -29,7 +29,7 @@ from typing import Iterable, Mapping, Sequence
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 ROOT_MODULE = "__root__"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 REGISTRY_ENTRY_MODULE_CANDIDATES = (
     "__init__.py",
     "anima_prompt/__init__.py",
@@ -947,6 +947,70 @@ def _literal_string_sequence(value: ast.AST | None) -> list[str]:
     return values if len(values) == len(value.elts) else []
 
 
+class _FunctionMetricVisitor(ast.NodeVisitor):
+    """Collect stable line metrics for functions without executing source."""
+
+    def __init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+        self.scope_parts: list[str] = []
+        self.scope_kinds: list[str] = []
+        self.name_counts: dict[str, int] = {}
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope_parts.append(node.name)
+        self.scope_kinds.append("class")
+        for statement in node.body:
+            self.visit(statement)
+        self.scope_kinds.pop()
+        self.scope_parts.pop()
+
+    def _visit_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        base_name = ".".join((*self.scope_parts, node.name))
+        occurrence = self.name_counts.get(base_name, 0) + 1
+        self.name_counts[base_name] = occurrence
+        qualified_name = base_name if occurrence == 1 else f"{base_name}#{occurrence}"
+        decorator_lines = [decorator.lineno for decorator in node.decorator_list]
+        line = min([node.lineno, *decorator_lines])
+        end_line = node.end_lineno or node.lineno
+        self.records.append(
+            {
+                "qualified_name": qualified_name,
+                "kind": "method"
+                if self.scope_kinds and self.scope_kinds[-1] == "class"
+                else "function",
+                "async": isinstance(node, ast.AsyncFunctionDef),
+                "line": line,
+                "end_line": end_line,
+                "loc": end_line - line + 1,
+            }
+        )
+
+        self.scope_parts.append(qualified_name.rsplit(".", 1)[-1])
+        self.scope_kinds.append("function")
+        for statement in node.body:
+            self.visit(statement)
+        self.scope_kinds.pop()
+        self.scope_parts.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+
+def _function_metrics(tree: ast.Module) -> list[dict[str, object]]:
+    visitor = _FunctionMetricVisitor()
+    visitor.visit(tree)
+    return sorted(
+        visitor.records,
+        key=lambda item: (int(item["line"]), str(item["qualified_name"])),
+    )
+
+
 def _analyze_module(path: str, data: bytes) -> dict[str, object]:
     source = _decode_source(data)
     module_name, is_package = _module_identity(path)
@@ -1007,6 +1071,7 @@ def _analyze_module(path: str, data: bytes) -> dict[str, object]:
         "is_package": is_package,
         "normalized_git_blob_sha1": _normalized_git_blob_sha1(data),
         "loc": len(source.splitlines()),
+        "functions": _function_metrics(tree),
         "top_level": {
             "function_count": function_count,
             "class_count": class_count,
@@ -1526,7 +1591,10 @@ def analyze_source_set(
             "encoding": "utf-8-sig",
             "newline_normalization": "CRLF and CR become LF before parsing and hashing",
             "path_format": "repository-relative POSIX",
-            "ordering": "paths, modules, edges, candidates, SCCs, and JSON keys are sorted",
+            "ordering": (
+                "paths, modules, functions, edges, candidates, SCCs, and JSON keys "
+                "are sorted"
+            ),
         },
         "inventory": {
             "module_count": len(shipped_paths),

--- a/tools/check_python_quality.ps1
+++ b/tools/check_python_quality.ps1
@@ -94,6 +94,13 @@ try {
     if ($importBoundaryExitCode -ne 0) {
         throw "Python import boundary gate failed with exit code $importBoundaryExitCode."
     }
+
+    Write-Host "`n== Python size/complexity ratchet (G-05A) =="
+    & $pythonCommand (Join-Path $PSScriptRoot "check_python_size_complexity.py")
+    $sizeComplexityExitCode = $LASTEXITCODE
+    if ($sizeComplexityExitCode -ne 0) {
+        throw "Python size/complexity ratchet failed with exit code $sizeComplexityExitCode."
+    }
 }
 finally {
     Set-Location -LiteralPath $originalLocation

--- a/tools/check_python_size_complexity.py
+++ b/tools/check_python_size_complexity.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Enforce the reviewed Python size and function-line growth ratchet.
+
+The checker consumes metrics from ``analyze_python_backend.py`` and a compact
+ledger of current threshold overages.  It does not maintain a second source
+inventory, import production modules, invoke Git, or write repository state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = Path(__file__).with_name("analyze_python_backend.py")
+DEFAULT_CONTRACT_PATH = (
+    REPOSITORY_ROOT
+    / "tests"
+    / "fixtures"
+    / "python_size_complexity_contract.v1.json"
+)
+CONTRACT_SCHEMA_VERSION = 1
+EXPECTED_THRESHOLDS = {
+    "adapter_module_lines": 400,
+    "function_lines": 120,
+    "module_lines": 800,
+}
+EXPECTED_ADAPTER_EXACT_PATHS = (
+    "__init__.py",
+    "api.py",
+    "easyuse_anima/bootstrap.py",
+    "easyuse_anima/registration.py",
+    "nodes.py",
+)
+EXPECTED_ADAPTER_PREFIXES = (
+    "easyuse_anima/api/",
+    "easyuse_anima/infrastructure/",
+    "easyuse_anima/nodes/",
+)
+
+
+class ContractError(ValueError):
+    """The checked-in size ledger is invalid or weaker than G-05A."""
+
+
+def _load_analyzer():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_python_backend_analyzer",
+        ANALYZER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyzer = _load_analyzer()
+
+
+def _require_sorted_unique_strings(values: object, *, field: str) -> tuple[str, ...]:
+    if not isinstance(values, list) or not all(
+        isinstance(value, str) and value for value in values
+    ):
+        raise ContractError(f"{field} must be a list of non-empty strings")
+    if values != sorted(set(values)):
+        raise ContractError(f"{field} must be sorted and unique")
+    return tuple(values)
+
+
+def _is_adapter_path(
+    path: str,
+    *,
+    exact_paths: Sequence[str],
+    prefixes: Sequence[str],
+) -> bool:
+    return path in exact_paths or path.startswith(tuple(prefixes))
+
+
+def _validate_exception_record(
+    record: object,
+    *,
+    function: bool,
+) -> dict[str, object]:
+    expected_keys = {
+        "baseline_loc",
+        "decomposition_boundary",
+        "owner_issue",
+        "path",
+    }
+    if function:
+        expected_keys.add("qualified_name")
+    if not isinstance(record, dict) or set(record) != expected_keys:
+        label = "function" if function else "module"
+        raise ContractError(f"{label} exception keys do not match the contract")
+
+    path = record["path"]
+    if not isinstance(path, str) or not path.endswith(".py"):
+        raise ContractError("exception path must be a production Python path")
+    if function:
+        qualified_name = record["qualified_name"]
+        if not isinstance(qualified_name, str) or not qualified_name:
+            raise ContractError("qualified_name must be a non-empty string")
+    baseline_loc = record["baseline_loc"]
+    if type(baseline_loc) is not int or baseline_loc <= 0:
+        raise ContractError("baseline_loc must be a positive integer")
+    owner_issue = record["owner_issue"]
+    if type(owner_issue) is not int or owner_issue <= 0:
+        raise ContractError("owner_issue must be a positive integer")
+    boundary = record["decomposition_boundary"]
+    if not isinstance(boundary, str) or len(boundary.strip()) < 20:
+        raise ContractError("decomposition_boundary must name a concrete boundary")
+    return dict(record)
+
+
+def validate_contract(document: object) -> dict[str, object]:
+    """Validate and normalize the reviewed G-05A ledger."""
+
+    expected_keys = {
+        "adapter_paths",
+        "function_exceptions",
+        "module_exceptions",
+        "schema_version",
+        "thresholds",
+    }
+    if not isinstance(document, dict) or set(document) != expected_keys:
+        raise ContractError("contract keys do not match the G-05A schema")
+    if (
+        type(document["schema_version"]) is not int
+        or document["schema_version"] != CONTRACT_SCHEMA_VERSION
+    ):
+        raise ContractError("unsupported size contract schema_version")
+    thresholds = document["thresholds"]
+    if (
+        not isinstance(thresholds, dict)
+        or any(type(value) is not int for value in thresholds.values())
+        or thresholds != EXPECTED_THRESHOLDS
+    ):
+        raise ContractError("size thresholds must remain 800/400/120 review triggers")
+
+    adapter_paths = document["adapter_paths"]
+    if not isinstance(adapter_paths, dict) or set(adapter_paths) != {
+        "exact",
+        "prefixes",
+    }:
+        raise ContractError("adapter_paths keys must be exactly exact and prefixes")
+    exact_paths = _require_sorted_unique_strings(
+        adapter_paths["exact"],
+        field="adapter_paths.exact",
+    )
+    prefixes = _require_sorted_unique_strings(
+        adapter_paths["prefixes"],
+        field="adapter_paths.prefixes",
+    )
+    if any(not path.endswith(".py") for path in exact_paths):
+        raise ContractError("adapter exact paths must end in .py")
+    if any(not prefix.endswith("/") for prefix in prefixes):
+        raise ContractError("adapter prefixes must end in /")
+    if any(path.startswith(tuple(prefixes)) for path in exact_paths):
+        raise ContractError("adapter exact paths must not duplicate a prefix")
+    if (
+        exact_paths != EXPECTED_ADAPTER_EXACT_PATHS
+        or prefixes != EXPECTED_ADAPTER_PREFIXES
+    ):
+        raise ContractError("adapter classification must match the reviewed G-05A set")
+
+    module_records = document["module_exceptions"]
+    function_records = document["function_exceptions"]
+    if not isinstance(module_records, list) or not isinstance(function_records, list):
+        raise ContractError("exception ledgers must be lists")
+    modules = [
+        _validate_exception_record(record, function=False)
+        for record in module_records
+    ]
+    functions = [
+        _validate_exception_record(record, function=True)
+        for record in function_records
+    ]
+    module_keys = [str(record["path"]) for record in modules]
+    function_keys = [
+        (str(record["path"]), str(record["qualified_name"]))
+        for record in functions
+    ]
+    if module_keys != sorted(set(module_keys)):
+        raise ContractError("module exceptions must be sorted and unique by path")
+    if function_keys != sorted(set(function_keys)):
+        raise ContractError(
+            "function exceptions must be sorted and unique by path and qualified_name"
+        )
+
+    for record in modules:
+        path = str(record["path"])
+        threshold = (
+            EXPECTED_THRESHOLDS["adapter_module_lines"]
+            if _is_adapter_path(path, exact_paths=exact_paths, prefixes=prefixes)
+            else EXPECTED_THRESHOLDS["module_lines"]
+        )
+        if int(record["baseline_loc"]) <= threshold:
+            raise ContractError("module exceptions must exceed their review threshold")
+    if any(
+        int(record["baseline_loc"]) <= EXPECTED_THRESHOLDS["function_lines"]
+        for record in functions
+    ):
+        raise ContractError("function exceptions must exceed the function threshold")
+
+    return {
+        "adapter_paths": {"exact": exact_paths, "prefixes": prefixes},
+        "function_exceptions": tuple(functions),
+        "module_exceptions": tuple(modules),
+        "schema_version": CONTRACT_SCHEMA_VERSION,
+        "thresholds": dict(EXPECTED_THRESHOLDS),
+    }
+
+
+def check_report(
+    report: Mapping[str, object],
+    contract: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Return deterministic overage-growth and stale-ledger violations."""
+
+    adapter_paths = contract["adapter_paths"]
+    exact_paths = tuple(adapter_paths["exact"])
+    prefixes = tuple(adapter_paths["prefixes"])
+    module_exceptions = {
+        str(record["path"]): record
+        for record in contract["module_exceptions"]
+    }
+    function_exceptions = {
+        (str(record["path"]), str(record["qualified_name"])): record
+        for record in contract["function_exceptions"]
+    }
+    modules = report["inventory"]["modules"]
+    modules_by_path = {str(module["path"]): module for module in modules}
+    functions_by_key = {
+        (str(module["path"]), str(function["qualified_name"])): function
+        for module in modules
+        for function in module["functions"]
+    }
+    violations: list[dict[str, object]] = []
+
+    for path, exception in module_exceptions.items():
+        if path not in modules_by_path:
+            violations.append(
+                {
+                    "rule": "stale-module-exception",
+                    "path": path,
+                    "symbol": "<module>",
+                    "current_loc": None,
+                    "baseline_loc": exception["baseline_loc"],
+                }
+            )
+    for key, exception in function_exceptions.items():
+        if key not in functions_by_key:
+            violations.append(
+                {
+                    "rule": "stale-function-exception",
+                    "path": key[0],
+                    "symbol": key[1],
+                    "current_loc": None,
+                    "baseline_loc": exception["baseline_loc"],
+                }
+            )
+
+    for path, module in modules_by_path.items():
+        threshold = (
+            EXPECTED_THRESHOLDS["adapter_module_lines"]
+            if _is_adapter_path(path, exact_paths=exact_paths, prefixes=prefixes)
+            else EXPECTED_THRESHOLDS["module_lines"]
+        )
+        current_loc = int(module["loc"])
+        if current_loc <= threshold:
+            continue
+        exception = module_exceptions.get(path)
+        if exception is None:
+            violations.append(
+                {
+                    "rule": "unreviewed-module-overage",
+                    "path": path,
+                    "symbol": "<module>",
+                    "current_loc": current_loc,
+                    "baseline_loc": threshold,
+                }
+            )
+        elif current_loc > int(exception["baseline_loc"]):
+            violations.append(
+                {
+                    "rule": "module-overage-growth",
+                    "path": path,
+                    "symbol": "<module>",
+                    "current_loc": current_loc,
+                    "baseline_loc": exception["baseline_loc"],
+                }
+            )
+
+    function_threshold = EXPECTED_THRESHOLDS["function_lines"]
+    for (path, qualified_name), function in functions_by_key.items():
+        current_loc = int(function["loc"])
+        if current_loc <= function_threshold:
+            continue
+        exception = function_exceptions.get((path, qualified_name))
+        if exception is None:
+            violations.append(
+                {
+                    "rule": "unreviewed-function-overage",
+                    "path": path,
+                    "symbol": qualified_name,
+                    "current_loc": current_loc,
+                    "baseline_loc": function_threshold,
+                }
+            )
+        elif current_loc > int(exception["baseline_loc"]):
+            violations.append(
+                {
+                    "rule": "function-overage-growth",
+                    "path": path,
+                    "symbol": qualified_name,
+                    "current_loc": current_loc,
+                    "baseline_loc": exception["baseline_loc"],
+                }
+            )
+
+    return sorted(
+        violations,
+        key=lambda item: (str(item["path"]), str(item["symbol"]), str(item["rule"])),
+    )
+
+
+def check_repository(
+    root: Path = REPOSITORY_ROOT,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> list[dict[str, object]]:
+    document = json.loads(contract_path.read_text(encoding="utf-8"))
+    contract = validate_contract(document)
+    return check_report(analyzer.analyze_repository(root), contract)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPOSITORY_ROOT)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT_PATH)
+    args = parser.parse_args(argv)
+
+    try:
+        violations = check_repository(args.root.resolve(), args.contract.resolve())
+    except (ContractError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Python size/complexity contract error: {error}", file=sys.stderr)
+        return 2
+    if violations:
+        for violation in violations:
+            print(
+                f"{violation['rule']}: {violation['path']}::"
+                f"{violation['symbol']} current={violation['current_loc']} "
+                f"baseline={violation['baseline_loc']}",
+                file=sys.stderr,
+            )
+        return 1
+    print("Python size/complexity ratchet passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 목적과 변경 경계

Issue #188 / G-05A의 production-free Contract/tool 작업입니다. 기존 AST-only backend analyzer를 유일한 inventory owner로 유지하면서, 새/변경 production module·function의 임계 초과 성장만 차단하는 reviewed ratchet를 추가합니다.

Base `e6d6a9cf04f3891fdd698914d15b9ccde57b9675` → Head `1b10e80607f5e7f9ae31efd557791f82bec34b46`

## 주요 변경

- analyzer schema 3에 decorator·method·nested·duplicate identity를 포함한 deterministic qualified function LOC metric 추가
- 현재 초과분 12 modules / 20 functions만 담는 compact owner ledger 추가
- 800 ordinary module / 400 adapter module / 120 function line trigger와 감소 수용·증가 차단·rename stale detection 고정
- 모든 reviewed exception에 owner issue와 구체 decomposition boundary 기록
- E-09 `bootstrap.initialize`는 #187 cohesive lifecycle exemption으로 고정
- ordinary Python quality runner에서 G-05A checker를 정확히 한 번 실행
- roadmap을 G-05A COMPLETE / G-06A READY로 전환

Production Python, public/root exports, routes, API payload, lifecycle, migration, release/Registry 상태는 변경하지 않습니다.

## 검증

- analyzer owner: 19 PASS
- size/complexity contract: 7 PASS
- completed import-boundary owner: 6 PASS
- runtime-state ownership: 7 PASS
- quality-runner contract: 7 PASS
- changed-file syntax/JSON/checker smoke: PASS
- 새 checker/tests targeted Ruff: PASS
- analyzer fixture projection 비교: 기존 import/state/side-effect/public/Registry evidence 보존, 1,217 function records 추가
- `git diff --check`: PASS
- official full at `1b10e80607f5e7f9ae31efd557791f82bec34b46`: 1,464 tests PASS; compile, Pyright baseline, import boundary, G-05A gate, frontend, diff PASS
- Ruff 140건은 기존 report-only baseline
- package/live: production/package/runtime surface 변경이 없어 미실행

## 위험과 rollback

가장 큰 review surface는 analyzer fixture의 deterministic function metric projection입니다. 별도 inventory는 없고, 기존 evidence가 그대로 보존됨을 비교했습니다. 향후 임계 초과 growth/Move는 같은 PR에서 해당 ledger record와 owner/decomposition evidence를 갱신해야 합니다.

Rollback은 이 Contract/tool squash commit 하나를 되돌리면 됩니다.

## Next

Issue #188 / G-06A canonical test-ownership Contract. P-API-02, D-14, release/tag/Registry는 계속 parked입니다.