### PR TITLE
[SEC-01] Define trusted deployment security contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,9 +24,9 @@ then only the active task section, owning Issue, direct source, and direct tests
   consumer, rollback, and breaking-change gates.
 - The completed compatibility lane is recorded in
   [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md).
-- First READY independent task: Issue
-  [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01 host
-  capability and settings threat-model Contract.
+- Issue [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01
+  completed with **TRUSTED_DEPLOYMENT_ONLY**. The first READY task is SEC-02
+  response-confidentiality Contract.
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md) owns that
   active lane. It does not reopen Phase F/G, P-API-02, or D-14.
 - Released baseline: 0.6.2. Registry activation is external administration and does
@@ -38,8 +38,8 @@ COMPLETE Phase D/E/F/G
   -> RETAIN P-API current root production facade
   -> PARKED H/D-14 compatibility retirement
 
-READY #199 SEC-01 security/admin Contract
-  -> CONDITIONAL exact SEC-02
+COMPLETE #199 SEC-01 security/admin Contract
+  -> READY SEC-02 response-confidentiality Contract
   -> CONDITIONAL narrow implementation/audit
 
 EVENT next ordinary release N
@@ -77,18 +77,24 @@ projection contains ordinary UI choices together with local/network configuratio
 including `wildcard.extra_paths`, `naia.host`, `naia.port`, and
 `naia.allow_remote_api`.
 
-SEC-01 must classify deployment trust, route/field sensitivity, authorization owner,
-and logging/redaction before any access-control or diagnostics implementation. It must
-not assume `request.remote`, Host, Origin, `comfy-user`, or forwarded headers are
-administrator authentication.
+[`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md)
+classifies the surface as **TRUSTED_DEPLOYMENT_ONLY**. `comfy-user`, `request.remote`,
+Host, Origin, and forwarded headers are not administrator authentication. The current
+settings UI remains inside one trusted-operator boundary, diagnostics remain absent,
+and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 owns only the
+exact response-confidentiality Contract for safe unexpected-error logging and
+`Cache-Control: no-store` on sensitive settings responses.
 
 ## Core documents
 
 ### Active
 
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md):
-  Issue #199 deployment/threat matrix, host-capability audit, settings-field
-  classification, E-09 guard, verdicts, validation, and Codex start instruction.
+  Issue #199 queue, validation, and exact SEC-02 resume card.
+- [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md):
+  completed deployment/threat matrix, host-capability audit, settings-field
+  classification, logging/redaction Contract, E-09 disposition, and
+  TRUSTED_DEPLOYMENT_ONLY verdict.
 
 ### Completed backend and compatibility plan
 

--- a/docs/architecture/security-admin-settings-roadmap.md
+++ b/docs/architecture/security-admin-settings-roadmap.md
@@ -4,7 +4,10 @@
 
 - Status: active independent maintenance lane after Phase F/G completion.
 - Owner: Issue #199.
-- First READY task: SEC-01 host capability and threat-model Contract.
+- SEC-01 host capability and threat-model Contract: complete with
+  **TRUSTED_DEPLOYMENT_ONLY**; see
+  [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md).
+- First READY task: SEC-02 response-confidentiality Contract.
 - Released baseline: 0.6.2.
 - This lane does not reopen Phase F/G, P-API-02, D-14, or Phase H.
 - Type: Security/Admin Contract first; no production behavior change before the
@@ -160,6 +163,12 @@ SEC-01 does not implement that owner.
 
 The audit must return exactly one primary verdict.
 
+SEC-01 selected **TRUSTED_DEPLOYMENT_ONLY**. No host administrator capability was
+proven, and conveying a process capability to the current browser UI would require a
+new authentication or gateway design. Administrator diagnostics remain absent. The
+current mixed settings projection stays within one trusted-operator deployment
+boundary; ordinary wildcard/autocomplete endpoints stay redacted.
+
 ### HOST_CAPABILITY
 
 Use only when a stable ComfyUI authenticated-admin contract is proven and available to
@@ -194,12 +203,18 @@ choose later.
 No task after SEC-01 is automatically READY.
 
 ```text
-READY       SEC-01 threat model / capability owner / field classification
-CONDITIONAL SEC-02 exact access and response Contract
+COMPLETE    SEC-01 threat model / capability owner / field classification
+READY       SEC-02 response-confidentiality Contract
 CONDITIONAL SEC-03 narrow backend implementation
 CONDITIONAL SEC-04 frontend settings migration, only if UI behavior changes
 CONDITIONAL SEC-05 security/package/live completion audit
 ```
+
+SEC-02 is justified by two directly observed response-confidentiality gaps: the shared
+unexpected-error correlator uses traceback-bearing exception logging, and the four
+sensitive settings read/mutation responses do not own an explicit
+`Cache-Control: no-store` contract. SEC-02 does not reconsider authentication,
+capability ownership, a diagnostics route, or a settings split.
 
 Examples of valid SEC-02 boundaries:
 
@@ -252,34 +267,89 @@ security architectures that are all viable, for example:
 User preference is not used as a substitute for security evidence. A missing host
 admin capability by itself is not a PRO blocker; it is an input to the SEC-01 verdict.
 
-## 9. Codex resume instruction
+## 9. SEC-02 task card and Codex resume instruction
 
 ```text
-Start Issue #199 / SEC-01 from latest origin/dev.
+Task / Issue:
+Issue #199 / SEC-02 response-confidentiality Contract
+
+Base SHA:
+Latest origin/dev after the SEC-01 Contract PR.
+
+Goal:
+Write the exact executable Contract for:
+1. sanitizing the shared unexpected-error request-correlation log so it contains only
+   the correlated request ID and a fixed event/category; and
+2. Cache-Control: no-store on GET /settings, POST /set_setting,
+   GET /long_text_settings, and POST /long_text_settings/save.
+Produce exactly one bounded SEC-03 implementation card only if the two requirements
+can remain inside their direct response owners.
+
+Allowed files:
+- docs/architecture/security-admin-settings-sec02-response-contract.md
+- docs/architecture/security-admin-settings-sec01-contract.md
+- docs/architecture/security-admin-settings-roadmap.md
+- docs/architecture/README.md
+- docs/development/README.md
+
+Production, test, tool, and fixture changes are forbidden in SEC-02.
 
 Read only:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document
 - Issue #199 latest checkpoint
-- current EasyUseAnima settings/status/wildcard/autocomplete route owners and direct tests
-- current settings public projection and frontend consumers
-- current ComfyUI PromptServer middleware and UserManager primary source
-- E-09 lifecycle Contract only for the process-capability guard
+- security-admin-settings-sec01-contract.md
+- easyuse_anima/api/responses.py
+- settings.py and long_text_settings.py direct response owners
+- ApiRequestCorrelationTests, ApiSettingsRouteTests,
+  ApiLongTextSettingsRouteTests, and ApiPathRedactionTests
 
-Do not reopen Phase F/G, P-API-02, D-14, release, or Registry work.
-Do not implement authentication, a token, a diagnostics route, or a settings split in
-SEC-01.
+Preserve:
+- response status/body/request-ID/header behavior;
+- CancelledError and aiohttp HTTPException control flow;
+- handler identity, route order/signature/registration, and repeated initialize;
+- all E-09 lifecycle invariants;
+- current settings fields, storage, projection, and frontend behavior;
+- ordinary wildcard/autocomplete redaction.
 
-Produce:
-- deployment/threat matrix
-- route/field sensitivity inventory
-- host capability verdict
-- logging/redaction contract
-- one primary verdict: HOST_CAPABILITY, PROCESS_CAPABILITY,
-  TRUSTED_DEPLOYMENT_ONLY, or NO_DIAGNOSTICS
-- exact SEC-02 task card only when implementation is justified
+Forbidden changes:
+- authentication, token/capability, proxy/header trust, diagnostics endpoint;
+- settings split, schema/persistence/migration, frontend behavior;
+- global ComfyUI/access-log configuration or middleware;
+- RuntimeConfig/bootstrap/lifecycle/reset/shutdown changes;
+- broad logger refactor or unrelated API cleanup.
 
-Reuse existing deterministic tests. Add a fixture only for a real unowned contract.
-Package/live are not triggered by a docs-only SEC-01 result.
+Focused evidence, one target per runner:
+- ApiRequestCorrelationTests: correlation and safe unexpected-error behavior;
+- ApiSettingsRouteTests: settings response and failure behavior;
+- ApiLongTextSettingsRouteTests: long-text response behavior;
+- ApiPathRedactionTests: ordinary endpoint path redaction;
+- source/Contract consistency and git diff --check.
+
+Promotion gates:
+Docs-only SEC-02 does not run official full, package, live HTTP, or browser checks.
+The SEC-03 card must require official full once on its final candidate SHA. It may
+reuse package/no-host evidence when only the direct response owners change. No live
+or browser smoke is triggered for a pure log/header change; trigger isolated live HTTP
+only if status/body/request-ID behavior or host logger integration changes, and browser
+only if frontend files or interaction change.
+
+Rollback boundary:
+Revert the SEC-02 documentation PR. There is no runtime state, storage, schema, or
+migration rollback.
+
+Stop conditions:
+- safe logging requires global ComfyUI/access/proxy logger changes;
+- no-store cannot be attached without changing public response semantics;
+- proxy-header trust or a capability owner becomes necessary;
+- any E-09 lifecycle or frontend/settings migration change is required.
+
+Next:
+SEC-03 narrow backend implementation only after this Contract proves one bounded
+owner set. SEC-04/SEC-05 remain conditional. D-14, release, tag, and Registry remain
+blocked.
+
+Reuse existing deterministic tests. Add no fixture unless the response Contract cannot
+be represented by the existing direct owner tests.
 ```

--- a/docs/architecture/security-admin-settings-sec01-contract.md
+++ b/docs/architecture/security-admin-settings-sec01-contract.md
@@ -1,0 +1,144 @@
+# SEC-01 Security/Admin Settings Contract
+
+## Status and authority
+
+- Issue: [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199).
+- Base: `7e8b323007b4ae3d858eeae273f647f9f0233fba` (`origin/dev`, merged PR #588).
+- Type: production-free deployment, capability, sensitivity, and redaction audit.
+- Primary verdict: **TRUSTED_DEPLOYMENT_ONLY**.
+- Follow-up: one SEC-02 response-confidentiality Contract is justified; no
+  authentication, capability token, diagnostics route, settings split, or frontend
+  migration is authorized by this document.
+
+This document classifies supported trust assumptions. It does not add enforcement to
+the current routes. An unsupported deployment remains technically reachable when an
+operator exposes ComfyUI without an adequate external boundary.
+
+## Primary-source capability finding
+
+The current ComfyUI source was reviewed at commit
+[`e651b7bef55a5376343dcb1c0edb79f0142c985e`](https://github.com/Comfy-Org/ComfyUI/commit/e651b7bef55a5376343dcb1c0edb79f0142c985e).
+
+- [`UserManager`](https://github.com/Comfy-Org/ComfyUI/blob/e651b7bef55a5376343dcb1c0edb79f0142c985e/app/user_manager.py)
+  uses `comfy-user` to select an existing user-data profile in multi-user mode. It
+  does not authenticate that header, assign an administrator role, or expose an
+  authenticated-admin capability to custom-node routes.
+- [`PromptServer`](https://github.com/Comfy-Org/ComfyUI/blob/e651b7bef55a5376343dcb1c0edb79f0142c985e/server.py)
+  provides origin/Host checks and optional CORS behavior. Those are browser-origin
+  controls, not principal authentication or route authorization.
+- EasyUseAnima settings are resolved once from a process-owned `USER_DATA_DIR` and
+  stored in `settings.json` and `long_text_settings.json`. Route requests do not
+  select a different repository through `comfy-user`.
+
+Consequently, `comfy-user`, `request.remote`, Host, Origin, or any one forwarded
+header is never accepted as administrator proof. Forwarded headers have meaning only
+inside an explicitly configured external proxy trust boundary; EasyUseAnima does not
+interpret them as authority.
+
+### Candidate disposition
+
+| Candidate | Result | Reason |
+| --- | --- | --- |
+| `HOST_CAPABILITY` | Rejected | No stable authenticated-admin capability is available to these custom-node routes in the reviewed host source. |
+| `PROCESS_CAPABILITY` | Rejected for this lane | RuntimeConfig/bootstrap could own immutable process-start data without changing E-09, but safely conveying a capability to the browser would require a new authentication or trusted-gateway design. No current route needs such a token under the selected deployment boundary. |
+| `TRUSTED_DEPLOYMENT_ONLY` | **Selected** | The current UI legitimately consumes raw local/network configuration, while no in-process administrator identity is available. The whole settings surface therefore stays inside one trusted operator boundary. |
+| `NO_DIAGNOSTICS` | Incorporated, not primary | Administrator diagnostics remain absent, but settings are an existing configuration surface rather than a diagnostics-only feature. |
+
+No focused PRO review is required: primary-source evidence leaves one viable boundary
+without proxy/header normalization or E-09 lifecycle redesign.
+
+## Deployment and threat matrix
+
+`Ordinary redacted routes` below means wildcard and autocomplete status/search/classify
+responses whose path-bearing internal state is removed. Redaction is not authentication
+and does not make an otherwise unsupported server exposure safe.
+
+| Deployment | Effective trust boundary | Sensitive settings read/mutation | Ordinary redacted routes | Support verdict |
+| --- | --- | --- | --- | --- |
+| Single-user direct loopback | Local OS account, browser session, and ComfyUI process are one trusted operator boundary. No administrator identity is inferred from loopback itself. | Allowed under the single trusted-operator assumption. | Allowed; redaction remains mandatory. | **Supported** for a trusted single operator. |
+| LAN or remote direct bind | Network reachability is the only boundary; ComfyUI supplies no authenticated admin principal to the routes. | Not an approved exposure. Any reachable client could read or mutate the process-wide settings. | Redaction remains mandatory but does not authorize remote exposure. | **Unsupported** unless an external boundary changes the model. |
+| Reverse proxy without authentication | The proxy only forwards reachability. Host, Origin, remote address, and forwarded headers are spoofable or routing metadata, not authority. | Not approved. | Redaction remains mandatory. | **Unsupported**. |
+| Reverse proxy with external authentication | The proxy or gateway owns authentication before ComfyUI. It must cover every route, reject bypass access, and strip or replace client-supplied authentication/forwarding headers. | Conditionally allowed only when every authenticated principal is a trusted operator with equal settings authority. EasyUseAnima does not distinguish viewer/admin roles. | Allowed behind the same boundary; still redacted. | **Conditionally supported** as an all-operators trusted deployment, not as EasyUseAnima authorization. |
+| ComfyUI `--multi-user` | `comfy-user` selects host user data; it is not authentication. EasyUseAnima settings remain in one process-resolved repository. | No per-user isolation or admin boundary. Allowed only if all users are mutually trusted operators under another supported deployment boundary. | Allowed only under that surrounding boundary; redaction remains mandatory. | **Conditionally supported** for mutually trusted profiles; **unsupported** as a security boundary. |
+| Managed or multi-tenant | Tenants require authenticated identity, role separation, isolation, and audit guarantees not supplied by the reviewed host/custom-node contract. | Not approved. | Endpoint redaction alone is insufficient for tenant isolation. | **Unsupported** until a separately proven host/gateway capability and storage-isolation contract exists. |
+
+For the conditionally supported authenticated-proxy case, the deployment owner also
+owns TLS, session security, proxy access-log redaction, cache policy enforcement, and
+prevention of direct ComfyUI bypass. A proxy that authenticates users but grants some
+of them read-only or non-administrator status does not satisfy this Contract because
+EasyUseAnima currently cannot consume that role distinction.
+
+## Route and field sensitivity inventory
+
+### Route classification
+
+| Route | Current data flow | Classification and Contract |
+| --- | --- | --- |
+| `GET /easyuse_anima/settings` | Returns the complete public settings projection, including raw local/network configuration. The frontend loads it during extension setup. | **Sensitive local configuration** as a whole. Trusted-deployment only; future response hardening must use `Cache-Control: no-store`. |
+| `POST /easyuse_anima/set_setting` | Mutates a known key and returns the complete projection. No current frontend caller was found, but the route remains a supported API surface. | **Sensitive local configuration** regardless of the mutated key because the response contains the mixed projection. Trusted-deployment only and `no-store`. |
+| `GET /easyuse_anima/long_text_settings` | Returns long-text values plus the complete projection; the long-text editors consume it. | **Sensitive local configuration** and authored prompt content. Trusted-deployment only and `no-store`. |
+| `POST /easyuse_anima/long_text_settings/save` | Mutates long-text values and returns the saved values plus complete projection. | **Sensitive local configuration** and authored prompt content. Trusted-deployment only and `no-store`. |
+| `GET /easyuse_anima/wildcards` | Resolves raw roots internally, but returns root IDs/labels/existence and wildcard items without absolute root paths. | **Ordinary redacted status/content**. Never add raw roots, repository paths, capability material, or secrets. |
+| `GET /easyuse_anima/autocomplete_status` | Builds status from source/index state and strips path fields. | **Ordinary redacted status**. Never add local source/index paths or secrets. |
+| `GET /easyuse_anima/autocomplete` | Returns matches and redacted nested status. | **Ordinary redacted search**. Query and results do not gain administrator semantics. |
+| `POST /easyuse_anima/classify_prompt` | Returns classification and redacted nested status. | **Ordinary redacted classification**. Prompt input must not be copied to error or request-ID logs. |
+
+The settings frontend directly consumes `/settings`, `/long_text_settings`, and
+`/long_text_settings/save`. Its wildcard-path editor and NAIA endpoint controls need
+the raw values, so silently redacting the existing settings projection would break a
+real consumer. A settings split is therefore neither required nor authorized by the
+selected trusted-deployment verdict.
+
+### Field classes
+
+| Sensitivity class | Current examples | Contract |
+| --- | --- | --- |
+| Ordinary redacted status | Request ID; wildcard root opaque ID/label/existence and wildcard items; autocomplete source identity/count/state; matches and classifications with path fields removed. | May be returned by ordinary endpoints, but never with resolved filesystem paths, request headers, or capability/secret material. |
+| Safe UI configuration | Autocomplete mode/source/limit/commit preferences; LoRA preset display/strength preferences; Prompt Studio visual and interaction preferences; translation provider/source/target choices; NAIA resolution and preprocessing choices. | Safe relative to the other settings fields, but the current mixed settings responses remain sensitive as a whole. Translation/NAIA choices can affect outbound behavior and must not be represented as authorization. |
+| Sensitive local configuration | `wildcard.extra_paths`; `naia.host`; `naia.port`; `naia.allow_remote_api`; `prompt.metadata_filter_words`; `naia.pre_prompt`; `naia.post_prompt`; `naia.auto_hide`; the process-resolved settings repository location. | Available only inside the trusted deployment boundary. Do not place values in logs, error details, URLs, or diagnostics. |
+| Administrator diagnostics | Resolved absolute wildcard roots; autocomplete source/index paths; settings/user-data file paths; traceback, environment, storage, and host-integration details. | No route currently exposes these, and SEC-01 authorizes none. Keep them absent unless a later Contract proves an authorization owner and benefit. |
+| Secret or capability material | External `Authorization`/cookie/session data, proxy identity assertions, future process capability values, API tokens, and secret headers. | Not settings fields and never serializable. Do not accept them through URL/query settings, echo them, persist them in EasyUseAnima settings, or emit them to any log/debug output. |
+
+## Logging and redaction Contract
+
+The following rules apply regardless of deployment trust:
+
+1. Client errors expose only the stable status/code/default message and correlated
+   request ID already owned by the API contract. Raw exception text, traceback,
+   filesystem path, request body, query secret, capability, token, cookie, and secret
+   header are forbidden.
+2. Request-correlation logs may contain the request ID and a fixed event/category only.
+   They must not format `str(exc)`, `repr(exc)`, exception arguments, request content,
+   raw URLs/query strings, or headers.
+3. Generic traceback logging is not safe at this boundary: an exception message and
+   stack can contain raw configuration and local paths. Debug mode does not relax the
+   redaction rule.
+4. EasyUseAnima must not add secret/capability material to access-log fields. A host or
+   external proxy that owns authentication must independently redact its access and
+   debug logs; that external guarantee is a condition of the supported deployment.
+5. The four sensitive settings responses use `Cache-Control: no-store`. Ordinary
+   wildcard/autocomplete endpoints stay redacted even if a future deployment adds
+   authentication.
+
+Current deterministic tests prove safe client payloads and path removal, but the
+shared request correlator still calls `logger.exception(...)`, which records the active
+exception traceback, and the sensitive settings responses have no explicit `no-store`
+owner. These are response-confidentiality gaps, not evidence for adding authentication
+or a process capability.
+
+## E-09 lifecycle disposition
+
+No lifecycle change is required. Bootstrap remains the only lifecycle owner;
+initialize/shutdown keep the same lock; atexit remains once-registered; shutdown stays
+terminal/idempotent; repeated initialize retains runtime identity and route refresh;
+the translation executor remains cleanup item 1; fixed rollback and cleanup ordering
+remain unchanged. SEC-01 adds no RuntimeConfig field, second lock, reset, close item,
+or hot reinitialize API.
+
+## Exact next task
+
+SEC-02 is READY only as the response-confidentiality Contract described in
+[`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md). It must fix
+the exact SEC-03 implementation boundary for sanitized unexpected-error logging and
+`no-store` on the four sensitive settings responses. Authentication, tokens,
+diagnostics, settings projection changes, and frontend migration remain forbidden.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,9 +13,10 @@ Read only the sections needed by the active task.
    - run package/live/benchmark only when triggered.
 3. Active independent maintenance lane:
    [`../architecture/security-admin-settings-roadmap.md`](../architecture/security-admin-settings-roadmap.md)
-   - first READY task: Issue #199 / SEC-01 host capability and threat-model Contract;
-   - SEC-01 is production-free and must not implement authentication, a token,
-     diagnostics, or a settings split.
+   - SEC-01 completed with TRUSTED_DEPLOYMENT_ONLY;
+   - first READY task: Issue #199 / SEC-02 response-confidentiality Contract;
+   - SEC-02 is production-free and must not implement authentication, a token,
+     diagnostics, a settings split, or response changes.
 4. Completed backend and compatibility state:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
    - Phase F/G and G-CLOSE are complete; there is no READY Phase F/G task;
@@ -61,7 +62,8 @@ COMPLETE  G-04 public API / G-05 size ratchet / G-06 test ownership
 COMPLETE  G-CLOSE Phase F/G completion audit
 RETAIN    P-API-01; P-API-02 parked
 PARKED    D-14 / Phase H root removal
-READY     #199 SEC-01 security/admin host-capability Contract
+COMPLETE  #199 SEC-01 security/admin host-capability Contract
+READY     #199 SEC-02 response-confidentiality Contract
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
@@ -76,7 +78,7 @@ The original backend stop is correct:
 That stop applies to the completed compatibility lane. It does not block the separate
 Issue #199 security/admin Contract.
 
-## Active SEC-01 boundary
+## Completed SEC-01 boundary
 
 Current primary-source evidence must be treated as follows:
 
@@ -89,7 +91,7 @@ Current primary-source evidence must be treated as follows:
 - the projection currently contains local/network configuration such as
   `wildcard.extra_paths`, `naia.host`, `naia.port`, and `naia.allow_remote_api`.
 
-SEC-01 must produce:
+SEC-01 produced:
 
 ```text
 deployment/threat matrix
@@ -109,9 +111,16 @@ TRUSTED_DEPLOYMENT_ONLY
 NO_DIAGNOSTICS
 ```
 
-SEC-01 must not add a token, diagnostics endpoint, settings split, authentication
-middleware, or frontend migration. It must not trust `comfy-user` or proxy headers as
-admin identity.
+The primary verdict is **TRUSTED_DEPLOYMENT_ONLY**. A single trusted operator on
+loopback is supported; an authenticated reverse proxy is conditionally supported only
+when every authenticated principal has equal operator authority and direct bypass is
+prevented. Direct LAN/remote, unauthenticated proxy, and managed/multi-tenant exposure
+are unsupported. `--multi-user` is not an authorization boundary.
+
+The authoritative result is
+[`../architecture/security-admin-settings-sec01-contract.md`](../architecture/security-admin-settings-sec01-contract.md).
+SEC-01 added no token, diagnostics endpoint, settings split, authentication
+middleware, frontend migration, or lifecycle state.
 
 ## E-09 non-regression summary
 
@@ -125,16 +134,16 @@ admin identity.
 - no API application or security capability may add a reset/close registry, second
   lock, second atexit, or production module reload.
 
-If a later SEC task needs an EasyUseAnima-owned capability, it must be immutable
-process-start configuration loaded by RuntimeConfig/bootstrap. SEC-01 only decides
-whether that owner is justified.
+SEC-01 rejected a process capability for this lane. If a future independently proven
+task needs one, it must still be immutable process-start configuration loaded by
+RuntimeConfig/bootstrap.
 
 ## Following state
 
 After SEC-01:
 
-1. create exactly one bounded SEC-02 only when the verdict proves implementation is
-   needed;
+1. run the exact production-free SEC-02 response-confidentiality Contract in the
+   security roadmap;
 2. keep diagnostics absent by default when no reliable authorization owner exists;
 3. do not reopen Phase F/G, P-API-02, or D-14 as a side effect;
 4. let the next ordinary release containing final shims become release N;


### PR DESCRIPTION
## 목적과 변경 경계

Issue #199 / SEC-01의 production-free 보안 Contract를 고정합니다.

- ComfyUI의 현재 UserManager/PromptServer primary source에서 custom-node route가 사용할 인증된 관리자 capability가 없음을 확인했습니다.
- 설정 UI가 실제로 raw 로컬/네트워크 값을 소비하므로 primary verdict를 **TRUSTED_DEPLOYMENT_ONLY**로 결정했습니다.
- authentication, capability token, diagnostics endpoint, settings split, frontend migration, lifecycle 변경은 포함하지 않습니다.

## Base → Head

- Base: `7e8b323007b4ae3d858eeae273f647f9f0233fba`
- Head: `25f76fa0d99f90c920c23e892edc69e30d5634fb`

## 주요 변경

- 여섯 deployment/threat model을 supported / conditionally supported / unsupported로 분류
- settings/wildcard/autocomplete route와 field를 다섯 sensitivity class로 inventory
- `comfy-user`, remote address, Host, Origin, 단일 forwarded header를 admin proof로 사용하지 않는 Contract 고정
- 일반 wildcard/autocomplete endpoint의 영구 redaction과 error/request-ID/access/debug log 금지 항목 고정
- E-09 lifecycle 비변경 확인
- exact SEC-02 response-confidentiality Contract를 READY로 전환
  - traceback-bearing unexpected-error logging
  - 네 sensitive settings response의 `Cache-Control: no-store`
  - SEC-02 자체는 production-free이며 SEC-03 구현 경계만 고정

## 검증

Focused unittest:

- `ApiRequestCorrelationTests`: 14 PASS
- `ApiSettingsRouteTests`: 8 PASS
- `ApiLongTextSettingsRouteTests`: 5 PASS
- `ApiWildcardRouteTests`: 4 PASS
- `ApiAutocompleteRouteTests`: 11 PASS
- `ApiPathRedactionTests`: 4 PASS
- `git diff --check`: PASS

문서-only SEC-01이므로 official full, package, live HTTP, browser는 지시와 roadmap에 따라 실행하지 않았습니다. 새 fixture도 추가하지 않았습니다.

## 남은 위험과 rollback

- 이 Contract는 unsupported deployment를 runtime에서 차단하지 않습니다. LAN/remote 직접 노출, unauthenticated proxy, managed/multi-tenant는 운영상 허용되지 않는 경계입니다.
- authenticated proxy는 모든 principal이 동일한 trusted operator 권한을 가질 때만 조건부 지원합니다.
- rollback은 이 문서 커밋 하나를 revert하면 되며 runtime/storage/schema migration은 없습니다.

## Next

Issue #199 / SEC-02 response-confidentiality Contract만 다음 READY입니다. SEC-03/04/05, D-14, release/tag/Registry는 계속 conditional/blocked입니다.

Closes no issue; relates to #199.