### PR TITLE
docs: define backend final convergence roadmap

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,177 +1,169 @@
 # Python Backend Architecture
 
-These documents define the target backend architecture, migration rules, and reviewed
+These documents define the target backend architecture, migration rules and reviewed
 cross-surface contracts. They do not imply that every target state is implemented.
 
-Before selecting work, read the bounded execution policy in
-[`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md),
-then only the active task section, owning Issue, direct source, and direct tests.
+Read the bounded execution policy first, then only the active task, its owning Issue,
+direct source and direct tests.
 
 ## Active sequencing
 
-- Phase D root/package consolidation is complete.
-- Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  and Phase E runtime ownership/lifecycle/test isolation are complete.
-- Phase F typed boundaries and Issue
-  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188) G-04/G-05/G-06
-  quality gates are complete. G-CLOSE records zero unfinished executable Phase F/G
-  tasks.
-- P-WC-01/P-WC-02 completed the Wildcard direct-shim conversion.
-- P-API-01 / Issue
-  [#582](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/582) completed with a
-  **RETAIN** verdict. P-API-02 is not READY.
-- D-14/Phase H root removal is correctly parked by production-import, release-window,
-  consumer, rollback, and breaking-change gates.
-- The completed compatibility lane is recorded in
-  [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md).
-- Issue [#199](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/199) / SEC-01
-  completed with **TRUSTED_DEPLOYMENT_ONLY**. SEC-02 completed with a direct-owner
-  **FEASIBLE** result, SEC-03 implemented it, SEC-04 was skipped, and SEC-05 closed the
-  lane with no follow-up. There is no READY security task.
-- [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md) owns that
-  completed lane. It does not reopen Phase F/G, P-API-02, or D-14.
-- Released baseline: 0.6.2. Registry activation is external administration and does
-  not block `dev`; do not republish or mutate the release.
+- Active final-convergence plan:
+  [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md)
+- Active owner: Issue
+  [#593](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/593)
+- First READY task: FC-01 original Definition-of-Done closure audit.
+- Parent architecture: Issue
+  [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185)
+- Compatibility/release ledger: Issue
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- E-09 lifecycle owner: completed Issue
+  [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
 
 ```text
-COMPLETE Phase D/E/F/G
-  -> COMPLETE P-WC direct-shim preparation
-  -> RETAIN P-API current root production facade
-  -> PARKED H/D-14 compatibility retirement
+COMPLETE Phase D/E/F/G and G-CLOSE
+COMPLETE P-WC Wildcard direct-shim conversion
+RETAIN   P-API-01 current root API production facade
+COMPLETE SEC-01 through SEC-05 security/admin lane
 
-COMPLETE #199 SEC-01 security/admin Contract
-  -> COMPLETE SEC-02 response-confidentiality Contract
-  -> COMPLETE SEC-03 narrow backend implementation
-  -> SKIPPED SEC-04 frontend migration
-  -> COMPLETE SEC-05 completion audit; no follow-up
+READY    FC-01 Definition-of-Done closure audit
+  ->     FC-02 complete owner-boundary gate
+  ->     FC-03 root API patch-owner migration
+  ->     FC-04 canonical API application/E-09 convergence
+  ->     FC-05 technical completion audit
 
-EVENT next ordinary release N
-  -> later H/D-14 re-audit
+EVENT    ordinary release N
+  ->     later H/D-14 compatibility re-audit
 ```
+
+The prior `no READY task` conclusion was correct for completed F/G/security work and
+compatibility deletion. It did not mean that the initial architecture Definition of
+Done had been fully reconciled.
 
 ## Current code boundary
 
-The current backend is functional and validated.
+The backend is functional and validated.
 
-### Compatibility/lifecycle boundary
+### Completed boundaries
 
-- root `__init__.py` imports root `api.py` and passes `api.register_routes` into
-  bootstrap initialization;
-- importing root `api.py` creates the translation route executor and route application
-  before bootstrap freezes the RuntimeServices cleanup plan;
-- root `api.py` remains a production route/payload/runtime facade;
-- root `wildcard_engine.py` is an import-only compatibility shim over canonical
-  Wildcard owners, but its final form has not shipped and release N has not begun.
+- node implementations live in canonical packages and root `nodes.py` is an explicit
+  compatibility facade;
+- feature routes, typed boundaries, migrations and common error categories are owned by
+  canonical packages;
+- RuntimeServices ownership, cleanup, rollback and isolated test runtime are complete;
+- Wildcard production consumers use canonical owners and root `wildcard_engine.py` is
+  import-only;
+- public API coverage, size-growth ratchet and canonical test ownership are executable
+  gates;
+- sensitive settings responses use safe logging and `no-store` under the completed
+  TRUSTED_DEPLOYMENT_ONLY security boundary.
 
-The API import order is part of the E-09 lifecycle contract. Any future candidate must
-preserve one application/executor identity, executor-before-cleanup-plan timing,
-repeated initialize behavior, terminal shutdown, and late root-import safety without a
-canonical-to-root back-reference.
+### Remaining technical convergence
 
-### Security/admin boundary
+1. The import-boundary checker covers a reviewed subset of canonical package groups.
+   The G-06 owner map contains additional canonical feature, adapter and composition
+   groups that need role-aware blocking coverage.
+2. Root `api.py` is still the production API application/composition module. Importing
+   it creates the translation route executor, handlers, route definitions and registrar
+   before bootstrap creates RuntimeServices.
+3. P-API-01 retained that shape because request-time root-global patch seams and E-09
+   creation timing could not both be preserved by the evaluated canonical candidates.
+   It explicitly permits a revisit after those patch seams migrate to exact canonical
+   owners. FC-03 is that prerequisite.
 
-Current ComfyUI source provides user-profile selection, origin/host controls, and
-optional CORS, but no demonstrated authenticated administrator capability for
-custom-node routes. The `comfy-user` header is a user-data selector, not proof of
-administrator authority.
+### Compatibility boundary
 
-Current EasyUseAnima settings routes read and mutate the settings projection. The
-projection contains ordinary UI choices together with local/network configuration,
-including `wildcard.extra_paths`, `naia.host`, `naia.port`, and
-`naia.allow_remote_api`.
+Actual root-shim removal remains event-gated:
 
-[`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md)
-classifies the surface as **TRUSTED_DEPLOYMENT_ONLY**. `comfy-user`, `request.remote`,
-Host, Origin, and forwarded headers are not administrator authentication. The current
-settings UI remains inside one trusted-operator boundary, diagnostics remain absent,
-and ordinary wildcard/autocomplete endpoints remain redacted. SEC-02 proved, and
-SEC-03 implemented, safe unexpected-error logging and `Cache-Control: no-store` on
-sensitive settings responses inside three direct production owners without root
-composition or lifecycle change.
+- final forms need an ordinary published release N;
+- consumer and harm evidence must be considered;
+- public removal needs breaking-change approval, release notes and rollback;
+- low-cost shims may be deliberately retained.
 
