### PR TITLE
docs: activate security/admin settings boundary lane

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,49 +12,45 @@ then only the active task section, owning Issue, direct source, and direct tests
 - Phase D root/package consolidation is complete.
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
   and Phase E runtime ownership/lifecycle/test isolation are complete.
-- D-14/Phase H root removal is correctly parked: all root surfaces remain retained by
-  production-import, release-window, consumer, rollback, or breaking-change gates.
-- [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md)
-  owns the current queue.
-- Phase F and Issue
-  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) / G-04 public
-  API snapshot coverage, G-05 size/complexity ratchet, and G-06 test ownership are
-  complete. G-CLOSE records zero unfinished executable Phase F/G tasks.
-- P-WC-01/P-WC-02 completed the Wildcard direct-shim conversion with the existing
-  canonical service owner. The final form has not shipped, so release N and removal
-  remain parked.
+- Phase F typed boundaries and Issue
+  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) G-04/G-05/G-06
+  quality gates are complete. G-CLOSE records zero unfinished executable Phase F/G
+  tasks.
+- P-WC-01/P-WC-02 completed the Wildcard direct-shim conversion.
 - P-API-01 / Issue
   [#582](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/582) completed with a
   **RETAIN** verdict. P-API-02 is not READY.
-- The completed evidence and revisit gates are recorded in
-  [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md)
-  and preserve the E-09 application/executor timing and root call-time seams.
-- First READY task: none. The next compatibility step is event-gated, not queued.
-- Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
-  remains the compatibility ledger. It owns pre-retirement evidence and later D-14
-  decisions, not an immediately executable deletion task.
+- D-14/Phase H root removal is correctly parked by production-import, release-window,
+  consumer, rollback, and breaking-change gates.
+- The completed compatibility lane is recorded in
+  [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md).
+- First READY independent task: Issue
+  [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01 host
+  capability and settings threat-model Contract.
+- [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md) owns that
+  active lane. It does not reopen Phase F/G, P-API-02, or D-14.
 - Released baseline: 0.6.2. Registry activation is external administration and does
   not block `dev`; do not republish or mutate the release.
 
 ```text
-COMPLETE Phase F typed-boundary and feature-error work
-  -> COMPLETE G-04A public API snapshot coverage audit
-  -> COMPLETE P-WC-01 Wildcard facade feasibility Contract
-  -> COMPLETE P-WC-02 Wildcard internal-consumer/facade Move
-  -> COMPLETE #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
-  -> PARKED P-API-02 until a recorded revisit event
-  -> COMPLETE G-05 size ratchet
-  -> COMPLETE G-06 test ownership
-  -> COMPLETE G-CLOSE Phase F/G completion audit
-  -> no READY Phase F/G task
-  -> next ordinary release N
+COMPLETE Phase D/E/F/G
+  -> COMPLETE P-WC direct-shim preparation
+  -> RETAIN P-API current root production facade
+  -> PARKED H/D-14 compatibility retirement
+
+READY #199 SEC-01 security/admin Contract
+  -> CONDITIONAL exact SEC-02
+  -> CONDITIONAL narrow implementation/audit
+
+EVENT next ordinary release N
   -> later H/D-14 re-audit
 ```
 
 ## Current code boundary
 
-The current backend is functional and validated. The API root surface is not yet a
-pure compatibility shim:
+The current backend is functional and validated.
+
+### Compatibility/lifecycle boundary
 
 - root `__init__.py` imports root `api.py` and passes `api.register_routes` into
   bootstrap initialization;
@@ -64,49 +60,61 @@ pure compatibility shim:
 - root `wildcard_engine.py` is an import-only compatibility shim over canonical
   Wildcard owners, but its final form has not shipped and release N has not begun.
 
-The API import order is part of the E-09 lifecycle contract, not merely a file-layout
-choice. Any candidate canonical owner must preserve one application/executor identity,
-executor-before-cleanup-plan timing, repeated initialize behavior, terminal shutdown,
-and late root-import safety without a canonical-to-root back-reference.
+The API import order is part of the E-09 lifecycle contract. Any future candidate must
+preserve one application/executor identity, executor-before-cleanup-plan timing,
+repeated initialize behavior, terminal shutdown, and late root-import safety without a
+canonical-to-root back-reference.
 
-Other final shim forms completed after 0.6.2 and therefore have no release N yet.
-Older direct/public shims may already satisfy a minimum version window, but absence of
-consumer evidence requires conservative retention under ADR-002.
+### Security/admin boundary
 
-This is not a test or Registry failure. It is an evidence-based compatibility stop.
-Root modules may remain indefinitely when their cost is low; deletion is not a measure
-of architectural success by itself.
+Current ComfyUI source provides user-profile selection, origin/host controls, and
+optional CORS, but no demonstrated authenticated administrator capability for
+custom-node routes. The `comfy-user` header is a user-data selector, not proof of
+administrator authority.
+
+Current EasyUseAnima settings routes read and mutate the settings projection. The
+projection contains ordinary UI choices together with local/network configuration,
+including `wildcard.extra_paths`, `naia.host`, `naia.port`, and
+`naia.allow_remote_api`.
+
+SEC-01 must classify deployment trust, route/field sensitivity, authorization owner,
+and logging/redaction before any access-control or diagnostics implementation. It must
+not assume `request.remote`, Host, Origin, `comfy-user`, or forwarded headers are
+administrator authentication.
 
 ## Core documents
 
+### Active
+
+- [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md):
+  Issue #199 deployment/threat matrix, host-capability audit, settings-field
+  classification, E-09 guard, verdicts, validation, and Codex start instruction.
+
+### Completed backend and compatibility plan
+
 - [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md):
-  active queue, pre-retirement feasibility, release N runway, D-14 triggers,
-  validation, and Codex start instruction.
+  completed Phase F/G plan, P-WC/P-API results, release-N runway, and D-14 event gates.
 - [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md):
-  mandatory P-API-01 creation-order, identity, terminal lifecycle, cleanup, rollback,
-  candidate, evidence, G-05/G-06, and release guardrails.
+  P-API creation-order, identity, terminal lifecycle, cleanup, rollback, RETAIN result,
+  and revisit events.
 - [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md):
   authoritative bootstrap lifecycle, fixed cleanup order, startup rollback, retained
   no-op boundaries, and terminal shutdown contract.
-- [`python-typed-boundary-f01-audit.md`](python-typed-boundary-f01-audit.md):
-  completed Phase F typed-boundary inventory and classifications.
-- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
-  completed public-surface owner map, root-name classifications, and no-G-04B decision.
-- [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md):
-  analyzer-owned line metrics, compact reviewed-overage ledger, and incremental growth
-  ratchet.
-- [`python-test-ownership-g06a-contract.md`](python-test-ownership-g06a-contract.md):
-  canonical package direct test owners and single-owner migration, package, and live
-  matrices.
 - [`python-phase-fg-completion-audit.md`](python-phase-fg-completion-audit.md):
-  final Phase F/G evidence reconciliation, zero-follow-up decision, and event-gated
-  compatibility handoff.
+  final Phase F/G evidence reconciliation and zero-follow-up decision.
+- [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md):
+  analyzer-owned line metrics and incremental growth ratchet.
+- [`python-test-ownership-g06a-contract.md`](python-test-ownership-g06a-contract.md):
+  canonical package direct test owners and shared matrix ownership.
+- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
+  completed public-surface owner map and no-G-04B decision.
 - [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md):
   FEASIBLE Wildcard direct-shim decision and P-WC-02 boundary.
-- [`python-feature-error-taxonomy-contract.md`](python-feature-error-taxonomy-contract.md):
-  executable error inventory, canonical categories, compatibility, and adapter authority.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 and Phase E execution record plus post-Phase-E D-14 verdict.
+
+### Target architecture and policy
+
 - [`python-backend.md`](python-backend.md): target ownership, phase definitions, and
   overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
@@ -117,30 +125,20 @@ of architectural success by itself.
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): support-window,
   evidence, staged-retirement, and public-breaking-change policy.
-- [`python-runtime-base-contract.md`](python-runtime-base-contract.md) and
-  [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md):
-  base runtime contract and process-state owner inventory.
-- Other completed Phase E feature/test contracts:
-  [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md),
-  [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md),
-  [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md),
-  [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md),
-  [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md), and
-  [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md).
 - [`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md):
   context budget, focused test ladder, evidence reuse, and reporting.
 
-## E-09 conflict guardrails for later phases
+## E-09 conflict guardrails
 
-- G-05 thresholds are review triggers and must not split the cohesive lifecycle owner,
-  lock, cleanup order, or rollback merely to reduce line counts.
-- G-06 keeps lifecycle integration evidence with bootstrap/runtime and must not add a
-  production reset API, production module reload, or private state mutation outside
-  `tests/runtime_test_support.py`.
-- Release/package shutdown evidence runs in a fresh process. Shutdown followed by
-  production reinitialize is not supported.
-- P-API must not create a second lock, atexit hook, application cleanup registry,
-  translation route executor, or runtime owner.
+- A security capability, when justified by a later Contract, is immutable process-start
+  configuration owned through RuntimeConfig/bootstrap.
+- It does not add a second lifecycle lock, atexit hook, shutdown/reset API, closeable
+  registry, or hot reinitialize behavior.
+- G-05 thresholds do not split the cohesive lifecycle owner merely to reduce line
+  counts.
+- G-06 keeps lifecycle integration evidence with bootstrap/runtime and does not add
+  production reload/reset behavior.
+- Release/package shutdown evidence runs in a fresh process.
 
 ## Cross-surface references
 
@@ -156,15 +154,15 @@ Read only when the task touches the surface:
 
 - Branch/release/validation policy: [`MAINTAINING.md`](../../MAINTAINING.md)
 - Development entrypoint: [`../development/README.md`](../development/README.md)
-- Completed Phase F/G plan and event gates: `post-phase-e-maintenance-roadmap.md`
-- P-API lifecycle compatibility: `python-api-papi01-e09-lifecycle-gate.md`
+- Active security/admin queue: `security-admin-settings-roadmap.md`
+- Completed Phase F/G and compatibility event gates: `post-phase-e-maintenance-roadmap.md`
 - Target architecture: `python-backend.md`, ADR-001, ADR-002
 - Feature behavior: owning Issue
 - Compatibility decisions: Issue #186 plus the shim registry
-- Quality ratchets: Issue #188
+- Security/admin settings boundary: Issue #199
 
 The efficiency protocol chooses the smallest sufficient evidence; it does not weaken
-correctness, compatibility, package, live, or release gates.
+correctness, compatibility, package, live, security, or release gates.
 
 No document in this directory authorizes root deletion, public breaking changes,
-release publication, tags, or Registry actions by itself.
+release publication, tags, Registry actions, or an authentication mechanism by itself.

--- a/docs/architecture/security-admin-settings-roadmap.md
+++ b/docs/architecture/security-admin-settings-roadmap.md
@@ -1,0 +1,285 @@
+# Security/Admin Settings Boundary Roadmap
+
+## Status and authority
+
+- Status: active independent maintenance lane after Phase F/G completion.
+- Owner: Issue #199.
+- First READY task: SEC-01 host capability and threat-model Contract.
+- Released baseline: 0.6.2.
+- This lane does not reopen Phase F/G, P-API-02, D-14, or Phase H.
+- Type: Security/Admin Contract first; no production behavior change before the
+  access owner and deployment model are fixed.
+
+## 1. Why this is the next executable lane
+
+The completed backend roadmap is correctly event-gated:
+
+```text
+Phase F/G complete
+P-API-01 RETAIN
+D-14/H waiting for release/consumer events
+```
+
+That state does not prohibit an independent security task with its own owner and
+rollback boundary. Issue #199 is P2 and is not dependent on a root-shim removal event.
+It therefore becomes the next bounded maintenance lane without pretending that an
+H/D-14 task is READY.
+
+## 2. Current evidence
+
+### ComfyUI host boundary
+
+Current ComfyUI source exposes a `UserManager`, but its multi-user request identity is
+selected by the client-provided `comfy-user` header. It validates that the selected ID
+exists; it does not authenticate the caller or assign an administrator role.
+
+The PromptServer middleware provides cache handling, deprecation warnings, optional
+CORS, an origin/host check for loopback browser requests, and optional Manager
+middleware. These are useful request-origin controls but do not establish an
+authenticated administrator capability for custom-node routes.
+
+Consequences:
+
+- `comfy-user` is a storage/profile selector, not authentication;
+- origin/host checks are not authorization;
+- `request.remote` is not sufficient behind reverse proxies;
+- arbitrary `X-Forwarded-*` or custom headers are not trusted unless a reviewed proxy
+  owner verifies and strips client-supplied values;
+- EasyUseAnima must not assume a host admin API that has not been demonstrated.
+
+### EasyUseAnima settings boundary
+
+Current EasyUseAnima settings routes:
+
+```text
+GET  /easyuse_anima/settings
+POST /easyuse_anima/set_setting
+```
+
+The GET route returns `public_settings()` and the POST route writes a known setting,
+then returns the same projection. The current projection includes values such as:
+
+```text
+wildcard.extra_paths
+naia.host
+naia.port
+naia.allow_remote_api
+naia.pre_prompt
+naia.post_prompt
+```
+
+This is a configuration surface, not a diagnostics-only endpoint. SEC-01 must decide
+whether the whole surface is intentionally trusted with the ComfyUI UI, or whether
+safe UI settings and sensitive local/admin configuration require separate access
+contracts.
+
+## 3. Deployment models to classify
+
+SEC-01 must classify each model rather than designing only for localhost:
+
+1. single-user direct loopback;
+2. LAN or remote direct bind;
+3. reverse proxy without authentication;
+4. reverse proxy with externally enforced authentication;
+5. ComfyUI `--multi-user` profile selection;
+6. managed/multi-tenant deployment where custom-node routes are reachable by users.
+
+For each model record:
+
+- caller trust assumption;
+- source of authenticated identity, if any;
+- whether forwarded headers are trusted and by whom;
+- whether settings read, settings mutation, and local path diagnostics are allowed;
+- whether the model is supported, conditionally supported, or explicitly unsupported.
+
+## 4. SEC-01 — Host capability and threat-model Contract
+
+Type: production-free Contract/gate.
+
+### Required inventory
+
+- current ComfyUI middleware, user-manager, request and route extension surfaces;
+- current EasyUseAnima settings/status/wildcard/autocomplete routes;
+- every setting or response field that contains a filesystem path, host/port, remote
+  enable flag, user-authored prompt text, or other local configuration;
+- frontend consumers of those fields;
+- logging and request-ID/error paths that could disclose a capability, raw path, or
+  secret header;
+- RuntimeConfig/bootstrap seams that could own process-start configuration without
+  creating a second lifecycle owner.
+
+### Required classifications
+
+Every relevant route and field is classified as one of:
+
+```text
+ordinary redacted status
+safe UI configuration
+sensitive local configuration
+administrator diagnostics
+secret/capability material
+```
+
+Do not classify all settings as sensitive merely because they are persisted. Base the
+classification on actual disclosure or mutation impact.
+
+### Trust rules
+
+SEC-01 must preserve these defaults:
+
+- no authenticated host capability is assumed without primary-source evidence;
+- `comfy-user`, `request.remote`, Host, Origin, and forwarded headers do not individually
+  prove administrator authority;
+- ordinary status/search/classify/wildcard responses remain redacted even for an
+  authorized diagnostic caller;
+- no capability or token is stored in ordinary EasyUseAnima settings;
+- no token is accepted in a query string or JSON body;
+- no token, raw path, or secret header appears in error payloads, request-ID logs,
+  access logs, or debug output;
+- a diagnostics endpoint is absent by default; when disabled it should not reveal that
+  a capability exists;
+- no outbound telemetry or noisy import-time warning is introduced.
+
+### E-09 lifecycle guard
+
+If SEC-01 concludes that an EasyUseAnima-owned process capability is required, the
+future owner must satisfy all of the following:
+
+- process-start configuration is loaded by RuntimeConfig/bootstrap before route use;
+- bootstrap remains the single lifecycle owner;
+- no second lock, atexit hook, shutdown/reset API, mutable application registry, or hot
+  reinitialize behavior is added;
+- the capability is immutable for the process lifetime unless a separate Behavior
+  Contract explicitly changes E-09;
+- no close operation is invented for immutable capability data;
+- package/no-host import remains safe when the capability is absent.
+
+SEC-01 does not implement that owner.
+
+## 5. Allowed SEC-01 verdicts
+
+The audit must return exactly one primary verdict.
+
+### HOST_CAPABILITY
+
+Use only when a stable ComfyUI authenticated-admin contract is proven and available to
+custom-node routes. Record the exact API, supported versions, failure behavior, and
+fallback when unavailable.
+
+### PROCESS_CAPABILITY
+
+Use when a dedicated EasyUseAnima process-start capability is necessary and can be
+owned by RuntimeConfig/bootstrap without weakening E-09. Produce one bounded SEC-02
+Contract card; do not implement a token in SEC-01.
+
+### TRUSTED_DEPLOYMENT_ONLY
+
+Use when the settings/configuration API should remain inside the same trusted boundary
+as the ComfyUI server and no safe in-process administrator capability is justified.
+Record supported deployment assumptions, required external authentication for remote
+exposure, and any field-level redaction or route split still needed.
+
+### NO_DIAGNOSTICS
+
+Use when no reliable authorization owner exists and path diagnostics provide
+insufficient benefit. Keep diagnostics unavailable and identify only independent
+settings-hardening work, if any.
+
+A combined result may include one primary verdict plus an exact field-level follow-up,
+but must not leave multiple mutually exclusive access models for implementation to
+choose later.
+
+## 6. Conditional follow-up queue
+
+No task after SEC-01 is automatically READY.
+
+```text
+READY       SEC-01 threat model / capability owner / field classification
+CONDITIONAL SEC-02 exact access and response Contract
+CONDITIONAL SEC-03 narrow backend implementation
+CONDITIONAL SEC-04 frontend settings migration, only if UI behavior changes
+CONDITIONAL SEC-05 security/package/live completion audit
+```
+
+Examples of valid SEC-02 boundaries:
+
+- split safe settings projection from sensitive configuration;
+- guard sensitive mutation without changing ordinary status routes;
+- add a disabled-by-default diagnostics route with an already approved owner;
+- document trusted external-auth deployment and remove an unjustified internal
+  diagnostics proposal.
+
+Do not combine all examples into one implementation.
+
+## 7. Validation
+
+### SEC-01
+
+- direct source and route-consumer inventory;
+- focused settings/API/redaction/security contract tests already present;
+- source/fixture consistency and `git diff --check`;
+- official full only when a test/tool/shared fixture changes;
+- no package/live for a docs-only Contract.
+
+### Future backend implementation
+
+Run only when triggered by the selected contract:
+
+- direct route and settings persistence tests;
+- disabled/wrong/correct capability cases, when a capability exists;
+- loopback/direct-remote/forwarded/reverse-proxy cases fixed by deterministic request
+  fixtures;
+- error/log redaction and `Cache-Control: no-store` where appropriate;
+- package/no-host import and E-09 lifecycle regression;
+- isolated live HTTP smoke for the changed backend surface;
+- browser smoke only when the settings UI or interaction changes.
+
+## 8. Stop and PRO conditions
+
+Codex handles ordinary inventory, threat-model writing, field classification, and
+focused test work without PRO review.
+
+Request focused technical PRO review only when primary-source evidence leaves multiple
+security architectures that are all viable, for example:
+
+- two host/proxy capability models with materially different trust guarantees;
+- a capability owner cannot be selected without changing E-09 lifecycle semantics;
+- a reverse-proxy trust contract requires subtle header normalization or spoofing
+  analysis beyond the bounded route owner;
+- a settings split creates unavoidable compatibility or data-migration alternatives;
+- logging/redaction guarantees cannot be proven across several independent owners.
+
+User preference is not used as a substitute for security evidence. A missing host
+admin capability by itself is not a PRO blocker; it is an input to the SEC-01 verdict.
+
+## 9. Codex resume instruction
+
+```text
+Start Issue #199 / SEC-01 from latest origin/dev.
+
+Read only:
+- current-policies.md
+- codex-execution-efficiency.md universal rules
+- this document
+- Issue #199 latest checkpoint
+- current EasyUseAnima settings/status/wildcard/autocomplete route owners and direct tests
+- current settings public projection and frontend consumers
+- current ComfyUI PromptServer middleware and UserManager primary source
+- E-09 lifecycle Contract only for the process-capability guard
+
+Do not reopen Phase F/G, P-API-02, D-14, release, or Registry work.
+Do not implement authentication, a token, a diagnostics route, or a settings split in
+SEC-01.
+
+Produce:
+- deployment/threat matrix
+- route/field sensitivity inventory
+- host capability verdict
+- logging/redaction contract
+- one primary verdict: HOST_CAPABILITY, PROCESS_CAPABILITY,
+  TRUSTED_DEPLOYMENT_ONLY, or NO_DIAGNOSTICS
+- exact SEC-02 task card only when implementation is justified
+
+Reuse existing deterministic tests. Add a fixture only for a real unowned contract.
+Package/live are not triggered by a docs-only SEC-01 result.
+```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,35 +11,31 @@ Read only the sections needed by the active task.
    - use focused edit-loop tests;
    - run official full once on the final candidate SHA;
    - run package/live/benchmark only when triggered.
-3. Current backend queue:
+3. Active independent maintenance lane:
+   [`../architecture/security-admin-settings-roadmap.md`](../architecture/security-admin-settings-roadmap.md)
+   - first READY task: Issue #199 / SEC-01 host capability and threat-model Contract;
+   - SEC-01 is production-free and must not implement authentication, a token,
+     diagnostics, or a settings split.
+4. Completed backend and compatibility state:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - Phase F/G and G-CLOSE are complete; there is no READY maintenance task;
-   - D-14/H root removal is parked, not failed.
-4. Mandatory P-API lifecycle gate:
+   - Phase F/G and G-CLOSE are complete; there is no READY Phase F/G task;
+   - D-14/H root removal and P-API-02 are event-gated, not failed.
+5. E-09/P-API compatibility gate:
    [`../architecture/python-api-papi01-e09-lifecycle-gate.md`](../architecture/python-api-papi01-e09-lifecycle-gate.md)
    - preserve one bootstrap lifecycle owner, terminal shutdown, translation-executor
      identity, fixed cleanup order, rollback, and late root-import behavior;
-   - P-API-01 completed with RETAIN; P-API-02 remains parked until a recorded revisit event.
-5. Backend target architecture and compatibility policy:
+   - P-API-01 completed with RETAIN; #199 may use RuntimeConfig/bootstrap only as an
+     immutable process-capability owner and must not add another lifecycle owner.
+6. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
-6. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
+7. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner architecture ambiguity. Ordinary
    implementation and test failures remain local task work.
-7. Read a topic guide only when the active task touches it:
+8. Read a topic guide only when the active task touches it:
    - completed D/E execution record: `../architecture/backend-roadmap-resume-0.6.2.md`
-   - F-01 typed-boundary audit: `../architecture/python-typed-boundary-f01-audit.md`
    - Phase F/G completion audit: `../architecture/python-phase-fg-completion-audit.md`
-   - feature error taxonomy: `../architecture/python-feature-error-taxonomy-contract.md`
-   - runtime base/state inventory: `../architecture/python-runtime-base-contract.md`,
-     `../architecture/python-runtime-state-inventory.md`
-   - repository/filesystem runtime contract: `../architecture/python-runtime-e03-repository-filesystem-contract.md`
-   - translation runtime contract: `../architecture/python-runtime-e04-translation-contract.md`
-   - Autocomplete runtime contract: `../architecture/python-runtime-e05-autocomplete-contract.md`
-   - Wildcard runtime contract: `../architecture/python-runtime-e06-wildcard-contract.md`
-   - Wildcard facade feasibility: `../architecture/python-wildcard-pwc01-facade-feasibility.md`
-   - AiO cache runtime contract: `../architecture/python-runtime-e08-aio-cache-contract.md`
+   - security/admin settings boundary: `../architecture/security-admin-settings-roadmap.md`
    - lifecycle runtime contract: `../architecture/python-runtime-e09-lifecycle-contract.md`
-   - test-isolation runtime contract: `../architecture/python-runtime-e10-test-isolation-contract.md`
    - compatibility registry: `../architecture/python-compatibility-shims.md`
    - queue identity: `../architecture/queue-ui-two-phase-correlation-addendum.md`
    - Prompt Studio execution projection: `../architecture/prompt-studio-execution-derived-projection.md`
@@ -48,7 +44,7 @@ Read only the sections needed by the active task.
    - Registry scanner prevention for a future release:
      [`docs/development/registry-scanner-safety.md`](registry-scanner-safety.md)
    - workflows: `../Anima AiO/Workflow_Management.md`
-8. Confirm `git status --short`, current branch/worktree, direct source, and direct
+9. Confirm `git status --short`, current branch/worktree, direct source, and direct
    tests.
 
 Do not read every roadmap, closed Issue, or historical PR. Registry activation is
@@ -60,21 +56,16 @@ ordinary `dev` work.
 ```text
 COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
+COMPLETE  Phase F typed boundaries and feature errors
+COMPLETE  G-04 public API / G-05 size ratchet / G-06 test ownership
+COMPLETE  G-CLOSE Phase F/G completion audit
+RETAIN    P-API-01; P-API-02 parked
 PARKED    D-14 / Phase H root removal
-COMPLETE  #563 Phase F typed-boundary and feature-error work
-COMPLETE  #188 G-04 public API snapshot coverage audit
-COMPLETE  #186 P-WC-01 Wildcard facade feasibility Contract
-COMPLETE  #186 P-WC-02 Wildcard direct-shim Move
-COMPLETE  #582 P-API-01 API facade / E-09 lifecycle Contract (RETAIN)
-PARKED    P-API-02 until a recorded revisit event
-COMPLETE  #188 G-05 size ratchet
-COMPLETE  #188 G-06 test ownership
-COMPLETE  #188 G-CLOSE Phase F/G completion audit
-NONE      no READY Phase F/G task
+READY     #199 SEC-01 security/admin host-capability Contract
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
-The D-14 stop is correct:
+The original backend stop is correct:
 
 - root `__init__.py` still imports root `api.py` for production registration;
 - root `api.py` remains a production route/payload/runtime facade;
@@ -82,34 +73,45 @@ The D-14 stop is correct:
 - final forms completed after 0.6.2 have no release N;
 - consumer evidence and public breaking-change approval do not support removal.
 
-That stop is an event-gated compatibility state, not an unfinished Phase F/G task.
+That stop applies to the completed compatibility lane. It does not block the separate
+Issue #199 security/admin Contract.
 
-## Completed P-API-01 result
+## Active SEC-01 boundary
 
-The completed evidence is intentionally narrow:
+Current primary-source evidence must be treated as follows:
+
+- ComfyUI `comfy-user` selects a user profile; it is not authenticated administrator
+  identity;
+- origin/host and CORS middleware are request-origin controls, not authorization;
+- `request.remote`, Host, Origin, or forwarded headers alone do not prove authority;
+- EasyUseAnima `GET /settings` returns the current public settings projection and
+  `POST /set_setting` mutates a known setting;
+- the projection currently contains local/network configuration such as
+  `wildcard.extra_paths`, `naia.host`, `naia.port`, and `naia.allow_remote_api`.
+
+SEC-01 must produce:
 
 ```text
-Issue #582 and #186 final P-API-01 checkpoints
-python-api-papi01-e09-lifecycle-gate.md  # RETAIN decision and revisit events
-test_python_api_facade_lifecycle_contract.py  # package -> late api identity proof
-existing E-09, route-owner, compatibility, import, and package/no-host owners
+deployment/threat matrix
+route and field sensitivity inventory
+host capability verdict
+logging/redaction contract
+one primary verdict
+exact SEC-02 task card only when justified
 ```
 
-P-API-01 confirmed the current order:
+Allowed primary verdicts:
 
 ```text
-import root api.py
-  -> create translation route executor/application
-  -> bootstrap.initialize(register_routes)
-  -> freeze RuntimeServices cleanup plan
+HOST_CAPABILITY
+PROCESS_CAPABILITY
+TRUSTED_DEPLOYMENT_ONLY
+NO_DIAGNOSTICS
 ```
 
-The canonical-application and bootstrap-owned-application shapes cannot preserve both
-the pre-cleanup-plan executor timing and all registration/request-time root callback
-seams without a back-reference, second mutable owner, or separate Behavior Contract.
-The retained-root shape is the only candidate that satisfies every current gate.
-
-P-API-01 made no production change and does not authorize the Move.
+SEC-01 must not add a token, diagnostics endpoint, settings split, authentication
+middleware, or frontend migration. It must not trust `comfy-user` or proxy headers as
+admin identity.
 
 ## E-09 non-regression summary
 
@@ -120,22 +122,23 @@ P-API-01 made no production change and does not authorize the Move.
 - translation route executor is unique and cleanup item 1;
 - seven-step cleanup order and expected-identity rollback remain fixed;
 - routes/marker remain installed; file-I/O limiters and provider clients are not closed;
-- no API application reset/close registry, second lock, second atexit, or production
-  module reload is added.
+- no API application or security capability may add a reset/close registry, second
+  lock, second atexit, or production module reload.
+
+If a later SEC task needs an EasyUseAnima-owned capability, it must be immutable
+process-start configuration loaded by RuntimeConfig/bootstrap. SEC-01 only decides
+whether that owner is justified.
 
 ## Following state
 
-After P-API-01, G-05A, G-06A, and G-CLOSE:
+After SEC-01:
 
-1. run one bounded P-API-02 only when the verdict is FEASIBLE;
-2. retain the recorded P-API verdict and completed G-05/G-06 gates;
-3. do not create another Phase F/G task without a new concrete finding;
+1. create exactly one bounded SEC-02 only when the verdict proves implementation is
+   needed;
+2. keep diagnostics absent by default when no reliable authorization owner exists;
+3. do not reopen Phase F/G, P-API-02, or D-14 as a side effect;
 4. let the next ordinary release containing final shims become release N;
 5. re-audit D-14 only after an event gate changes.
-
-G-05 must not split E-09 lifecycle ownership merely to satisfy a line threshold. G-06
-must not add production reset APIs, `importlib.reload()` lifecycle tests, or private
-runtime mutation outside `tests/runtime_test_support.py`.
 
 No dedicated release, outbound telemetry, import-time deprecation warning, or public
 root removal is authorized by this queue.
@@ -161,18 +164,17 @@ command.
 - Documentation-only changes reuse the latest valid code evidence.
 - Run package validation only for import/registration/archive/dependency/release
   closure changes.
-- Run live ComfyUI only for host-visible behavior.
-- Release lifecycle smoke uses a fresh process for terminal shutdown; shutdown followed
-  by production reinitialize is not a supported gate.
-- Run benchmark only for performance/output-quality policy.
+- Run isolated HTTP live smoke for a later backend security behavior change.
+- Run browser smoke only when settings UI behavior changes.
+- Release lifecycle smoke uses a fresh process; shutdown followed by production
+  reinitialize is not a supported gate.
 
 ## Technical PRO boundary
 
-Request focused technical PRO review only when direct evidence leaves multiple valid
-cross-boundary designs, an import cycle cannot be avoided by the existing injection
-pattern, translation-executor identity cannot precede cleanup-plan creation without a
-new lifecycle mechanism, or compatibility evidence cannot distinguish public support
-from test-only seams. User preference is not a substitute for technical analysis.
+Request focused technical PRO review only when primary-source evidence leaves multiple
+viable security architectures with materially different trust guarantees, a capability
+owner would require changing E-09 lifecycle semantics, or proxy/header normalization
+cannot be resolved within the bounded route owner.
 
-Routine test failures, helper layout, type annotation choices, and owner-local
-implementation decisions remain with Codex.
+A missing ComfyUI admin capability, ordinary test failure, field classification, helper
+layout, and owner-local implementation choices remain with Codex.


### PR DESCRIPTION
## 목적

Phase F/G와 G-CLOSE 완료, P-API-01 RETAIN, D-14/H event-gated 상태를 그대로 유지하면서 독립적인 P2 Security/Admin 작업인 Issue #199를 다음 실행 lane으로 고정합니다.

Base: `dev@0fbaacf43d1713c685e79165b3013b29cf445cc2`

## 확인한 현재 경계

- ComfyUI `UserManager`의 `comfy-user` header는 profile selector이며 authenticated admin identity가 아닙니다.
- PromptServer의 origin/host/CORS middleware는 request-origin control이지 custom-node route authorization이 아닙니다.
- EasyUseAnima `GET /settings`와 `POST /set_setting`은 현재 인증 owner 없이 설정 projection을 읽고 변경합니다.
- projection에는 `wildcard.extra_paths`, `naia.host`, `naia.port`, `naia.allow_remote_api` 같은 local/network configuration이 포함됩니다.

## 변경

- `docs/architecture/security-admin-settings-roadmap.md` 추가
  - deployment/threat matrix
  - host capability audit
  - route/field sensitivity classification
  - logging/redaction rules
  - E-09 lifecycle guard
  - SEC-01 verdicts와 conditional follow-up
  - Codex resume instruction
- architecture/development entrypoint를 Issue #199 / SEC-01로 갱신
- completed F/G/P-API/D-14 상태와 release-N event gate는 유지

## 첫 작업

`SEC-01`은 production-free Contract입니다. 다음 중 하나의 primary verdict만 선택합니다.

```text
HOST_CAPABILITY
PROCESS_CAPABILITY
TRUSTED_DEPLOYMENT_ONLY
NO_DIAGNOSTICS
```

SEC-01에서는 인증, token, diagnostics endpoint, settings split, frontend migration을 구현하지 않습니다.

## E-09 보존

향후 process capability가 필요하더라도 RuntimeConfig/bootstrap의 immutable process-start config로만 설계하며, second lock/atexit/shutdown/reset/close registry/hot reinitialize를 추가하지 않습니다.

## 범위와 검증

Docs-only 3 files입니다.

- production/test/tool/fixture/workflow/version/release artifact 변경 없음
- official full/package/live 미실행
- Registry/release/root-removal 작업 없음

Refs #199
Refs #185
Refs #187