### PR TITLE
SEC-03 응답 기밀성 계약 구현

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,7 +26,8 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md).
 - Issue [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01
   completed with **TRUSTED_DEPLOYMENT_ONLY**. SEC-02 completed with a direct-owner
-  **FEASIBLE** result. The first READY task is SEC-03 narrow backend implementation.
+  **FEASIBLE** result, SEC-03 implemented it, and SEC-04 was skipped. The first READY
+  task is SEC-05 completion audit.
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md) owns that
   active lane. It does not reopen Phase F/G, P-API-02, or D-14.
 - Released baseline: 0.6.2. Registry activation is external administration and does
@@ -40,8 +41,9 @@ COMPLETE Phase D/E/F/G
 
 COMPLETE #199 SEC-01 security/admin Contract
   -> COMPLETE SEC-02 response-confidentiality Contract
-  -> READY SEC-03 narrow backend implementation
-  -> CONDITIONAL completion audit
+  -> COMPLETE SEC-03 narrow backend implementation
+  -> SKIPPED SEC-04 frontend migration
+  -> READY SEC-05 completion audit
 
 EVENT next ordinary release N
   -> later H/D-14 re-audit
@@ -82,16 +84,17 @@ including `wildcard.extra_paths`, `naia.host`, `naia.port`, and
 classifies the surface as **TRUSTED_DEPLOYMENT_ONLY**. `comfy-user`, `request.remote`,
 Host, Origin, and forwarded headers are not administrator authentication. The current
 settings UI remains inside one trusted-operator boundary, diagnostics remain absent,
-and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 proved that safe
-unexpected-error logging and `Cache-Control: no-store` on sensitive settings responses
-fit inside three direct production owners without root composition or lifecycle change.
+and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 proved, and
+SEC-03 implemented, safe unexpected-error logging and `Cache-Control: no-store` on
+sensitive settings responses inside three direct production owners without root
+composition or lifecycle change.
 
 ## Core documents
 
 ### Active
 
 - [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md):
-  Issue #199 queue, validation, and exact SEC-03 resume card.
+  Issue #199 queue, validation, completed SEC-03 card, and exact SEC-05 resume card.
 - [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md):
   completed deployment/threat matrix, host-capability audit, settings-field
   classification, logging/redaction Contract, E-09 disposition, and
@@ -110,6 +113,22 @@ fit inside three direct production owners without root composition or lifecycle 
 - [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md):
   authoritative bootstrap lifecycle, fixed cleanup order, startup rollback, retained
   no-op boundaries, and terminal shutdown contract.