-## Core documents
+Technical architecture completion does not require deleting every public shim.
 
-### Completed security/admin lane
+## Fixed owner model
 
-- [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md):
-  completed Issue #199 queue, validation, SEC-03 implementation, and SEC-05 audit.
-- [`security-admin-settings-sec01-contract.md`](security-admin-settings-sec01-contract.md):
-  completed deployment/threat matrix, host-capability audit, settings-field
-  classification, logging/redaction Contract, E-09 disposition, and
-  TRUSTED_DEPLOYMENT_ONLY verdict.
-- [`security-admin-settings-sec02-response-contract.md`](security-admin-settings-sec02-response-contract.md):
-  safe fixed logging, private sensitivity marker, `no-store` coverage, exact owner set,
-  preserved invariants, verification ownership, and SEC-03 rollback/stop boundary.
+The target owner matrix remains:
 
-### Completed backend and compatibility plan
+| Surface | Owner and durable responsibility |
+| --- | --- |
+| Root `__init__.py` | permanent ComfyUI entrypoint; exported mappings and one guarded startup path |
+| Root compatibility files | explicit aliases/facades only; no new feature, I/O, cache or lifecycle logic |
+| `bootstrap.py` | sole lifecycle/composition owner, RuntimeConfig, initialize/shutdown and concrete wiring |
+| `runtime.py` | installed RuntimeServices identity and process runtime access |
+| `registration.py` | pure node mapping composition |
+| `nodes/*` | raw ComfyUI-to-feature adapters |
+| `api/application` | canonical API application identities after FC-04 |
+| `api/router.py` | route order/signature/resolver/registrar infrastructure |
+| `api/routes/*` | request parse, feature call and response/error mapping |
+| Feature packages | domain rules, typed contracts, migrations and feature ports |
+| `infrastructure/*` | generic Comfy/filesystem/HTTP integration without feature meaning |
+| `common` | proven domain-neutral primitives only |
 
-- [`post-phase-e-maintenance-roadmap.md`](post-phase-e-maintenance-roadmap.md):
-  completed Phase F/G plan, P-WC/P-API results, release-N runway, and D-14 event gates.
+FC-02 must enforce this complete role model without forcing adapters and composition
+modules through feature-only rules.
+
+## E-09 lifecycle invariants
+
+All final-convergence work preserves:
+
+- bootstrap as the only lifecycle owner;
+- one initialize/shutdown lock and one atexit registration;
+- terminal/idempotent shutdown and no hot reinitialize;
+- repeated initialize preserving runtime identity while refreshing routes;
+- one translation route executor created before cleanup-plan composition;
+- executor shutdown as cleanup item 1;
+- the fixed seven-step cleanup order;
+- expected-identity rollback and preservation of the original startup error;
+- retained route marker/routes and no invented route deregistration;
+- no file-I/O limiter or provider/client cleanup without a separate contract.
+
+FC-03 changes patch ownership only. FC-04 may move application construction only after
+its lifecycle Contract proves these invariants.
+
+## Core active documents
+
+- [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md):
+  FC-01 through FC-07, technical versus compatibility completion, optional large-module
+  disposition, validation and Codex resume instruction.
+- [`python-backend.md`](python-backend.md): target architecture, phases and original
+  Definition of Done.
 - [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md):
-  P-API creation-order, identity, terminal lifecycle, cleanup, rollback, RETAIN result,
-  and revisit events.
+  current API identity graph, RETAIN verdict, root patch-time seam inventory and revisit
+  events.
 - [`python-runtime-e09-lifecycle-contract.md`](python-runtime-e09-lifecycle-contract.md):
