### PR TITLE
[SEC-02] Fix the response confidentiality contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -25,8 +25,8 @@ then only the active task section, owning Issue, direct source, and direct tests
 - The completed compatibility lane is recorded in
   [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md).
 - Issue [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01
-  completed with **TRUSTED_DEPLOYMENT_ONLY**. The first READY task is SEC-02
-  response-confidentiality Contract.
+  completed with **TRUSTED_DEPLOYMENT_ONLY**. SEC-02 completed with a direct-owner
+  **FEASIBLE** result. The first READY task is SEC-03 narrow backend implementation.
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md) owns that
   active lane. It does not reopen Phase F/G, P-API-02, or D-14.
 - Released baseline: 0.6.2. Registry activation is external administration and does
@@ -39,8 +39,9 @@ COMPLETE Phase D/E/F/G
   -> PARKED H/D-14 compatibility retirement
 
 COMPLETE #199 SEC-01 security/admin Contract
-  -> READY SEC-02 response-confidentiality Contract
-  -> CONDITIONAL narrow implementation/audit
+  -> COMPLETE SEC-02 response-confidentiality Contract
+  -> READY SEC-03 narrow backend implementation
+  -> CONDITIONAL completion audit
 
 EVENT next ordinary release N
   -> later H/D-14 re-audit
@@ -81,20 +82,23 @@ including `wildcard.extra_paths`, `naia.host`, `naia.port`, and
 classifies the surface as **TRUSTED_DEPLOYMENT_ONLY**. `comfy-user`, `request.remote`,
 Host, Origin, and forwarded headers are not administrator authentication. The current
 settings UI remains inside one trusted-operator boundary, diagnostics remain absent,
-and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 owns only the
-exact response-confidentiality Contract for safe unexpected-error logging and
-`Cache-Control: no-store` on sensitive settings responses.
+and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 proved that safe
+unexpected-error logging and `Cache-Control: no-store` on sensitive settings responses
+fit inside three direct production owners without root composition or lifecycle change.
 
 ## Core documents
 
 ### Active
 
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md):
-  Issue #199 queue, validation, and exact SEC-02 resume card.
+  Issue #199 queue, validation, and exact SEC-03 resume card.
 - [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md):
   completed deployment/threat matrix, host-capability audit, settings-field
   classification, logging/redaction Contract, E-09 disposition, and
   TRUSTED_DEPLOYMENT_ONLY verdict.
+- [`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md):
+  safe fixed logging, private sensitivity marker, `no-store` coverage, exact owner set,
+  preserved invariants, verification ownership, and SEC-03 rollback/stop boundary.
 
 ### Completed backend and compatibility plan
 

--- a/docs/architecture/security-admin-settings-roadmap.md
+++ b/docs/architecture/security-admin-settings-roadmap.md
@@ -7,7 +7,10 @@
 - SEC-01 host capability and threat-model Contract: complete with
   **TRUSTED_DEPLOYMENT_ONLY**; see
   [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md).
-- First READY task: SEC-02 response-confidentiality Contract.
+- SEC-02 response-confidentiality Contract: complete with a direct-owner
+  **FEASIBLE** result; see
+  [`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md).
+- First READY task: SEC-03 narrow backend implementation.
 - Released baseline: 0.6.2.
 - This lane does not reopen Phase F/G, P-API-02, D-14, or Phase H.
 - Type: Security/Admin Contract first; no production behavior change before the
@@ -204,17 +207,17 @@ No task after SEC-01 is automatically READY.
 
 ```text
 COMPLETE    SEC-01 threat model / capability owner / field classification
-READY       SEC-02 response-confidentiality Contract
-CONDITIONAL SEC-03 narrow backend implementation
+COMPLETE    SEC-02 response-confidentiality Contract
+READY       SEC-03 narrow backend implementation
 CONDITIONAL SEC-04 frontend settings migration, only if UI behavior changes
 CONDITIONAL SEC-05 security/package/live completion audit
 ```
 