+- [`python-runtime-base-contract.md`](python-runtime-base-contract.md):
+  RuntimeServices identity, construction, installation, and cleanup-plan base contract.
+- [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md):
+  repository and filesystem runtime ownership.
+- [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md):
+  translation service, facade, route-executor, and cleanup ownership.
+- [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
+  autocomplete index and snapshot lifecycle ownership.
+- [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md):
+  wildcard cache and source lifecycle ownership.
+- [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md):
+  AiO first-pass cache ownership and cleanup contract.
+- [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md):
+  package, runtime, and host test-isolation boundary.
+- [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md):
+  completed mutable-runtime owner and disposition inventory.
 - [`python-phase-fg-completion-audit.md`](python-phase-fg-completion-audit.md):
   final Phase F/G evidence reconciliation and zero-follow-up decision.
 - [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md):

--- a/docs/architecture/security-admin-settings-roadmap.md
+++ b/docs/architecture/security-admin-settings-roadmap.md
@@ -10,7 +10,9 @@
 - SEC-02 response-confidentiality Contract: complete with a direct-owner
   **FEASIBLE** result; see
   [`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md).
-- First READY task: SEC-03 narrow backend implementation.
+- SEC-03 narrow backend implementation: complete.
+- SEC-04 frontend migration: skipped because no frontend behavior changed.
+- First READY task: SEC-05 completion audit.
 - Released baseline: 0.6.2.
 - This lane does not reopen Phase F/G, P-API-02, D-14, or Phase H.
 - Type: Security/Admin Contract first; no production behavior change before the
@@ -208,9 +210,9 @@ No task after SEC-01 is automatically READY.
 ```text
 COMPLETE    SEC-01 threat model / capability owner / field classification
 COMPLETE    SEC-02 response-confidentiality Contract
-READY       SEC-03 narrow backend implementation
-CONDITIONAL SEC-04 frontend settings migration, only if UI behavior changes
-CONDITIONAL SEC-05 security/package/live completion audit
+COMPLETE    SEC-03 narrow backend implementation
+SKIPPED     SEC-04 frontend settings migration; no UI behavior changed
+READY       SEC-05 security completion audit
 ```
 
 SEC-02 fixed one executable Contract for the two directly observed
@@ -270,7 +272,7 @@ security architectures that are all viable, for example:
 User preference is not used as a substitute for security evidence. A missing host
 admin capability by itself is not a PRO blocker; it is an input to the SEC-01 verdict.
 
-## 9. SEC-03 task card and Codex resume instruction
+## 9. Completed SEC-03 task card
 
 ```text
 Task / Issue:
@@ -293,6 +295,8 @@ Allowed production files:
 
 Allowed test/docs files:
 - tests/test_api_contract.py
+- tests/test_prompt_translation_api.py, because the shared correlator logging method is
+  a direct existing expectation exposed by official full
 - tests/fixtures/python_backend_baseline.json only when the analyzer requires the
   exact changed-owner delta
 - docs/architecture/security-admin-settings-sec02-response-contract.md
@@ -337,6 +341,8 @@ Edit loop and focused evidence, one target per runner:
 - ApiSettingsRouteTests: both marked handlers and unchanged settings behavior;
 - ApiLongTextSettingsRouteTests: both marked handlers and unchanged long-text behavior;
 - ApiPathRedactionTests: ordinary endpoint path redaction;
+- PromptTranslationApiTests: unchanged translation status/payload taxonomy with the
+  fixed shared logging event;
 - PythonBootstrapTests: unchanged composition/repeated initialize/lifecycle behavior;
 - PythonPackageSkeletonTests: direct package/no-host import remains safe;
 - current import-boundary and analyzer owners: no forbidden edge or unexplained metric
@@ -367,4 +373,71 @@ D-14, release, tag, and Registry remain blocked until the security lane closes a
 later roadmap gate explicitly authorizes them.
 
 Reuse existing deterministic tests. Add no new fixture or test module.
+```
+
+## 10. SEC-05 task card and Codex resume instruction
+
+```text
+Task / Issue:
+Issue #199 / SEC-05 security completion audit
+
+Base SHA:
+Latest origin/dev after the SEC-03 implementation PR.
+
+Goal:
+Audit the merged SEC-03 result against the SEC-01 threat model and SEC-02 response
+Contract, reconcile the security roadmap/indexes, and close Issue #199 only when the
+lane has no unowned response-confidentiality gap.
+
+Allowed production files:
+- none
+
+Allowed docs files:
+- docs/architecture/security-admin-settings-sec01-contract.md
+- docs/architecture/security-admin-settings-sec02-response-contract.md
+- docs/architecture/security-admin-settings-roadmap.md
+- docs/architecture/README.md
+- docs/development/README.md
+
+Read only:
+- current-policies.md
+- codex-execution-efficiency.md universal rules
+- this SEC-05 card
+- Issue #199 latest checkpoint
+- SEC-01 and SEC-02 Contracts
+- merged SEC-03 diff and validation record
+- easyuse_anima/api/responses.py
+- easyuse_anima/api/routes/settings.py
+- easyuse_anima/api/routes/long_text_settings.py
+- the direct SEC-03 tests and generated analyzer fixture
+
+Required audit:
+- fixed unexpected-error log contains only the correlated request ID;
+- all four sensitive routes receive Cache-Control: no-store on every specified
+  success/error/HTTPException outcome;
+- ordinary wildcard/autocomplete responses remain unmarked and redacted;
+- status/body/request-ID, route identity/order, bootstrap, package import, and E-09
+  lifecycle invariants remain preserved;
+- no authentication, capability, proxy trust, diagnostics, settings split,
+  persistence, frontend, root-composition, or lifecycle scope entered the lane;
+- SEC-03 official-full evidence belongs to the merged implementation SHA and no
+  package/live/browser trigger fired.
+
+Validation:
+- targeted source/Contract/test-fixture consistency;
+- git diff --check for the docs-only audit;
+- reuse the merged SEC-03 focused and official-full evidence;
+- do not rerun official full, package/pack, live HTTP, or browser for docs-only
+  reconciliation.
+
+Stop conditions:
+- a production or test correction is required;
+- a sensitive outcome lacks no-store or a log can disclose exception/request data;
+- route/public API, package import, or E-09 lifecycle behavior changed;
+- package/live/browser evidence becomes necessary to support a claim.
+
+Next:
+If the audit passes, mark SEC-01 through SEC-05 complete, close Issue #199, and leave
+D-14, release, tag, and Registry blocked until a separate roadmap gate explicitly
+authorizes them. If it fails, stop and write only the smallest exact follow-up card.
 ```

--- a/docs/architecture/security-admin-settings-sec01-contract.md
+++ b/docs/architecture/security-admin-settings-sec01-contract.md
@@ -139,6 +139,8 @@ or hot reinitialize API.
 
 SEC-02 completed with a direct-owner **FEASIBLE** result in
 [`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md).
-SEC-03 is READY only for sanitized unexpected-error logging and `no-store` on the four
-sensitive settings responses. Authentication, tokens, diagnostics, settings projection
-changes, and frontend migration remain forbidden.
+SEC-03 completed sanitized unexpected-error logging and `no-store` on the four
+sensitive settings responses without entering any forbidden boundary. SEC-04 was
+skipped because frontend behavior did not change. SEC-05 is READY as the production-free
+completion audit. Authentication, tokens, diagnostics, settings projection changes,
+and frontend migration remain forbidden.

--- a/docs/architecture/security-admin-settings-sec02-response-contract.md
+++ b/docs/architecture/security-admin-settings-sec02-response-contract.md
@@ -4,12 +4,15 @@
 
 - Issue: [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199).
 - Base: `185021175cb5c9a535c20d49fc6fd5eb8dd3b8ce` (`origin/dev`, merged PR #589).
-- Primary class: `CONTRACT`; production, tests, tools, and fixtures are unchanged.
+- Primary class: `CONTRACT`; implemented by SEC-03 without changing the frozen owner
+  or rollback boundary.
 - Result: **FEASIBLE** inside the direct response owners.
-- Next: SEC-03 narrow backend implementation is READY.
+- SEC-03 status: complete.
+- Next: SEC-05 completion audit is READY; SEC-04 was skipped because no frontend
+  behavior changed.
 
-This Contract implements none of the rules below. It fixes one executable owner set
-and rollback boundary for the later implementation.
+This Contract fixed one executable owner set and rollback boundary. SEC-03 implemented
+that exact boundary in the three production owners and its existing direct test owner.
 
 ## Frozen response flow
 
@@ -131,6 +134,8 @@ fixture is justified.
 - `ApiLongTextSettingsRouteTests` owns both long-text handlers, legacy/wrapped input,
   dynamic dependencies, and payload shapes.
 - `ApiPathRedactionTests` owns the unchanged ordinary wildcard/autocomplete redaction.
+- `PromptTranslationApiTests` owns unchanged translation error taxonomy while the
+  shared correlation boundary emits the fixed safe logging event.
 - `PythonBootstrapTests`, package-skeleton direct import, import-boundary, and analyzer
   owners prove that composition/lifecycle/import surfaces did not expand.
 
@@ -139,6 +144,19 @@ candidate SHA. Package/live/browser are not triggered while the implementation s
 inside this fixed pure log/header boundary. An isolated live HTTP smoke becomes
 required only if status/body/request-ID behavior or host logger integration changes;
 browser smoke becomes required only if frontend files or interaction change.
+
+## SEC-03 implementation record
+
+SEC-03 implemented the fixed logging event and private sensitive-response marker in
+`easyuse_anima/api/responses.py`, marked only the four settings/long-text handlers in
+their two route modules, and extended `tests/test_api_contract.py`. The generated
+analyzer baseline records only those owner deltas. No status, body, request-ID, route,
+bootstrap, lifecycle, persistence, schema, or frontend behavior changed.
+
+Direct response contracts, path redaction, bootstrap, package import, import-boundary,
+and analyzer gates passed. The final candidate runs official full exactly once; its
+result is the promotion evidence consumed by SEC-05. Package/live/browser remain
+untriggered because the implementation stayed inside this pure log/header boundary.
 
 ## Rollback and stop boundary
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -15,8 +15,9 @@ Read only the sections needed by the active task.
    [`../architecture/security-admin-settings-roadmap.md`](../architecture/security-admin-settings-roadmap.md)
    - SEC-01 completed with TRUSTED_DEPLOYMENT_ONLY;
    - SEC-02 completed with a direct-owner FEASIBLE result;
-   - first READY task: Issue #199 / SEC-03 narrow backend implementation;
-   - SEC-03 must not implement authentication, a token, diagnostics, a settings split,
+   - SEC-03 completed the narrow backend implementation and SEC-04 was skipped;
+   - first READY task: Issue #199 / SEC-05 production-free completion audit;
+   - SEC-05 must not implement authentication, a token, diagnostics, a settings split,
      frontend behavior, root composition, or lifecycle changes.
 4. Completed backend and compatibility state:
    [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
@@ -38,6 +39,14 @@ Read only the sections needed by the active task.
    - Phase F/G completion audit: `../architecture/python-phase-fg-completion-audit.md`
    - security/admin settings boundary: `../architecture/security-admin-settings-roadmap.md`
    - lifecycle runtime contract: `../architecture/python-runtime-e09-lifecycle-contract.md`
+   - runtime base contract: `../architecture/python-runtime-base-contract.md`
+   - repository/filesystem contract: `../architecture/python-runtime-e03-repository-filesystem-contract.md`
+   - translation runtime contract: `../architecture/python-runtime-e04-translation-contract.md`
+   - autocomplete runtime contract: `../architecture/python-runtime-e05-autocomplete-contract.md`
+   - wildcard runtime contract: `../architecture/python-runtime-e06-wildcard-contract.md`
+   - AiO cache runtime contract: `../architecture/python-runtime-e08-aio-cache-contract.md`
+   - test-isolation contract: `../architecture/python-runtime-e10-test-isolation-contract.md`
+   - runtime state inventory: `../architecture/python-runtime-state-inventory.md`
    - compatibility registry: `../architecture/python-compatibility-shims.md`
    - queue identity: `../architecture/queue-ui-two-phase-correlation-addendum.md`
    - Prompt Studio execution projection: `../architecture/prompt-studio-execution-derived-projection.md`
@@ -65,7 +74,9 @@ RETAIN    P-API-01; P-API-02 parked
 PARKED    D-14 / Phase H root removal
 COMPLETE  #199 SEC-01 security/admin host-capability Contract
 COMPLETE  #199 SEC-02 response-confidentiality Contract
-READY     #199 SEC-03 narrow backend implementation
+COMPLETE  #199 SEC-03 narrow backend implementation
+SKIPPED   #199 SEC-04 frontend settings migration
+READY     #199 SEC-05 security completion audit
 EVENT     next ordinary release N -> later D-14 re-audit
 ```
 
@@ -142,10 +153,9 @@ RuntimeConfig/bootstrap.
 
 ## Following state
 
-After SEC-01:
+After SEC-03:
 
-1. run the exact SEC-03 response-confidentiality implementation in the security
-   roadmap and SEC-02 Contract;
+1. run the exact SEC-05 production-free completion audit in the security roadmap;
 2. keep diagnostics absent by default when no reliable authorization owner exists;
 3. do not reopen Phase F/G, P-API-02, or D-14 as a side effect;
 4. let the next ordinary release containing final shims become release N;

--- a/easyuse_anima/api/responses.py
+++ b/easyuse_anima/api/responses.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping, cast
 
 
 REQUEST_ID_HEADER = "X-Request-ID"
+_SENSITIVE_RESPONSE_MARKER = "_easyuse_anima_sensitive_response"
 
 _PROFILE_MUTATION_HTTP_MAPPINGS: tuple[tuple[str, int, str, str], ...] = (
     (
@@ -61,6 +62,13 @@ def attach_request_id_header(response, request_id: str):
     headers = getattr(response, "headers", None)
     if headers is not None:
         headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
+def _attach_no_store_header(response):
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        headers["Cache-Control"] = "no-store"
     return response
 
 
@@ -207,6 +215,10 @@ def build_request_correlator(
     """Build the root-compatible cancellation and correlation boundary."""
 
     def _request_correlated(handler):
+        sensitive_response = (
+            getattr(handler, _SENSITIVE_RESPONSE_MARKER, False) is True
+        )
+
         @wraps(handler)
         async def correlated_handler(request):
             request_id = create_id()
@@ -216,9 +228,11 @@ def build_request_correlator(
                 raise
             except Exception as exc:
                 if isinstance(exc, get_http_exception_type()):
+                    if sensitive_response:
+                        _attach_no_store_header(exc)
                     attach_id_header(exc, request_id)
                     raise
-                get_logger().exception(
+                get_logger().error(
                     "Unhandled EasyUseAnima API error (request_id=%s)",
                     request_id,
                 )
@@ -227,6 +241,8 @@ def build_request_correlator(
                     "internal_error",
                     "An unexpected server error occurred.",
                 )
+            if sensitive_response:
+                _attach_no_store_header(response)
             return correlate(response, request_id)
 
         setattr(correlated_handler, "_easyuse_anima_request_correlation", True)

--- a/easyuse_anima/api/routes/long_text_settings.py
+++ b/easyuse_anima/api/routes/long_text_settings.py
@@ -57,6 +57,16 @@ def build_long_text_settings_handlers(
             await run_file_io(save_long_text_settings_payload, values)
         )
 
+    setattr(
+        get_long_text_settings_handler,
+        "_easyuse_anima_sensitive_response",
+        True,
+    )
+    setattr(
+        save_long_text_settings_handler,
+        "_easyuse_anima_sensitive_response",
+        True,
+    )
     return get_long_text_settings_handler, save_long_text_settings_handler
 
 

--- a/easyuse_anima/api/routes/settings.py
+++ b/easyuse_anima/api/routes/settings.py
@@ -49,6 +49,8 @@ def build_settings_handlers(
             return unknown_setting_response()
         return json_response(payload)
 
+    setattr(get_settings_handler, "_easyuse_anima_sensitive_response", True)
+    setattr(set_setting_handler, "_easyuse_anima_sensitive_response", True)
     return get_settings_handler, set_setting_handler
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -73954,118 +73954,126 @@
         "functions": [
           {
             "async": false,
-            "end_line": 49,
+            "end_line": 50,
             "kind": "function",
-            "line": 34,
+            "line": 35,
             "loc": 16,
             "qualified_name": "error_payload"
           },
           {
             "async": false,
-            "end_line": 55,
+            "end_line": 56,
             "kind": "function",
-            "line": 52,
+            "line": 53,
             "loc": 4,
             "qualified_name": "create_request_id"
           },
           {
             "async": false,
-            "end_line": 64,
+            "end_line": 65,
             "kind": "function",
-            "line": 58,
+            "line": 59,
             "loc": 7,
             "qualified_name": "attach_request_id_header"
           },
           {
             "async": false,
-            "end_line": 86,
+            "end_line": 72,
             "kind": "function",
-            "line": 67,
+            "line": 68,
+            "loc": 5,
+            "qualified_name": "_attach_no_store_header"
+          },
+          {
+            "async": false,
+            "end_line": 94,
+            "kind": "function",
+            "line": 75,
             "loc": 20,
             "qualified_name": "correlate_response"
           },
           {
             "async": false,
-            "end_line": 104,
+            "end_line": 112,
             "kind": "function",
-            "line": 89,
+            "line": 97,
             "loc": 16,
             "qualified_name": "build_error_response"
           },
           {
             "async": false,
-            "end_line": 102,
+            "end_line": 110,
             "kind": "function",
-            "line": 92,
+            "line": 100,
             "loc": 11,
             "qualified_name": "build_error_response._error_response"
           },
           {
             "async": false,
-            "end_line": 118,
+            "end_line": 126,
             "kind": "function",
-            "line": 107,
+            "line": 115,
             "loc": 12,
             "qualified_name": "build_contract_error_response"
           },
           {
             "async": false,
-            "end_line": 116,
+            "end_line": 124,
             "kind": "function",
-            "line": 110,
+            "line": 118,
             "loc": 7,
             "qualified_name": "build_contract_error_response._contract_error_response"
           },
           {
             "async": false,
-            "end_line": 195,
+            "end_line": 203,
             "kind": "function",
-            "line": 121,
+            "line": 129,
             "loc": 75,
             "qualified_name": "build_profile_error_response"
           },
           {
             "async": false,
-            "end_line": 193,
+            "end_line": 201,
             "kind": "function",
-            "line": 152,
+            "line": 160,
             "loc": 42,
             "qualified_name": "build_profile_error_response._profile_error_response"
           },
           {
             "async": false,
-            "end_line": 235,
+            "end_line": 251,
             "kind": "function",
-            "line": 198,
-            "loc": 38,
+            "line": 206,
+            "loc": 46,
             "qualified_name": "build_request_correlator"
           },
           {
             "async": false,
-            "end_line": 233,
+            "end_line": 249,
             "kind": "function",
-            "line": 209,
-            "loc": 25,
+            "line": 217,
+            "loc": 33,
             "qualified_name": "build_request_correlator._request_correlated"
           },
           {
             "async": true,
-            "end_line": 230,
+            "end_line": 246,
             "kind": "function",
-            "line": 210,
-            "loc": 21,
+            "line": 222,
+            "loc": 25,
             "qualified_name": "build_request_correlator._request_correlated.correlated_handler"
           }
         ],
         "is_package": false,
-        "loc": 244,
+        "loc": 260,
         "module": "easyuse_anima.api.responses",
-        "normalized_git_blob_sha1": "2d29dbb90c61cedd8a7bc190658a7e80d2841b5b",
+        "normalized_git_blob_sha1": "26440d8794e12895d044460246bc9934ea18cd80",
         "path": "easyuse_anima/api/responses.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 8,
-          "global_count": 3
+          "function_count": 9,
+          "global_count": 4
         }
       },
       {
@@ -74365,10 +74373,10 @@
           },
           {
             "async": false,
-            "end_line": 60,
+            "end_line": 70,
             "kind": "function",
             "line": 32,
-            "loc": 29,
+            "loc": 39,
             "qualified_name": "build_long_text_settings_handlers"
           },
           {
@@ -74389,9 +74397,9 @@
           }
         ],
         "is_package": false,
-        "loc": 63,
+        "loc": 73,
         "module": "easyuse_anima.api.routes.long_text_settings",
-        "normalized_git_blob_sha1": "6243033451ff6a532b1ee0f4d2825b268c87f6a1",
+        "normalized_git_blob_sha1": "dfb465f183130b36d8d418c423b566c76a7ddd00",
         "path": "easyuse_anima/api/routes/long_text_settings.py",
         "top_level": {
           "class_count": 0,
@@ -74647,10 +74655,10 @@
           },
           {
             "async": false,
-            "end_line": 52,
+            "end_line": 54,
             "kind": "function",
             "line": 17,
-            "loc": 36,
+            "loc": 38,
             "qualified_name": "build_settings_handlers"
           },
           {
@@ -74671,9 +74679,9 @@
           }
         ],
         "is_package": false,
-        "loc": 55,
+        "loc": 57,
         "module": "easyuse_anima.api.routes.settings",
-        "normalized_git_blob_sha1": "86d3953f2f78ba58bfad7cdfa9f9ec398f0c3504",
+        "normalized_git_blob_sha1": "d6a75144cb4735e1b43c61976f527eaea7dab5ad",
         "path": "easyuse_anima/api/routes/settings.py",
         "top_level": {
           "class_count": 0,

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -972,6 +972,7 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         self.assertEqual(response["payload"], payload)
         self.assertNotIn("request_id", response["payload"])
         self.assertEqual(response.headers["X-Request-ID"], request_id)
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
 
     def test_translation_status_taxonomy_keeps_request_correlation(self):
         api, routes = load_api_routes()
@@ -1023,13 +1024,14 @@ class ApiRequestCorrelationTests(unittest.TestCase):
                 response.headers["X-Request-ID"],
             )
 
-    def test_unexpected_exception_is_safe_500_and_logged_with_request_id(self):
+    def test_unexpected_exception_is_safe_500_and_logged_with_request_id_only(self):
         api, routes = load_api_routes()
         request_id = "32345678-1234-4567-89ab-1234567890ab"
         secret = r"C:\Users\alice\secret.json API_TOKEN=top-secret"
         with (
             patch.object(api, "create_request_id", return_value=request_id),
             patch.object(api, "_list_aio_profiles", side_effect=RuntimeError(secret)),
+            patch.object(api._LOGGER, "error") as log_error,
             patch.object(api._LOGGER, "exception") as log_exception,
         ):
             response = asyncio.run(
@@ -1047,23 +1049,29 @@ class ApiRequestCorrelationTests(unittest.TestCase):
             },
         )
         self.assertEqual(response.headers["X-Request-ID"], request_id)
-        log_exception.assert_called_once()
-        self.assertEqual(log_exception.call_args.args[1], request_id)
+        self.assertNotIn("Cache-Control", response.headers)
+        log_error.assert_called_once_with(
+            "Unhandled EasyUseAnima API error (request_id=%s)",
+            request_id,
+        )
+        log_exception.assert_not_called()
         serialized = json.dumps(response["payload"])
+        serialized_log = repr(log_error.call_args)
         for forbidden in ("alice", "secret.json", "API_TOKEN", "top-secret", "Traceback"):
             self.assertNotIn(forbidden, serialized)
+            self.assertNotIn(forbidden, serialized_log)
 
     def test_cancelled_request_is_not_normalized_or_logged(self):
         api, routes = load_api_routes()
         with (
             patch.object(api, "_run_file_io", side_effect=asyncio.CancelledError()),
-            patch.object(api._LOGGER, "exception") as log_exception,
+            patch.object(api._LOGGER, "error") as log_error,
         ):
             with self.assertRaises(asyncio.CancelledError):
                 asyncio.run(
                     routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest())
                 )
-        log_exception.assert_not_called()
+        log_error.assert_not_called()
 
     def test_http_exception_preserves_control_flow_and_body_with_header(self):
         from aiohttp import web as aiohttp_web
@@ -1079,7 +1087,7 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         with (
             patch.object(api, "create_request_id", return_value=request_id),
             patch.object(api.web, "HTTPException", aiohttp_web.HTTPException),
-            patch.object(api._LOGGER, "exception") as log_exception,
+            patch.object(api._LOGGER, "error") as log_error,
         ):
             with self.assertRaises(aiohttp_web.HTTPNotFound) as raised:
                 asyncio.run(raises_http_exception(JsonRequest()))
@@ -1087,7 +1095,30 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         self.assertEqual(raised.exception.status, 404)
         self.assertEqual(raised.exception.text, "not found")
         self.assertEqual(raised.exception.headers["X-Request-ID"], request_id)
-        log_exception.assert_not_called()
+        self.assertNotIn("Cache-Control", raised.exception.headers)
+        log_error.assert_not_called()
+
+    def test_sensitive_http_exception_keeps_control_flow_and_adds_no_store(self):
+        api, routes = load_api_routes()
+        request_id = "52345678-1234-4567-89ab-1234567890ab"
+        original = FakeHTTPException(status=409, body=b"conflict")
+
+        with (
+            patch.object(api, "create_request_id", return_value=request_id),
+            patch.object(api, "_get_settings_payload_sync", side_effect=original),
+            patch.object(api._LOGGER, "error") as log_error,
+        ):
+            with self.assertRaises(FakeHTTPException) as raised:
+                asyncio.run(
+                    routes.handlers["/easyuse_anima/settings"](JsonRequest())
+                )
+
+        self.assertIs(raised.exception, original)
+        self.assertEqual(raised.exception.status, 409)
+        self.assertEqual(raised.exception.body, b"conflict")
+        self.assertEqual(raised.exception.headers["X-Request-ID"], request_id)
+        self.assertEqual(raised.exception.headers["Cache-Control"], "no-store")
+        log_error.assert_not_called()
 
     def test_lora_preview_keeps_raw_and_binary_contracts_with_header(self):
         api, routes = load_api_routes()
@@ -1952,7 +1983,7 @@ class ApiLoraProfileFixRouteTests(unittest.TestCase):
                 "_fix_lora_profile_payload",
                 side_effect=ValueError(secret),
             ),
-            patch.object(api._LOGGER, "exception") as log_exception,
+            patch.object(api._LOGGER, "error") as log_error,
         ):
             response = asyncio.run(
                 routes.handlers["/easyuse_anima/lora_profiles/fix"](
@@ -1970,7 +2001,7 @@ class ApiLoraProfileFixRouteTests(unittest.TestCase):
         serialized = json.dumps(response["payload"])
         for forbidden in ("alice", "profile.json", "API_TOKEN", "top-secret"):
             self.assertNotIn(forbidden, serialized)
-        log_exception.assert_called_once()
+        log_error.assert_called_once()
 
 
 class ApiWildcardRouteTests(unittest.TestCase):
@@ -2186,6 +2217,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
                     )
                 )
                 self.assertTrue(handler._easyuse_anima_request_correlation)
+                self.assertTrue(handler._easyuse_anima_sensitive_response)
 
     def test_get_keeps_dynamic_payload_seam_and_legacy_success_shape(self):
         api, routes = load_api_routes()
@@ -2204,6 +2236,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
 
         self.assertEqual(response["status"], 200)
         self.assertIs(response["payload"], payload)
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
         get_payload.assert_called_once_with()
 
     def test_set_keeps_dynamic_seam_raw_value_default_and_success_shape(self):
@@ -2235,6 +2268,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
 
             self.assertEqual(response["status"], 200)
             self.assertIs(response["payload"], payload)
+            self.assertEqual(response.headers["Cache-Control"], "no-store")
             save_payload.assert_called_once_with(
                 data["key"],
                 expected_value,
@@ -2255,6 +2289,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
         self.assertEqual(response["status"], 422)
         self.assertEqual(response["payload"]["code"], "invalid_request")
         self.assertEqual(response["payload"]["details"], {"field": "key"})
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
         save_payload.assert_not_called()
         file_io.assert_not_called()
 
@@ -2285,6 +2320,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
         serialized = json.dumps(response["payload"])
         for forbidden in ("alice", "settings.json", "API_TOKEN", "top-secret"):
             self.assertNotIn(forbidden, serialized)
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
 
     def test_unexpected_save_failure_stays_on_correlated_safe_500_boundary(self):
         api, routes = load_api_routes()
@@ -2295,7 +2331,7 @@ class ApiSettingsRouteTests(unittest.TestCase):
                 "_save_setting_payload_sync",
                 side_effect=ValueError(secret),
             ),
-            patch.object(api._LOGGER, "exception") as log_exception,
+            patch.object(api._LOGGER, "error") as log_error,
         ):
             response = asyncio.run(
                 routes.handlers["/easyuse_anima/set_setting"](
@@ -2313,7 +2349,8 @@ class ApiSettingsRouteTests(unittest.TestCase):
         serialized = json.dumps(response["payload"])
         for forbidden in ("alice", "settings.json", "API_TOKEN", "top-secret"):
             self.assertNotIn(forbidden, serialized)
-        log_exception.assert_called_once()
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
+        log_error.assert_called_once()
 
 
 class ApiLongTextSettingsRouteTests(unittest.TestCase):
@@ -2415,6 +2452,7 @@ class ApiLongTextSettingsRouteTests(unittest.TestCase):
                     )
                 )
                 self.assertTrue(handler._easyuse_anima_request_correlation)
+                self.assertTrue(handler._easyuse_anima_sensitive_response)
 
     def test_get_route_keeps_dynamic_payload_seam(self):
         api, routes = load_api_routes()
@@ -2437,6 +2475,7 @@ class ApiLongTextSettingsRouteTests(unittest.TestCase):
 
         self.assertEqual(response["status"], 200)
         self.assertEqual(response["payload"], payload)
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
         get_payload.assert_called_once_with()
 
     def test_save_route_preserves_wrapped_and_legacy_payloads(self):
@@ -2466,7 +2505,21 @@ class ApiLongTextSettingsRouteTests(unittest.TestCase):
 
                 self.assertEqual(response["status"], 200)
                 self.assertEqual(response["payload"], payload)
+                self.assertEqual(response.headers["Cache-Control"], "no-store")
                 save_payload.assert_called_once_with(expected_values)
+
+    def test_invalid_save_payload_is_correlated_and_not_cached(self):
+        api, routes = load_api_routes()
+
+        response = asyncio.run(
+            routes.handlers["/easyuse_anima/long_text_settings/save"](
+                JsonRequest({"values": []})
+            )
+        )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(response["payload"]["code"], "invalid_request")
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
 
 
 class ApiAutocompleteRouteTests(unittest.TestCase):
@@ -3552,7 +3605,7 @@ class ApiRequestContractTests(unittest.TestCase):
                 "_list_aio_profiles",
                 side_effect=RuntimeError("storage programming error"),
             ),
-            patch.object(api._LOGGER, "exception") as log_exception,
+            patch.object(api._LOGGER, "error") as log_error,
         ):
             response = asyncio.run(
                 routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest())
@@ -3563,7 +3616,7 @@ class ApiRequestContractTests(unittest.TestCase):
             response["payload"]["request_id"],
             response.headers["X-Request-ID"],
         )
-        log_exception.assert_called_once()
+        log_error.assert_called_once()
 
     def test_profile_list_does_not_mask_arbitrary_value_error_as_invalid_request(self):
         api, routes = load_api_routes()
@@ -3580,14 +3633,14 @@ class ApiRequestContractTests(unittest.TestCase):
                     operation_name,
                     side_effect=ValueError("storage programming error"),
                 ),
-                patch.object(api._LOGGER, "exception") as log_exception,
+                patch.object(api._LOGGER, "error") as log_error,
             ):
                 response = asyncio.run(routes.handlers[route](JsonRequest()))
 
             self.assertEqual(response["status"], 500)
             self.assertEqual(response["payload"]["code"], "internal_error")
             self.assertNotEqual(response["payload"]["code"], "invalid_request")
-            log_exception.assert_called_once()
+            log_error.assert_called_once()
 
     def test_normal_settings_and_profile_success_payloads_remain_compatible(self):
         api, routes = load_api_routes()
@@ -3665,6 +3718,7 @@ class ApiPathRedactionTests(unittest.TestCase):
                 routes.handlers["/easyuse_anima/autocomplete_status"](JsonRequest())
             )
 
+        self.assertNotIn("Cache-Control", response.headers)
         payload = response["payload"]
         self.assertEqual(payload["source"], "selected")
         self.assertEqual(payload["source_label"], "Selected dataset")
@@ -3701,6 +3755,7 @@ class ApiPathRedactionTests(unittest.TestCase):
                 )
             )
 
+        self.assertNotIn("Cache-Control", response.headers)
         payload = response["payload"]
         self.assertEqual(payload["query"], produced["query"])
         self.assertEqual(payload["results"], produced["results"])
@@ -3738,6 +3793,7 @@ class ApiPathRedactionTests(unittest.TestCase):
                 )
             )
 
+        self.assertNotIn("Cache-Control", response.headers)
         payload = response["payload"]
         self.assertEqual(payload["tokens"], produced["tokens"])
         self.assertEqual(payload["future"], produced["future"])
@@ -3765,6 +3821,7 @@ class ApiPathRedactionTests(unittest.TestCase):
                 routes.handlers["/easyuse_anima/wildcards"](JsonRequest())
             )
 
+        self.assertNotIn("Cache-Control", response.headers)
         payload = response["payload"]
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["items"], ["artist/name"])

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -655,13 +655,13 @@ class PromptTranslationApiTests(unittest.TestCase):
                         "resolve_prompt_translation_settings",
                         side_effect=error,
                     ),
-                    patch.object(api._LOGGER, "exception") as log_exception,
+                    patch.object(api._LOGGER, "error") as log_error,
                 ):
                     response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
                 self.assertEqual(response["status"], 500)
                 self.assertEqual(response["payload"]["code"], "internal_error")
                 self.assertNotEqual(response["payload"]["code"], "translation_upstream_error")
-                log_exception.assert_called_once()
+                log_error.assert_called_once()
 
         response = asyncio.run(handler(JsonRequest([])))
         self.assertEqual(response["status"], 400)


### PR DESCRIPTION
## 목적과 변경 경계

Issue #199 / SEC-03 response-confidentiality 구현입니다.

- unexpected API exception 로그를 traceback/exception data 없이 correlated request ID만 포함하는 fixed error event로 변경
- settings 및 long-text settings 4개 handler에 private sensitivity marker를 부여하고 모든 반환/재전파 outcome에 `Cache-Control: no-store` 적용
- ordinary wildcard/autocomplete response의 기존 redaction 및 cache contract 유지
- SEC-04를 건너뛰고 SEC-05 production-free completion audit을 다음 READY task로 고정

## Base -> Head

- `95354b0ec503e97d1015f20c07b82c6f1a34080a` -> `0b62b3908588b040c4e05e69b27a1227225c1166`

## 주요 파일과 보존 계약

- `easyuse_anima/api/responses.py`: fixed safe log event, private sensitive-response handling
- `easyuse_anima/api/routes/settings.py`: settings handler 2개 marker
- `easyuse_anima/api/routes/long_text_settings.py`: long-text handler 2개 marker
- direct API/translation tests 및 generated analyzer baseline
- SEC roadmap/Contract/index 상태 갱신

보존: status/body/request-ID, CancelledError/HTTPException control flow, handler identity와 route order/signature/registration, repeated initialize, E-09 lifecycle, settings storage/projection/frontend behavior, ordinary endpoint redaction.

## 검증

- changed Python compile 및 fatal Ruff: PASS
- ApiRequestCorrelationTests 15, ApiSettingsRouteTests 8, ApiLongTextSettingsRouteTests 6, ApiPathRedactionTests 4: PASS
- PromptTranslationApiTests 13: PASS
- PythonBootstrapTests 13, PythonPackageSkeletonTests 1: PASS
- import-boundary owners 16, PythonBackendAnalyzerTests 19: PASS
- final SHA official full: Python 1,471 tests, frontend 120 JS files, Pyright baseline, import boundary, size/complexity, diff check 모두 PASS
- package/live/browser: pure log/header boundary이므로 Contract상 미실행

## 남은 위험과 rollback

- deployment verdict는 계속 `TRUSTED_DEPLOYMENT_ONLY`이며 authentication/capability/diagnostics를 추가하지 않습니다.
- rollback은 이 PR 하나를 revert하면 되며 runtime state, storage, schema, migration, frontend rollback은 없습니다.

## Next

- SEC-05 production-free completion audit
- D-14, release, tag, Registry는 별도 roadmap gate가 명시적으로 허용할 때까지 시작하지 않음