-  authoritative bootstrap lifecycle, fixed cleanup order, startup rollback, retained
-  no-op boundaries, and terminal shutdown contract.
-- [`python-runtime-base-contract.md`](python-runtime-base-contract.md):
-  RuntimeServices identity, construction, installation, and cleanup-plan base contract.
-- [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md):
-  repository and filesystem runtime ownership.
-- [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md):
-  translation service, facade, route-executor, and cleanup ownership.
-- [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
-  autocomplete index and snapshot lifecycle ownership.
-- [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md):
-  wildcard cache and source lifecycle ownership.
-- [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md):
-  AiO first-pass cache ownership and cleanup contract.
-- [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md):
-  package, runtime, and host test-isolation boundary.
-- [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md):
-  completed mutable-runtime owner and disposition inventory.
-- [`python-phase-fg-completion-audit.md`](python-phase-fg-completion-audit.md):
-  final Phase F/G evidence reconciliation and zero-follow-up decision.
-- [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md):
-  analyzer-owned line metrics and incremental growth ratchet.
-- [`python-test-ownership-g06a-contract.md`](python-test-ownership-g06a-contract.md):
-  canonical package direct test owners and shared matrix ownership.
-- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md):
-  completed public-surface owner map and no-G-04B decision.
-- [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md):
-  FEASIBLE Wildcard direct-shim decision and P-WC-02 boundary.
-- [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
-  completed D-08 and Phase E execution record plus post-Phase-E D-14 verdict.
-
-### Target architecture and policy
-
-- [`python-backend.md`](python-backend.md): target ownership, phase definitions, and
-  overall Definition of Done.
-- [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
-  accumulated historical execution detail; not the current immediate queue.
-- [`python-compatibility-shims.md`](python-compatibility-shims.md): current root/shim
-  inventory, known consumers, release evidence, and removal gates.
-- [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
-  monolith decision.
-- [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): support-window,
-  evidence, staged-retirement, and public-breaking-change policy.
+  authoritative lifecycle and cleanup/rollback contract.
+- [`python-compatibility-shims.md`](python-compatibility-shims.md): current root surfaces,
+  release evidence and ADR-002 gates.
 - [`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md):
-  context budget, focused test ladder, evidence reuse, and reporting.
+  task-card, focused validation, evidence reuse and context policy.
 
-## E-09 conflict guardrails
+## Completed evidence documents
 
-- A security capability, when justified by a later Contract, is immutable process-start
-  configuration owned through RuntimeConfig/bootstrap.
-- It does not add a second lifecycle lock, atexit hook, shutdown/reset API, closeable
-  registry, or hot reinitialize behavior.
-- G-05 thresholds do not split the cohesive lifecycle owner merely to reduce line
-  counts.
-- G-06 keeps lifecycle integration evidence with bootstrap/runtime and does not add
-  production reload/reset behavior.
-- Release/package shutdown evidence runs in a fresh process.
+Read only when the active task touches the boundary:
+
+- [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md): completed D-08
+  and Phase E execution record.
+- [`python-phase-fg-completion-audit.md`](python-phase-fg-completion-audit.md): completed
+  typed/quality lane under its scoped criteria.
+- [`python-public-api-g04a-audit.md`](python-public-api-g04a-audit.md)
+- [`python-size-complexity-g05a-contract.md`](python-size-complexity-g05a-contract.md)
+- [`python-test-ownership-g06a-contract.md`](python-test-ownership-g06a-contract.md)
+- [`python-wildcard-pwc01-facade-feasibility.md`](python-wildcard-pwc01-facade-feasibility.md)
+- [`security-admin-settings-roadmap.md`](security-admin-settings-roadmap.md)
+- [`python-runtime-base-contract.md`](python-runtime-base-contract.md)
+- [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md)
+- [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md)
+- [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md)
+- [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md)
+- [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md)
+- [`python-runtime-e08-aio-cache-contract.md`](python-runtime-e08-aio-cache-contract.md)
+- [`python-runtime-e10-test-isolation-contract.md`](python-runtime-e10-test-isolation-contract.md)
 
 ## Cross-surface references
 
-Read only when the task touches the surface:
+Read only when needed:
 
 - [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md)
 - [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md)
@@ -183,15 +175,10 @@ Read only when the task touches the surface:
 
 - Branch/release/validation policy: [`MAINTAINING.md`](../../MAINTAINING.md)
 - Development entrypoint: [`../development/README.md`](../development/README.md)
-- Completed security/admin queue: `security-admin-settings-roadmap.md`
-- Completed Phase F/G and compatibility event gates: `post-phase-e-maintenance-roadmap.md`
-- Target architecture: `python-backend.md`, ADR-001, ADR-002
-- Feature behavior: owning Issue
+- Active technical queue: `backend-final-convergence-roadmap.md`
+- Target architecture: `python-backend.md`, ADR-001 and ADR-002
 - Compatibility decisions: Issue #186 plus the shim registry
-- Security/admin settings boundary: Issue #199
+- Feature behavior: owning Issue
 
-The efficiency protocol chooses the smallest sufficient evidence; it does not weaken
-correctness, compatibility, package, live, security, or release gates.
-
-No document in this directory authorizes root deletion, public breaking changes,
-release publication, tags, Registry actions, or an authentication mechanism by itself.
+No document here independently authorizes root deletion, a public breaking change,
+release publication, tags or Registry actions.

--- a/docs/architecture/backend-final-convergence-roadmap.md
+++ b/docs/architecture/backend-final-convergence-roadmap.md
@@ -1,0 +1,393 @@
+# Backend Final Convergence Roadmap
+
+## Status and authority
+
+- Status: active final-convergence plan.
+- Active owner: Issue #593.
+- Parent architecture: Issue #185.
+- Compatibility ledger: Issue #186 and ADR-002.
+- Lifecycle authority: E-09 / Issue #187.
+- Current released baseline: 0.6.2.
+- Current completed lanes: Phase D, Phase E, Phase F, G-04/G-05/G-06, P-WC,
+  P-API-01, G-CLOSE, and SEC-01 through SEC-05.
+- First READY task: FC-01, production-free Definition-of-Done closure audit.
+
+This document supersedes the `no READY task` conclusion only for the initial backend
+architecture Definition of Done. It does not reopen completed Phase F/G or security
+work, and it does not authorize P-API-02, root deletion, release, tag, or Registry work.
+
+## 1. Current stop and the remaining gap
+
+The current event-gated stop is correct for compatibility retirement:
+
+- P-API-01 retained root `api.py` because current request-time root patch seams and the
+  E-09 executor-before-cleanup-plan timing cannot both be preserved by the previously
+  evaluated canonical application shapes;
+- P-API-02 is not READY from that verdict;
+- final direct shims have not all shipped in a release N;
+- consumer evidence and public breaking-change approval do not authorize removal.
+
+The stop is not identical to the original technical Definition of Done:
+
+1. The blocking import-boundary checker covers a reviewed subset of canonical package
+   groups, while the G-06 owner map covers the complete current package/test surface.
+2. Root `api.py` is still a production application/composition container rather than an
+   explicit compatibility facade.
+3. The P-API-01 retention document names a separate compatibility patch-owner migration
+   as a valid revisit event; that prerequisite has not been attempted.
+4. Several large-module exceptions have reviewed decomposition boundaries but no final
+   disposition. They are not all mandatory splits, but they need one finite audit.
+
+## 2. Two completion states
+
+### Technical architecture completion
+
+This state may be reached before release N:
+
+- `easyuse_anima` owns all production implementation;
+- root Python files are the permanent entrypoint or explicit compatibility
+  facades/shims;
+- every canonical owner group has a blocking role-aware import/dependency gate;
+- root `api.py` no longer creates the production application/runtime composition;
+- bootstrap remains the single E-09 lifecycle owner;
+- route, payload, error, workflow, profile, settings, node and object-identity contracts
+  remain compatible;
+- full, package/archive, no-host, lifecycle and representative host/API gates pass.
+
+### Compatibility retirement completion
+
+This state is event-gated:
+
+- an ordinary release publishes the final canonical-plus-shim forms as release N;
+- support-window, consumer, harm and rollback evidence are collected;
+- eligible private shims may be removed first;
+- public removal requires a reviewed breaking-change Issue and release note;
+- low-cost public shims may be deliberately retained indefinitely.
+
+Technical completion does not require deletion of every public shim.
+
+## 3. Ordered execution queue
+
+```text
+READY FC-01  original Definition-of-Done closure audit
+  -> FC-02   complete canonical owner-boundary gate
+  -> FC-03A  root API patch-owner compatibility Contract
+  -> FC-03B  canonical dependency/patch-owner Move
+  -> FC-04A  canonical API application + E-09 lifecycle Contract
+  -> FC-04B  cohesive production application Move
+  -> FC-05   technical completion audit
+
+EVENT FC-06  next ordinary release N
+  -> FC-07   later H/D-14 compatibility re-audit
+```
+
+Only one FC task is active by default.
+
+## 4. FC-01 — Original Definition-of-Done closure audit
+
+Type: Contract/audit; production-free.
+
+Map every checkbox in `python-backend.md` to current deterministic evidence and classify
+it as:
+
+```text
+complete
+technical gap
+compatibility event
+deliberate retain
+```
+
+Required checks:
+
+- compare the import-boundary checker's reviewed groups with the complete G-06 owner
+  groups and exact top-level canonical owners;
+- confirm whether adapters, feature packages, infrastructure, nodes/registration and
+  runtime/bootstrap have the intended role rules;
+- map each root file to permanent entrypoint, explicit shim/facade, or remaining
+  implementation;
+- reuse P-API-01's exact root symbol and patch-time inventory;
+- map E-09, typed/migration, public identity, package/archive, validation and shim gates;
+- identify the exact technical tasks required before FC-05.
+
+Do not create a duplicate inventory when the analyzer, compatibility fixture, G-06 map,
+Pyright/import ledgers or direct tests already own the evidence.
+
+Exit:
+
+- confirm or correct the FC-02 through FC-04 task boundaries;
+- publish one compact closure matrix;
+- select FC-02 as READY unless the audit proves a smaller prerequisite.
+
+## 5. FC-02 — Complete canonical owner-boundary gate
+
+Type: Contract/tool. A real violation may require a separate smallest correction Move.
+
+### Source of truth
+
+Use the G-06 production-path groups as the current complete owner inventory and the
+existing AST analyzer as the only import graph. Do not create a second repository
+inventory.
+
+### Required coverage
+
+The current role-aware gate must account for at least:
+
+```text
+feature/service:
+  aio, autocomplete, image, lora, naia, profiles, prompt, seed, settings,
+  translation, wildcard
+
+common:
+  common and canonical error primitives
+
+infrastructure:
+  the complete infrastructure package, with reviewed subroles where needed
+
+adapter:
+  api/routes and nodes
+
+composition/entry:
+  bootstrap, runtime, registration, API application/router, workflow adapter
+```
+
+The exact role rules are fixed by FC-01. Adapter and composition modules must not be
+forced through feature-only rules merely to increase coverage.
+
+### Implementation rules
+
+- extend the existing import-boundary contract/checker rather than adding another tool;
+- reject canonical-to-root imports, new runtime SCCs, feature-to-adapter/bootstrap/
+  registration back references, compatibility fallback imports and unowned side effects;
+- preserve intentional adapter-to-feature and composition-to-adapter directions;
+- do not broad-allowlist actual violations;
+- if violations exist, fix one cohesive owner group at a time before enabling its gate.
+
+Exit: every current canonical production path is included in a blocking role-specific
+owner gate or an explicitly reviewed permanent entry/compatibility rule.
+
+## 6. FC-03 — Root API patch-owner migration
+
+P-API-01 retained root `api.py` because canonical candidates could not preserve both
+E-09 timing and request-time root-global patch semantics. FC-03 intentionally satisfies
+its first recorded revisit event before reevaluating application placement.
+
+### FC-03A — Compatibility Contract
+
+Production-free.
+
+For each root API symbol family, classify:
+
+```text
+supported host/API behavior
+supported named dynamic compatibility seam
+transitional private patch seam
+unsupported test-only owner inspection
+production-only implementation detail
+```
+
+Required decisions:
+
+- retain route methods, paths, order, signature, marker, response/error and request-ID
+  behavior;
+- retain the specifically supported dynamic profile/translation error seams;
+- move repository-only owner inspection to canonical tests;
+- assign request/registration-time mutable dependencies to one canonical patch/injection
+  owner;
+- define the minimum long-lived root facade surface;
+- forbid a canonical-to-root back reference.
+
+### FC-03B — Dependency/patch-owner Move
+
+Introduce one typed/private canonical dependency owner, such as an
+`ApiApplicationDependencies` bundle or a reviewed equivalent.
+
+- handlers and registrar resolve supported call-time dependencies through that owner;
+- root compatibility patching, where deliberately retained, targets the same canonical
+  owner rather than a second root-owned cell;
+- test-only root mirrors are migrated to direct canonical owner tests;
+- application construction remains in its current location during FC-03B;
+- route behavior, payloads, errors, lifecycle, public exports and execution order remain
+  unchanged.
+
+Exit: a future canonical application can preserve every supported seam without importing
+root `api.py`.
+
+## 7. FC-04 — Canonical API application and E-09 convergence
+
+### FC-04A — Lifecycle Contract
+
+Production-free first. Define one immutable application bundle containing the exact
+translation route executor, handlers, route definitions/signature, registrar and
+compatibility identity view.
+
+Frozen requirements:
+
+- exactly one application and one translation route executor per process;
+- application creation occurs before `bootstrap.initialize()` freezes the RuntimeServices
+  cleanup plan;
+- executor shutdown remains cleanup item 1;
+- application construction remains outside initialize unless a separate Behavior
+  Contract explicitly changes rollback timing;
+- bootstrap remains the only lock/atexit/terminal/cleanup owner;
+- no application `close`, reset registry, second lifecycle lock or hot reinitialize;
+- entrypoint and late root API import resolve the same application identities;
+- no canonical module imports a root compatibility module;
+- direct canonical/no-host imports do not create the application or lifecycle state.
+
+Compare only evidence-backed shapes after FC-03. Request focused technical PRO review
+only when at least two shapes satisfy every lifecycle and compatibility condition.
+
+### FC-04B — Cohesive Move
+
+Expected production surface, subject to FC-04A:
+
+```text
+__init__.py
+api.py
+easyuse_anima/api/application.py or the selected canonical owner
+easyuse_anima/bootstrap.py
+```
+
+Together with direct tests, analyzer/contract fixtures and docs.
+
+- move production application construction into the canonical package;
+- make root `api.py` an explicit compatibility facade/binder over exact canonical
+  objects;
+- preserve E-09 cleanup order, rollback, repeated initialize, route refresh, terminal
+  shutdown and late-import identity;
+- preserve package/flat import and all supported host/API contracts.
+
+This is one rollback unit. Do not split executor/application identity and entrypoint
+wiring across separately deployable intermediate states.
+
+## 8. FC-05 — Technical completion audit
+
+Type: integrated Contract/gate.
+
+Reconcile the original Definition of Done after FC-04 and any mandatory FC-02 correction.
+
+Required promotion evidence on one integrated candidate:
+
+```text
+official full
+pinned Pyright/Ruff and complete owner-boundary gates
+comfy node validate
+actual comfy node pack and archive/CRC/import closure
+root/canonical identity and no internal root implementation imports
+no-host canonical imports
+fresh-process E-09 terminal lifecycle
+0.5.2 workflow/profile/settings/API compatibility fixtures
+representative isolated ComfyUI API/node execution smoke
+```
+
+Record technical architecture completion and close the implementation lane of #185.
+Issue #186 remains open only as the compatibility/release ledger.
+
+## 9. Optional MD lane — large-module disposition
+
+After FC-01, audit the current G-05 exception ledger without changing production.
+Classify each exception as:
+
+```text
+cohesive-retain
+split-ready
+blocked-by-contract
+event-driven
+```
+
+Priority review candidates:
+
+- `easyuse_anima/aio/generation_normalization.py`
+- `easyuse_anima/aio/legacy_generation.py`
+- `easyuse_anima/prompt/artist_mix.py`
+- `easyuse_anima/nodes/prompt_advanced_nodes.py`
+- `easyuse_anima/prompt/advanced.py`
+
+Do not split the E-09 bootstrap lifecycle, the atomic JSON transaction owner or root
+compatibility shims merely to satisfy a line threshold.
+
+A split is allowed only when it has:
+
+- independently named responsibility and owner;
+- direct behavior/contract tests;
+- measurable reduction in change collision or review scope;
+- one bounded rollback unit;
+- no new generic `utils`, `misc` or service-locator module.
+
+The MD lane is not an FC-05 blocker unless it finds an owner/import violation or a
+module that prevents FC-03/FC-04 convergence.
+
+## 10. Release N and H/D-14
+
+### FC-06 — Ordinary release N
+
+Do not publish solely to start a shim clock. The next normal feature/bug release that
+contains the final canonical-plus-shim forms becomes release N. Record exact tag, SHA,
+archive hash, identity parity, internal root-import scan and validate/pack/read-back.
+
+### FC-07 — Later compatibility re-audit
+
+Run only after an ADR-002 event changes. Consider private shims first. Public removal
+requires breaking-change approval, impact, release notes and rollback. Deliberate
+long-term retention of low-cost shims is a valid completed outcome.
+
+## 11. Validation efficiency
+
+### Edit loop
+
+```text
+changed-file syntax/static
+direct task-specific focused owners
+current analyzer/contract projection
+git diff --check
+```
+
+Do not run the broad quick/full suite in the edit loop.
+
+### Promotion
+
+- official full once on the exact final code/test/tool/fixture SHA;
+- validate/pack/archive for import, entrypoint, registration, package or release changes;
+- isolated live ComfyUI only for host-visible behavior or the FC-05 integrated gate;
+- reuse evidence when only documentation changes and its source tree is unchanged.
+
+Keep one active task by default. FC-02 and the optional MD audit may run in parallel
+only when their allowed files and evidence owners are explicitly disjoint.
+
+## 12. Stop and PRO conditions
+
+Codex resolves ordinary implementation and focused-test failures inside the current
+owner. Stop and request focused technical PRO review only when:
+
+- FC-03 leaves multiple API application/lifecycle shapes that all satisfy E-09 and
+  compatibility gates;
+- executor-before-cleanup timing requires dynamic cleanup-plan mutation or a second
+  lifecycle owner;
+- a supported root seam cannot be represented without canonical-to-root import;
+- the full owner gate exposes an actual cycle or ownership ambiguity not expressible by
+  the reviewed role model;
+- a behavior-preserving Move cannot be separated from lifecycle/compatibility Behavior.
+
+## 13. Codex resume instruction
+
+```text
+Start Issue #593 / FC-01 from latest origin/dev.
+
+Read only:
+- current-policies.md
+- codex-execution-efficiency.md universal rules
+- this document's FC-01 and validation sections
+- Issue #593 latest checkpoint
+- python-backend.md Overall Definition of Done
+- current import-boundary checker/ledger
+- G-06 test ownership map
+- P-API-01 completed inventory/revisit events
+- compatibility registry and direct evidence named by those documents
+
+Do not implement FC-02+ during FC-01. Do not reopen completed F/G/security lanes.
+Do not start P-API-02, root removal, release, tag or Registry work.
+
+Produce one closure matrix, confirm or correct the next task boundaries, run only direct
+consistency/focused checks and git diff check, then create a dev-targeted Draft PR.
+Documentation-only FC-01 does not trigger official full/package/live.
+```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 # EasyUse Anima Development Entry
 
-Use this file as the first development-doc entry point for a new Codex session.
-Read only the sections needed by the active task.
+Use this file as the first development-doc entry point for a new Codex session. Read
+only the active task section and its direct owners.
 
 ## Read order
 
@@ -11,54 +11,17 @@ Read only the sections needed by the active task.
    - use focused edit-loop tests;
    - run official full once on the final candidate SHA;
    - run package/live/benchmark only when triggered.
-3. Completed independent security/admin lane:
-   [`../architecture/security-admin-settings-roadmap.md`](../architecture/security-admin-settings-roadmap.md)
-   - SEC-01 completed with TRUSTED_DEPLOYMENT_ONLY;
-   - SEC-02 completed with a direct-owner FEASIBLE result;
-   - SEC-03 completed the narrow backend implementation and SEC-04 was skipped;
-   - SEC-05 completed the production-free audit with no follow-up;
-   - there is no READY security task and the lane remains TRUSTED_DEPLOYMENT_ONLY.
-4. Completed backend and compatibility state:
-   [`../architecture/post-phase-e-maintenance-roadmap.md`](../architecture/post-phase-e-maintenance-roadmap.md)
-   - Phase F/G and G-CLOSE are complete; there is no READY Phase F/G task;
-   - D-14/H root removal and P-API-02 are event-gated, not failed.
-5. E-09/P-API compatibility gate:
-   [`../architecture/python-api-papi01-e09-lifecycle-gate.md`](../architecture/python-api-papi01-e09-lifecycle-gate.md)
-   - preserve one bootstrap lifecycle owner, terminal shutdown, translation-executor
-     identity, fixed cleanup order, rollback, and late root-import behavior;
-   - P-API-01 completed with RETAIN; #199 may use RuntimeConfig/bootstrap only as an
-     immutable process-capability owner and must not add another lifecycle owner.
-6. Backend target architecture and compatibility policy:
-   [`../architecture/README.md`](../architecture/README.md)
-7. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
-   documented hard stop or unresolved cross-owner architecture ambiguity. Ordinary
-   implementation and test failures remain local task work.
-8. Read a topic guide only when the active task touches it:
-   - completed D/E execution record: `../architecture/backend-roadmap-resume-0.6.2.md`
-   - Phase F/G completion audit: `../architecture/python-phase-fg-completion-audit.md`
-   - security/admin settings boundary: `../architecture/security-admin-settings-roadmap.md`
-   - lifecycle runtime contract: `../architecture/python-runtime-e09-lifecycle-contract.md`
-   - runtime base contract: `../architecture/python-runtime-base-contract.md`
-   - repository/filesystem contract: `../architecture/python-runtime-e03-repository-filesystem-contract.md`
-   - translation runtime contract: `../architecture/python-runtime-e04-translation-contract.md`
-   - autocomplete runtime contract: `../architecture/python-runtime-e05-autocomplete-contract.md`
-   - wildcard runtime contract: `../architecture/python-runtime-e06-wildcard-contract.md`
-   - AiO cache runtime contract: `../architecture/python-runtime-e08-aio-cache-contract.md`
-   - test-isolation contract: `../architecture/python-runtime-e10-test-isolation-contract.md`
-   - runtime state inventory: `../architecture/python-runtime-state-inventory.md`
-   - compatibility registry: `../architecture/python-compatibility-shims.md`
-   - queue identity: `../architecture/queue-ui-two-phase-correlation-addendum.md`
-   - Prompt Studio execution projection: `../architecture/prompt-studio-execution-derived-projection.md`
-   - dual-canvas UI checks: `browser-smoke-matrix.md`
-   - custom-node integrations: `custom-node-integrations.md`
-   - Registry scanner prevention for a future release:
-     [`docs/development/registry-scanner-safety.md`](registry-scanner-safety.md)
-   - workflows: `../Anima AiO/Workflow_Management.md`
-9. Confirm `git status --short`, current branch/worktree, direct source, and direct
-   tests.
+3. Active final-convergence queue:
+   [`../architecture/backend-final-convergence-roadmap.md`](../architecture/backend-final-convergence-roadmap.md)
+4. Active owner: Issue #593.
+5. Target architecture and original Definition of Done:
+   [`../architecture/python-backend.md`](../architecture/python-backend.md)
+6. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
+   documented hard stop or unresolved cross-owner architecture ambiguity.
+7. Confirm branch/worktree status, direct source and direct tests.
 
-Do not read every roadmap, closed Issue, or historical PR. Registry activation is
-external release administration; do not poll or modify an immutable release during
+Do not reread all historical roadmaps, closed PRs or completed Phase D/E/F/G/security
+lanes. Registry activation is external release administration and does not block
 ordinary `dev` work.
 
 ## Current state
@@ -68,101 +31,99 @@ COMPLETE  Phase D package/root consolidation
 COMPLETE  Phase E runtime ownership/lifecycle/test isolation
 COMPLETE  Phase F typed boundaries and feature errors
 COMPLETE  G-04 public API / G-05 size ratchet / G-06 test ownership
-COMPLETE  G-CLOSE Phase F/G completion audit
-RETAIN    P-API-01; P-API-02 parked
-PARKED    D-14 / Phase H root removal
-COMPLETE  #199 SEC-01 security/admin host-capability Contract
-COMPLETE  #199 SEC-02 response-confidentiality Contract
-COMPLETE  #199 SEC-03 narrow backend implementation
-SKIPPED   #199 SEC-04 frontend settings migration
-COMPLETE  #199 SEC-05 security completion audit; no follow-up
-EVENT     next ordinary release N -> later D-14 re-audit
+COMPLETE  P-WC Wildcard direct-shim conversion
+RETAIN    P-API-01 current root API production facade
+COMPLETE  SEC-01 through SEC-05 security/admin lane
+
+READY     #593 FC-01 original Definition-of-Done closure audit
+NEXT      FC-02 complete canonical owner-boundary gate
+NEXT      FC-03 root API patch-owner migration
+NEXT      FC-04 canonical API application/E-09 convergence
+NEXT      FC-05 technical completion audit
+
+EVENT     next ordinary release N
+LATER     H/D-14 compatibility re-audit
 ```
 
-The original backend stop is correct:
+The former `no READY task` statement applied to the completed F/G/security and
+compatibility-removal lanes. It did not close the original backend Definition of Done.
 
-- root `__init__.py` still imports root `api.py` for production registration;
-- root `api.py` remains a production route/payload/runtime facade;
-- `wildcard_engine.py` is a direct shim, but that final form has not shipped;
-- final forms completed after 0.6.2 have no release N;
-- consumer evidence and public breaking-change approval do not support removal.
+## Why final convergence remains
 
-That stop applies to the completed compatibility lane. It does not block the separate
-Issue #199 security/admin Contract.
+The current backend is functional and validated, but two technical gaps remain:
 
-## Completed SEC-01 boundary
+1. the blocking import-boundary gate covers a reviewed subset while the G-06 owner map
+   covers the complete canonical package/test surface;
+2. root `api.py` still creates the production API application, translation route
+   executor, handlers, route definitions and registrar.
 
-Current primary-source evidence must be treated as follows:
+P-API-01 retained that facade because the then-current canonical candidates could not
+preserve both request-time root patch seams and E-09 executor/cleanup timing. The same
+Contract explicitly allows a later revisit after those patch seams move to exact
+canonical owners. FC-03 performs that prerequisite before FC-04 reevaluates application
+placement.
 
-- ComfyUI `comfy-user` selects a user profile; it is not authenticated administrator
-  identity;
-- origin/host and CORS middleware are request-origin controls, not authorization;
-- `request.remote`, Host, Origin, or forwarded headers alone do not prove authority;
-- EasyUseAnima `GET /settings` returns the current public settings projection and
-  `POST /set_setting` mutates a known setting;
-- the projection currently contains local/network configuration such as
-  `wildcard.extra_paths`, `naia.host`, `naia.port`, and `naia.allow_remote_api`.
+Actual shim deletion remains release/consumer gated and is not required for technical
+architecture completion.
 
-SEC-01 produced:
+## FC-01 direct reading scope
 
 ```text
-deployment/threat matrix
-route and field sensitivity inventory
-host capability verdict
-logging/redaction contract
-one primary verdict
-exact SEC-02 task card only when justified
+docs/architecture/backend-final-convergence-roadmap.md      # FC-01 only
+docs/architecture/python-backend.md                         # Overall DoD
+docs/architecture/python-phase-fg-completion-audit.md
+docs/architecture/python-api-papi01-e09-lifecycle-gate.md
+docs/architecture/python-compatibility-shims.md
+tools/check_python_import_boundaries.py
+tests/fixtures/python_import_boundary_contract.v1.json
+tests/fixtures/python_test_ownership_contract.v1.json
 ```
 
-Allowed primary verdicts:
+Read direct tests or analyzer output only when the closure matrix needs to verify a
+specific row. Do not read every production package during FC-01.
+
+## FC-01 boundary
+
+Production, test, tool and fixture changes are forbidden unless the audit proves that
+existing deterministic evidence cannot express one required row.
+
+Classify every original Definition-of-Done item as:
 
 ```text
-HOST_CAPABILITY
-PROCESS_CAPABILITY
-TRUSTED_DEPLOYMENT_ONLY
-NO_DIAGNOSTICS
+complete
+technical gap
+compatibility event
+deliberate retain
 ```
 
-The primary verdict is **TRUSTED_DEPLOYMENT_ONLY**. A single trusted operator on
-loopback is supported; an authenticated reverse proxy is conditionally supported only
-when every authenticated principal has equal operator authority and direct bypass is
-prevented. Direct LAN/remote, unauthenticated proxy, and managed/multi-tenant exposure
-are unsupported. `--multi-user` is not an authorization boundary.
+Required outputs:
 
-The authoritative result is
-[`../architecture/security-admin-settings-sec01-contract.md`](../architecture/security-admin-settings-sec01-contract.md).
-SEC-01 added no token, diagnostics endpoint, settings split, authentication
-middleware, frontend migration, or lifecycle state.
+- one compact closure matrix;
+- exact gap between import-boundary and G-06 owner coverage;
+- confirmed FC-02 owner/role model;
+- confirmed FC-03 root patch-owner migration boundary;
+- confirmed FC-04 E-09 application/lifecycle boundary;
+- corrected next task card if the evidence disproves an assumption.
 
-## E-09 non-regression summary
+Do not implement FC-02 or later work in the FC-01 PR.
 
-- bootstrap is the sole lifecycle owner;
-- initialize/shutdown share one lock and atexit is registered once;
-- shutdown is terminal/idempotent; no hot reinitialize;
-- repeated initialize before shutdown reuses runtime identity and refreshes routes;
-- translation route executor is unique and cleanup item 1;
-- seven-step cleanup order and expected-identity rollback remain fixed;
-- routes/marker remain installed; file-I/O limiters and provider clients are not closed;
-- no API application or security capability may add a reset/close registry, second
-  lock, second atexit, or production module reload.
+## Fixed lifecycle and compatibility guards
 
-SEC-01 rejected a process capability for this lane. If a future independently proven
-task needs one, it must still be immutable process-start configuration loaded by
-RuntimeConfig/bootstrap.
+Later FC tasks must preserve:
 
-## Following state
+- bootstrap as the single lifecycle owner;
+- one initialize/shutdown lock and one atexit registration;
+- terminal/idempotent shutdown and no hot reinitialize;
+- one translation route executor created before cleanup-plan composition;
+- executor shutdown as cleanup item 1 and the fixed seven-step cleanup order;
+- expected-identity rollback and original startup error;
+- route marker retention and no route deregistration;
+- no file-I/O limiter or provider/client cleanup invention;
+- root/canonical identity and 0.5.2 workflow/profile/settings/API compatibility.
 
-After SEC-05:
-
-1. keep the completed security lane closed unless new primary-source evidence changes
-   the deployment or authorization boundary;
-2. keep diagnostics absent by default when no reliable authorization owner exists;
-3. do not reopen Phase F/G, P-API-02, or D-14 as a side effect;
-4. let the next ordinary release containing final shims become release N;
-5. re-audit D-14 only after an event gate changes.
-
-No dedicated release, outbound telemetry, import-time deprecation warning, or public
-root removal is authorized by this queue.
+FC-03 may migrate patch ownership but does not change behavior. FC-04 application
+construction remains outside `initialize()` unless a separate reviewed Behavior Contract
+explicitly changes rollback semantics.
 
 ## Validation
 
@@ -170,32 +131,46 @@ root removal is authorized by this queue.
 
 ```text
 changed-file syntax/static check
-one task-specific focused target at a time
-current direct contract/analyzer fixture
+one direct focused owner at a time
+current analyzer/contract projection
 git diff --check
 ```
 
-The repository `quick` profile is broad and is not a task preflight or per-edit
-command.
+The broad quick/full profiles are not edit-loop commands.
 
-### Final candidate
+### Promotion
 
-- Run official full once on the exact final code/test diff when tests, tools, shared
-  fixtures, or production change.
-- Documentation-only changes reuse the latest valid code evidence.
-- Run package validation only for import/registration/archive/dependency/release
-  closure changes.
-- Run isolated HTTP live smoke for a later backend security behavior change.
-- Run browser smoke only when settings UI behavior changes.
-- Release lifecycle smoke uses a fresh process; shutdown followed by production
-  reinitialize is not a supported gate.
+- Documentation-only FC-01 reuses current valid code evidence.
+- Run official full once when code, tests, tools or shared fixtures change.
+- Run validate/pack/archive for import, entrypoint, registration, dependency, archive or
+  release changes.
+- Run isolated live ComfyUI only for host-visible behavior or FC-05 integration.
+- Terminal lifecycle smoke runs in a fresh process; shutdown followed by production
+  reinitialize is not supported.
 
 ## Technical PRO boundary
 
-Request focused technical PRO review only when primary-source evidence leaves multiple
-viable security architectures with materially different trust guarantees, a capability
-owner would require changing E-09 lifecycle semantics, or proxy/header normalization
-cannot be resolved within the bounded route owner.
+Request focused technical PRO review only when direct evidence leaves multiple valid
+API/lifecycle designs, the complete owner gate exposes an unresolvable role/cycle
+ambiguity, or preserving a supported seam requires a canonical-to-root dependency,
+dynamic cleanup-plan mutation or second lifecycle owner.
 
-A missing ComfyUI admin capability, ordinary test failure, field classification, helper
-layout, and owner-local implementation choices remain with Codex.
+Routine test failures, helper names, fixture placement and owner-local implementation
+choices remain with Codex.
+
+## Completed reference lanes
+
+Read only when a current task touches the boundary:
+
+- completed D/E record: `../architecture/backend-roadmap-resume-0.6.2.md`
+- E-09 lifecycle: `../architecture/python-runtime-e09-lifecycle-contract.md`
+- Phase F/G close: `../architecture/python-phase-fg-completion-audit.md`
+- security/admin: `../architecture/security-admin-settings-roadmap.md`
+- queue/live UI identity: `../architecture/queue-ui-two-phase-correlation-addendum.md`
+- Prompt Studio projection: `../architecture/prompt-studio-execution-derived-projection.md`
+- dual-canvas UI: `browser-smoke-matrix.md`
+- Registry scanner safety: `registry-scanner-safety.md`
+- workflows: `../Anima AiO/Workflow_Management.md`
+
+No roadmap document alone authorizes root deletion, public breaking changes, release,
+tag or Registry publication.


### PR DESCRIPTION
## 목적

현재 `no READY task` 상태를 초기 backend Definition of Done과 다시 대조하고, 실제로 남은 기술적 수렴과 release 이후 호환성 retirement를 분리합니다.

Base: `dev@4deb2ee4b8c90fff2ad74b8cd3a52c250386423f` after SEC-05 / PR #592.

## 검토 결과

완료된 Phase F/G·security lane 기준으로 READY 작업이 0인 것은 맞지만, 초기 전체 목표와는 다음 차이가 남습니다.

- blocking import-boundary gate는 현재 reviewed 11개 group만 강제하며 G-06의 전체 canonical owner map보다 좁습니다.
- root `api.py`는 여전히 production application/executor/route/payload/runtime composition owner입니다.
- P-API-01은 RETAIN을 판정하면서도, root call-time patch seam을 exact canonical owner로 이전하는 별도 Contract를 명시적 revisit event로 기록했습니다.
- shim 삭제는 release N/consumer/breaking-change gate가 필요하지만 technical architecture completion은 그 전에 가능합니다.

## 새 실행 큐

```text
READY FC-01  original Definition-of-Done closure audit
  -> FC-02   complete canonical owner-boundary gate
  -> FC-03A  root API patch-owner Contract
  -> FC-03B  canonical dependency/patch-owner Move
  -> FC-04A  canonical API application/E-09 Contract
  -> FC-04B  cohesive application Move
  -> FC-05   technical completion audit

EVENT FC-06  ordinary release N
  -> FC-07   later H/D-14 re-audit
```

## 주요 설계

- technical architecture completion과 compatibility retirement completion을 분리
- G-06 owner map + 기존 AST analyzer를 재사용해 전체 owner gate 확장
- FC-03에서 P-API-01의 첫 revisit prerequisite를 의도적으로 충족
- FC-04는 executor-before-cleanup timing, bootstrap single lifecycle owner와 fixed E-09 rollback/cleanup을 유지
- root `api.py` 삭제가 아니라 explicit compatibility facade로 축소
- large-module debt는 별도 disposition audit 후 split-ready만 제한적으로 Move
- public shim은 장기 retain 가능하며, 삭제 여부가 technical completion의 척도가 아님

## 변경 파일

- `docs/architecture/backend-final-convergence-roadmap.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

Docs-only입니다. Production, tests, tools, fixtures, workflow, version, release/Registry artifact를 변경하지 않습니다.

## 검증

- diff는 문서 3개뿐입니다.
- current DoD, import-boundary checker, G-06 owner map, P-API-01 inventory/revisit events, compatibility registry와 대조했습니다.
- official full/package/live는 docs-only 변경으로 trigger되지 않습니다.

## Next

Merge 후 Issue #593 / FC-01 production-free closure audit만 시작합니다. FC-02+, P-API-02, root removal, release/tag/Registry는 시작하지 않습니다.

Refs #185
Refs #186
Refs #187
Refs #188
Refs #582
Refs #593