-SEC-02 is justified by two directly observed response-confidentiality gaps: the shared
-unexpected-error correlator uses traceback-bearing exception logging, and the four
-sensitive settings read/mutation responses do not own an explicit
-`Cache-Control: no-store` contract. SEC-02 does not reconsider authentication,
-capability ownership, a diagnostics route, or a settings split.
+SEC-02 fixed one executable Contract for the two directly observed
+response-confidentiality gaps: traceback-bearing unexpected-error logging and the
+missing `Cache-Control: no-store` owner for four sensitive settings responses. The
+direct-owner result does not reconsider authentication, capability ownership, a
+diagnostics route, or a settings split.
 
 Examples of valid SEC-02 boundaries:
 
@@ -267,43 +270,49 @@ security architectures that are all viable, for example:
 User preference is not used as a substitute for security evidence. A missing host
 admin capability by itself is not a PRO blocker; it is an input to the SEC-01 verdict.
 
-## 9. SEC-02 task card and Codex resume instruction
+## 9. SEC-03 task card and Codex resume instruction
 
 ```text
 Task / Issue:
-Issue #199 / SEC-02 response-confidentiality Contract
+Issue #199 / SEC-03 response-confidentiality implementation
 
 Base SHA:
-Latest origin/dev after the SEC-01 Contract PR.
+Latest origin/dev after the SEC-02 Contract PR.
 
 Goal:
-Write the exact executable Contract for:
-1. sanitizing the shared unexpected-error request-correlation log so it contains only
-   the correlated request ID and a fixed event/category; and
-2. Cache-Control: no-store on GET /settings, POST /set_setting,
-   GET /long_text_settings, and POST /long_text_settings/save.
-Produce exactly one bounded SEC-03 implementation card only if the two requirements
-can remain inside their direct response owners.
+Implement security-admin-settings-sec02-response-contract.md exactly:
+1. replace traceback-bearing unexpected-error logging with one fixed error event that
+   contains only the correlated request ID; and
+2. mark the four settings/long-text handlers as sensitive so the existing correlation
+   wrapper sets Cache-Control: no-store on every returned or re-raised outcome.
 
-Allowed files:
+Allowed production files:
+- easyuse_anima/api/responses.py
+- easyuse_anima/api/routes/settings.py
+- easyuse_anima/api/routes/long_text_settings.py
+
+Allowed test/docs files:
+- tests/test_api_contract.py
+- tests/fixtures/python_backend_baseline.json only when the analyzer requires the
+  exact changed-owner delta
 - docs/architecture/security-admin-settings-sec02-response-contract.md
 - docs/architecture/security-admin-settings-sec01-contract.md
 - docs/architecture/security-admin-settings-roadmap.md
 - docs/architecture/README.md
 - docs/development/README.md
 
-Production, test, tool, and fixture changes are forbidden in SEC-02.
-
 Read only:
 - current-policies.md
 - codex-execution-efficiency.md universal rules
 - this document
 - Issue #199 latest checkpoint
+- security-admin-settings-sec02-response-contract.md
 - security-admin-settings-sec01-contract.md
 - easyuse_anima/api/responses.py
 - settings.py and long_text_settings.py direct response owners
 - ApiRequestCorrelationTests, ApiSettingsRouteTests,
   ApiLongTextSettingsRouteTests, and ApiPathRedactionTests
+- direct bootstrap/package/import/analyzer owners when their focused gate runs
 
 Preserve:
 - response status/body/request-ID/header behavior;
@@ -318,38 +327,44 @@ Forbidden changes:
 - settings split, schema/persistence/migration, frontend behavior;
 - global ComfyUI/access-log configuration or middleware;
 - RuntimeConfig/bootstrap/lifecycle/reset/shutdown changes;
+- api.py, bootstrap.py, router.py, public exports, or route definition changes;
 - broad logger refactor or unrelated API cleanup.
 
-Focused evidence, one target per runner:
-- ApiRequestCorrelationTests: correlation and safe unexpected-error behavior;
-- ApiSettingsRouteTests: settings response and failure behavior;
-- ApiLongTextSettingsRouteTests: long-text response behavior;
+Edit loop and focused evidence, one target per runner:
+- changed-file Python syntax/static and git diff --check;
+- ApiRequestCorrelationTests: fixed safe log event, exact sensitive headers,
+  correlation, CancelledError/HTTPException, and ordinary-route non-marking;
+- ApiSettingsRouteTests: both marked handlers and unchanged settings behavior;
+- ApiLongTextSettingsRouteTests: both marked handlers and unchanged long-text behavior;
 - ApiPathRedactionTests: ordinary endpoint path redaction;
-- source/Contract consistency and git diff --check.
+- PythonBootstrapTests: unchanged composition/repeated initialize/lifecycle behavior;
+- PythonPackageSkeletonTests: direct package/no-host import remains safe;
+- current import-boundary and analyzer owners: no forbidden edge or unexplained metric
+  change.
 
 Promotion gates:
-Docs-only SEC-02 does not run official full, package, live HTTP, or browser checks.
-The SEC-03 card must require official full once on its final candidate SHA. It may
-reuse package/no-host evidence when only the direct response owners change. No live
-or browser smoke is triggered for a pure log/header change; trigger isolated live HTTP
-only if status/body/request-ID behavior or host logger integration changes, and browser
-only if frontend files or interaction change.
+Run official full exactly once on the final candidate SHA. Package/pack, live HTTP,
+and browser are not triggered while the diff stays inside the fixed three production
+owners and direct tests. Trigger isolated live HTTP only if status/body/request-ID
+behavior or host logger integration changes; trigger browser only if frontend files or
+interaction change.
 
 Rollback boundary:
-Revert the SEC-02 documentation PR. There is no runtime state, storage, schema, or
-migration rollback.
+Revert the one SEC-03 implementation PR. There is no runtime state, storage, schema,
+migration, or frontend rollback.
 
 Stop conditions:
 - safe logging requires global ComfyUI/access/proxy logger changes;
 - no-store cannot be attached without changing public response semantics;
 - proxy-header trust or a capability owner becomes necessary;
-- any E-09 lifecycle or frontend/settings migration change is required.
+- api.py/bootstrap/router/public export, E-09 lifecycle, or frontend/settings
+  migration change is required;
+- an analyzer/import failure cannot be explained by the exact three-file owner delta.
 
 Next:
-SEC-03 narrow backend implementation only after this Contract proves one bounded
-owner set. SEC-04/SEC-05 remain conditional. D-14, release, tag, and Registry remain
-blocked.
+If SEC-03 stays inside this card, skip SEC-04 and make SEC-05 the next completion audit.
+D-14, release, tag, and Registry remain blocked until the security lane closes and a
+later roadmap gate explicitly authorizes them.
 
-Reuse existing deterministic tests. Add no fixture unless the response Contract cannot
-be represented by the existing direct owner tests.
+Reuse existing deterministic tests. Add no new fixture or test module.
 ```

--- a/docs/architecture/security-admin-settings-sec01-contract.md
+++ b/docs/architecture/security-admin-settings-sec01-contract.md
@@ -137,8 +137,8 @@ or hot reinitialize API.
 
 ## Exact next task
 
-SEC-02 is READY only as the response-confidentiality Contract described in
-[`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md). It must fix
-the exact SEC-03 implementation boundary for sanitized unexpected-error logging and
-`no-store` on the four sensitive settings responses. Authentication, tokens,
-diagnostics, settings projection changes, and frontend migration remain forbidden.
+SEC-02 completed with a direct-owner **FEASIBLE** result in
+[`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md).
+SEC-03 is READY only for sanitized unexpected-error logging and `no-store` on the four
+sensitive settings responses. Authentication, tokens, diagnostics, settings projection
+changes, and frontend migration remain forbidden.

--- a/docs/architecture/security-admin-settings-sec02-response-contract.md
+++ b/docs/architecture/security-admin-settings-sec02-response-contract.md
@@ -1,0 +1,158 @@
+# SEC-02 Response Confidentiality Contract
+
+## Status and authority
+
+- Issue: [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199).
+- Base: `185021175cb5c9a535c20d49fc6fd5eb8dd3b8ce` (`origin/dev`, merged PR #589).
+- Primary class: `CONTRACT`; production, tests, tools, and fixtures are unchanged.
+- Result: **FEASIBLE** inside the direct response owners.
+- Next: SEC-03 narrow backend implementation is READY.
+
+This Contract implements none of the rules below. It fixes one executable owner set
+and rollback boundary for the later implementation.
+
+## Frozen response flow
+
+The current composition order is:
+
+```text
+settings / long-text handler factory
+  -> raw handler
+  -> bootstrap.build_settings_route_group
+  -> request-correlation wrapper
+  -> ordered route definition / registrar
+```
+
+This order permits a raw settings handler to carry one private sensitivity marker.
+The existing shared correlation wrapper closes over that raw handler, so it can apply
+response confidentiality after either normal completion or its own unexpected-error
+normalization. No root `api.py` callback, bootstrap signature, router definition,
+middleware, public export, or lifecycle owner needs to change.
+
+## Exact logging Contract
+
+For an unexpected non-HTTP exception crossing the shared request-correlation boundary:
+
+1. Preserve the existing correlated JSON response exactly:
+   - status `500`;
+   - code `internal_error`;
+   - message `An unexpected server error occurred.`;
+   - one server-generated request ID in body and `X-Request-ID` header.
+2. Emit exactly
+   `logger.error("Unhandled EasyUseAnima API error (request_id=%s)", request_id)`.
+3. Do not call traceback-bearing `logger.exception` and do not pass `exc_info`,
+   `stack_info`, exception text/arguments/type, request object, body, query, URL,
+   headers, filesystem path, token, capability, or secret material to the logger.
+4. Preserve `asyncio.CancelledError` propagation with no log or normalization.
+5. Preserve aiohttp `HTTPException` propagation, body/status, and correlated request-ID
+   header. It is not converted to the generic 500 and is not logged.
+
+The implementation remains in `easyuse_anima/api/responses.py`. It does not configure
+ComfyUI, aiohttp access logs, a reverse proxy, or the global logging subsystem.
+
+## Exact sensitive-response Contract
+
+The following four routes are sensitive as complete response surfaces:
+
+```text
+GET  /easyuse_anima/settings
+POST /easyuse_anima/set_setting
+GET  /easyuse_anima/long_text_settings
+POST /easyuse_anima/long_text_settings/save
+```
+
+Their raw factory handlers carry the private boolean marker
+`_easyuse_anima_sensitive_response = True`. The marker:
+
+- is attached before bootstrap applies the existing request-correlation wrapper;
+- is not part of any module `__all__`, public API, route signature, or serialized
+  payload;
+- is copied naturally to the wrapped handler by the existing `functools.wraps`
+  behavior but is consumed from the closed-over raw handler;
+- does not classify wildcard, autocomplete, translation, profile, LoRA, or AiO routes.
+
+For a marked handler, the correlation wrapper sets the exact header
+`Cache-Control: no-store` on every response it returns or re-raises:
+
+- successful read or mutation;
+- request-contract validation error;
+- unknown-setting error;
+- unexpected exception normalized to the generic correlated 500;
+- aiohttp `HTTPException`, if one crosses that handler boundary.
+
+The header is applied without changing response status, body, content type, existing
+headers, request ID, handler identity, or payload identity. Ordinary wildcard and
+autocomplete responses remain redacted and do not gain this sensitive marker or a new
+cache contract in SEC-03.
+
+## Owner and dependency decision
+
+The complete SEC-03 production owner set is:
+
+| File | Exact responsibility |
+| --- | --- |
+| `easyuse_anima/api/responses.py` | Consume the private marker, add `no-store` on all correlated sensitive outcomes, and replace traceback-bearing unexpected-error logging with the fixed safe event. |
+| `easyuse_anima/api/routes/settings.py` | Mark only the two settings handlers as sensitive before returning them from the factory. |
+| `easyuse_anima/api/routes/long_text_settings.py` | Mark only the two long-text settings handlers as sensitive before returning them from the factory. |
+
+No additional owner is necessary. In particular:
+
+- `api.py` dependency mappings stay unchanged;
+- `easyuse_anima/bootstrap.py` continues to wrap the same ordered four handlers;
+- `easyuse_anima/api/router.py` keeps the exact route order/signature/registrar;
+- RuntimeConfig and RuntimeServices gain no capability or cleanup state;
+- frontend settings loading and persistence behavior stay unchanged.
+
+The private marker string is an internal response contract, not authentication or an
+authorization capability. A caller cannot gain access by setting it on a request.
+
+## Preserved invariants
+
+- Exact 21-route order, signature, handler names/identity, registration marker, and
+  idempotent/repeated route refresh.
+- Dynamic root monkeypatch seams and injected response/persistence callbacks.
+- Settings and long-text parsing, defaults, file-I/O dispatch, mutation order,
+  payload identity/merge shape, status/error taxonomy, and request correlation.
+- Wildcard/autocomplete path redaction and all ordinary endpoint payloads.
+- E-09 single lifecycle owner, shared initialize/shutdown lock, once atexit,
+  terminal/idempotent shutdown, translation executor identity and cleanup item 1,
+  fixed seven-step cleanup, rollback, and no-reset/no-hot-reinitialize rules.
+- Canonical/root `__all__` and public bootstrap/router surfaces.
+
+## Verification ownership
+
+Existing deterministic tests can express the entire implementation Contract. No new
+fixture is justified.
+
+- `ApiRequestCorrelationTests` owns safe fixed logging, sensitive success/error/header
+  correlation, CancelledError, HTTPException, and ordinary-route non-marking.
+- `ApiSettingsRouteTests` owns both settings handlers, all success/error paths, dynamic
+  dependencies, raw values, and payload shapes.
+- `ApiLongTextSettingsRouteTests` owns both long-text handlers, legacy/wrapped input,
+  dynamic dependencies, and payload shapes.
+- `ApiPathRedactionTests` owns the unchanged ordinary wildcard/autocomplete redaction.
+- `PythonBootstrapTests`, package-skeleton direct import, import-boundary, and analyzer
+  owners prove that composition/lifecycle/import surfaces did not expand.
+
+SEC-03 changes production and tests, so it runs official full exactly once on its final
+candidate SHA. Package/live/browser are not triggered while the implementation stays
+inside this fixed pure log/header boundary. An isolated live HTTP smoke becomes
+required only if status/body/request-ID behavior or host logger integration changes;
+browser smoke becomes required only if frontend files or interaction change.
+
+## Rollback and stop boundary
+
+Rollback is one SEC-03 commit/PR. Reverting it removes the private marker, restores the
+previous logging call, and removes the four cache headers. There is no runtime state,
+storage, schema, migration, or frontend rollback.
+
+Stop SEC-03 instead of widening it if any of the following is required:
+
+- changing `api.py`, bootstrap/router public signatures, route registration, or E-09
+  lifecycle state;
+- configuring ComfyUI/aiohttp/proxy access logging or trusting a proxy/header identity;
+- adding authentication, a token/capability, diagnostics, settings split, persistence
+  migration, or frontend behavior;
+- changing response status/body/request-ID/content type or ordinary endpoint payloads;
+- an analyzer/import failure that cannot be explained by the exact three-file owner
+  change.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -14,9 +14,10 @@ Read only the sections needed by the active task.
 3. Active independent maintenance lane:
    [`../architecture/security-admin-settings-roadmap.md`](../architecture/security-admin-settings-roadmap.md)
    - SEC-01 completed with TRUSTED_DEPLOYMENT_ONLY;
-   - first READY task: Issue #199 / SEC-02 response-confidentiality Contract;
-   - SEC-02 is production-free and must not implement authentication, a token,
-     diagnostics, a settings split, or response changes.
+   - SEC-02 completed with a direct-owner FEASIBLE result;
+   - first READY task: Issue #199 / SEC-03 narrow backend implementation;
+   - SEC-03 must not implement authentication, a token, diagnostics, a settings split,
+     frontend behavior, root composition, or lifecycle changes.
 4. Completed backend and compatibility state:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
    - Phase F/G and G-CLOSE are complete; there is no READY Phase F/G task;
@@ -63,7 +64,8 @@ COMPLETE  G-CLOSE Phase F/G completion audit
 RETAIN    P-API-01; P-API-02 parked
 PARKED    D-14 / Phase H root removal
 COMPLETE  #199 SEC-01 security/admin host-capability Contract
-READY     #199 SEC-02 response-confidentiality Contract
+COMPLETE  #199 SEC-02 response-confidentiality Contract
+READY     #199 SEC-03 narrow backend implementation
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
@@ -142,8 +144,8 @@ RuntimeConfig/bootstrap.
 
 After SEC-01:
 
-1. run the exact production-free SEC-02 response-confidentiality Contract in the
-   security roadmap;
+1. run the exact SEC-03 response-confidentiality implementation in the security
+   roadmap and SEC-02 Contract;
 2. keep diagnostics absent by default when no reliable authorization owner exists;
 3. do not reopen Phase F/G, P-API-02, or D-14 as a side effect;
 4. let the next ordinary release containing final shims become release N;


### PR DESCRIPTION
## 목적과 변경 경계

Issue #199 / SEC-02 production-free response-confidentiality Contract를 고정합니다.

- 결과: direct response owner 안에서 **FEASIBLE**
- production, test, tool, fixture 변경 없음
- authentication, token/capability, diagnostics, settings split, frontend, root composition, lifecycle 변경 없음

## Base → Head

- Base: `185021175cb5c9a535c20d49fc6fd5eb8dd3b8ce`
- Head: `e95904cbc96e9929fa0d0a4ca794a0fde87edf45`

## 고정한 SEC-03 경계

Production owner는 다음 세 파일뿐입니다.

- `easyuse_anima/api/responses.py`
- `easyuse_anima/api/routes/settings.py`
- `easyuse_anima/api/routes/long_text_settings.py`

정확한 동작:

- 네 settings/long-text raw handler에 private marker `_easyuse_anima_sensitive_response = True`
- 기존 correlation wrapper가 success, validation/unknown-setting error, unexpected 500, HTTPException에 `Cache-Control: no-store` 적용
- unexpected exception은 traceback 없이 다음 고정 호출만 사용
  - `logger.error("Unhandled EasyUseAnima API error (request_id=%s)", request_id)`
- status/body/content-type/request-ID/header, route identity/order/registration, dynamic seams, E-09 lifecycle은 보존
- ordinary wildcard/autocomplete endpoint에는 marker/cache 동작 추가 없음

## 검증

- source/Contract owner 및 wrapping 순서 일치 확인
- stale READY/resume 문구 없음
- `git diff --check`: PASS
- SEC-01/#589에서 통과한 direct API tests 46건 재사용
  - production/test/fixture가 바뀌지 않아 재실행하지 않음
- official full/package/live/browser: docs-only Contract이므로 미실행

## 남은 위험과 rollback

- SEC-03에서 api.py/bootstrap/router/public export, global logger/middleware, lifecycle, frontend, settings schema/persistence가 필요해지면 stop합니다.
- rollback은 이 문서 PR 하나를 revert하면 되며 runtime/storage/schema migration은 없습니다.

## Next

SEC-03 narrow backend implementation이 다음 READY입니다. 범위가 유지되면 SEC-04는 건너뛰고 SEC-05 completion audit로 이동합니다.

Relates to #199.