### PR TITLE
refactor: remove AiO node adapter back-references (FC-02C)

### DIFF
--- a/docs/architecture/backend-final-convergence-roadmap.md
+++ b/docs/architecture/backend-final-convergence-roadmap.md
@@ -401,6 +401,17 @@ This is one rollback unit because both violations are the same AiO orchestration
 owner invoking Comfy node adapters for reusable behavior. The adapters keep
 their host-facing metadata; the shared image operations own execution.
 
+FC-02C removes both exact `legacy_generation -> nodes` edges through the owners
+fixed by FC-02B. The image, SAM3, and Impact node classes retain their original
+host-facing schemas and method signatures while delegating to
+`_upscale_image_by_multiple`, `_run_sam3_detailer`, and
+`_run_impact_detailer`. Provider discovery remains call-time, AiO still owns
+stage planning and `try/finally` model cleanup, and both operation modules have
+empty public surfaces and no import-time side effects. The analyzer inventory
+grows from 177 to 179 shipped modules, and the reviewed SAM3 function-size
+exception moves from the node method to the exact shared operation. After the
+cohesive Move merges, FC-02D is the only authorized next task.
+
 ### FC-02D — Complete owner-boundary Contract/tool
 
 Use the G-06 production-path groups as the sole current owner inventory and the

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1195,10 +1195,10 @@ EasyUseAnimaWildcard
   `easyuse_anima.infrastructure.comfy.resources` function directly, and tests
   patch that real consumer rather than retaining a root-only monkeypatch seam.
 - B-10b2 Detailer-hook cleanup: `_EasyUseAnimaAlignedDetailerHook` is no longer
-  a root alias. The image and Impact Detailer adapters already import the
-  canonical `easyuse_anima.image.detailer` class directly; normal-package and
-  synthetic package-entrypoint tests preserve class identity and hook
-  construction without a root-only private import.
+  a root alias. The image adapter and shared SAM3/Impact execution operation
+  import the canonical `easyuse_anima.image.detailer` class directly;
+  normal-package and synthetic package-entrypoint tests preserve class identity
+  and hook construction without a root-only private import.
 - B-10b3 Impact-delegate cleanup: `_EasyUseAnimaImpactDetailerDelegate` is no
   longer a root alias. The SAM3 adapter already imports the canonical
   `easyuse_anima.nodes.impact_detailer_nodes` class directly; normal-package
@@ -1217,9 +1217,10 @@ EasyUseAnimaWildcard
   `_align_nearest` and `_align_down` remain for residual runtime callers.
 - B-10b6 image-scaling cleanup: `_image_scale_by_multiple_size`,
   `_max_long_edge_value`, `_normalize_image_scale_options`, and
-  `_scale_by_value` are no longer root aliases. The canonical image adapter and
-  scaling policy already consume `easyuse_anima.image.scaling` directly;
-  normal-package and synthetic package-entrypoint tests preserve size,
+  `_scale_by_value` are no longer root aliases. The shared image upscale
+  operation consumes `easyuse_anima.image.scaling` directly, and the image/AiO
+  adapters delegate to that operation; normal-package and synthetic
+  package-entrypoint tests preserve size,
   max-edge, and legacy shifted-widget normalization behavior. The two scaling
   constants and mapped image-scale node class remain root compatibility seams.
 - B-10b7 AiO cache-clear cleanup: `_clear_aio_first_pass_cache` is no longer a

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -8,10 +8,10 @@ from typing import Any, cast
 from ..common.values import _as_bool, _as_float, _as_int, _single_value
 from ..image.geometry import _image_tensor_size
 from ..image.sam3 import _context_value, _segs_has_items
+from ..image.sam3_detailer import _run_sam3_detailer
+from ..image.upscale import _upscale_image_by_multiple
 from ..infrastructure.comfy.invocation import _node_output_tuple
 from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
-from ..nodes.image_nodes import EasyUseAnimaImageScaleByMultiple
-from ..nodes.sam3_nodes import EasyUseAnimaSAM3Detailer
 from ..prompt.artist_mix import _encode_prompt_data_positive_conditioning
 from ..prompt.conditioning import (
     ANIMA_MOD_GUIDANCE_PROFILE_OFF,
@@ -165,7 +165,7 @@ def _run_aio_highres_stage(
         scheduler_default="simple",
         inherit_backend=True,
     )
-    scaled_image, width, height, applied_scale = EasyUseAnimaImageScaleByMultiple().upscale(
+    scaled_image, width, height, applied_scale = _upscale_image_by_multiple(
         image,
         highres_settings.get("scale_by", 1.25),
         highres_settings.get("upscale_method", "bicubic"),
@@ -292,7 +292,7 @@ def _run_aio_detailer_target(
         stage_sampler,
     )
     try:
-        result = EasyUseAnimaSAM3Detailer().doit(
+        result = _run_sam3_detailer(
             enabled=True,
             image=image,
             ctx_SAM3=sam3_context,

--- a/easyuse_anima/image/sam3_detailer.py
+++ b/easyuse_anima/image/sam3_detailer.py
@@ -1,0 +1,254 @@
+"""Private SAM3 and Impact detailer execution operations."""
+
+from __future__ import annotations
+
+import logging
+
+from ..common.values import _as_bool
+from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from .detailer import _EasyUseAnimaAlignedDetailerHook
+from .geometry import _alignment_value
+from .sam3 import (
+    _call_impact_detailer,
+    _context_value,
+    _empty_mask_for_image,
+    _empty_segs_for_image,
+    _find_impact_detailer_class,
+    _find_impact_mask_to_segs_class,
+    _find_sam3_detect_class,
+    _format_sam3_detection_prompt,
+    _segs_has_items,
+)
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"SAM3 node Comfy host helper is unavailable: {name}")
+
+
+def _encode_with_comfy_clip(clip, text: str):
+    helper = resolve_comfy_host_helper(
+        "_encode_with_comfy_clip",
+        _missing_host_helper,
+    )
+    return helper(clip, text)
+
+
+def _run_impact_detailer(
+    image,
+    segs,
+    model,
+    clip,
+    vae,
+    guide_size,
+    guide_size_for,
+    max_size,
+    seed,
+    steps,
+    cfg,
+    sampler_name,
+    scheduler,
+    positive,
+    negative,
+    denoise,
+    feather,
+    noise_mask,
+    force_inpaint,
+    wildcard,
+    cycle=1,
+    alignment="impact",
+    preserve_conditioning_metadata=True,
+    fail_on_unsupported_opt=False,
+    detailer_hook=None,
+    inpaint_model=False,
+    noise_mask_feather=0,
+    scheduler_func_opt=None,
+    tiled_encode=False,
+    tiled_decode=False,
+):
+    alignment_text = str(alignment or "impact")
+    alignment_int = _alignment_value(alignment_text)
+
+    if not _as_bool(preserve_conditioning_metadata, True):
+        logger.warning(
+            "[EasyUseAnima] preserve_conditioning_metadata=false is reserved for a native backend; "
+            "the Impact backend leaves conditioning handling to Impact Pack."
+        )
+
+    effective_detailer_hook = detailer_hook
+    if alignment_int is not None:
+        effective_detailer_hook = _EasyUseAnimaAlignedDetailerHook(detailer_hook, alignment_int)
+
+    detailer_cls = _find_impact_detailer_class()
+    detailer = detailer_cls()
+    result = _call_impact_detailer(
+        detailer,
+        image=image,
+        segs=segs,
+        model=model,
+        clip=clip,
+        vae=vae,
+        guide_size=guide_size,
+        guide_size_for=guide_size_for,
+        max_size=max_size,
+        seed=seed,
+        steps=steps,
+        cfg=cfg,
+        sampler_name=sampler_name,
+        scheduler=scheduler,
+        positive=positive,
+        negative=negative,
+        denoise=denoise,
+        feather=feather,
+        noise_mask=noise_mask,
+        force_inpaint=force_inpaint,
+        wildcard=wildcard,
+        cycle=cycle,
+        detailer_hook=effective_detailer_hook,
+        inpaint_model=inpaint_model,
+        noise_mask_feather=noise_mask_feather,
+        scheduler_func_opt=scheduler_func_opt,
+        tiled_encode=tiled_encode,
+        tiled_decode=tiled_decode,
+    )
+    if isinstance(result, dict):
+        value = result.get("result")
+        if isinstance(value, tuple) and value:
+            return (value[0],)
+    if isinstance(result, tuple):
+        if not result:
+            raise RuntimeError("[EasyUseAnima] Impact DetailerForEach returned an empty tuple.")
+        return (result[0],)
+    return (result,)
+
+
+def _run_sam3_detailer(
+    enabled,
+    image,
+    ctx_SAM3,
+    detect_prompt,
+    detect_count,
+    threshold,
+    refine_iterations,
+    individual_masks,
+    combined,
+    crop_factor,
+    bbox_fill,
+    drop_size,
+    contour_fill,
+    model,
+    clip,
+    vae,
+    guide_size,
+    guide_size_for,
+    max_size,
+    seed,
+    steps,
+    cfg,
+    sampler_name,
+    scheduler,
+    positive,
+    negative,
+    denoise,
+    feather,
+    noise_mask,
+    force_inpaint,
+    wildcard,
+    cycle=1,
+    alignment="impact",
+    preserve_conditioning_metadata=True,
+    fail_on_unsupported_opt=False,
+    detailer_hook=None,
+    inpaint_model=False,
+    noise_mask_feather=0,
+    scheduler_func_opt=None,
+    tiled_encode=False,
+    tiled_decode=False,
+):
+    empty_mask = _empty_mask_for_image(image)
+    empty_segs = _empty_segs_for_image(image)
+    if not _as_bool(enabled, True):
+        return (image, empty_segs, empty_mask, image)
+
+    sam3_model = _context_value(ctx_SAM3, "model")
+    sam3_clip = _context_value(ctx_SAM3, "clip")
+    if sam3_model is None or sam3_clip is None:
+        raise RuntimeError(
+            "[EasyUseAnima] ctx_SAM3 must contain SAM3 model and CLIP. "
+            "Use the AiO SAM3 detailer path or a compatible rgthree context."
+        )
+
+    sam3_text = _format_sam3_detection_prompt(detect_prompt, detect_count)
+    conditioning = _encode_with_comfy_clip(sam3_clip, sam3_text)
+
+    sam3_cls = _find_sam3_detect_class()
+    sam3_result = sam3_cls.execute(
+        model=sam3_model,
+        image=image,
+        conditioning=conditioning,
+        threshold=float(threshold),
+        refine_iterations=int(refine_iterations),
+        individual_masks=_as_bool(individual_masks, False),
+    )
+    sam3_values = _node_output_tuple(sam3_result)
+    if len(sam3_values) < 1:
+        raise RuntimeError("[EasyUseAnima] SAM3_Detect returned no mask.")
+    mask = sam3_values[0]
+
+    mask_to_segs_cls = _find_impact_mask_to_segs_class()
+    mask_to_segs_result = mask_to_segs_cls.doit(
+        mask,
+        _as_bool(combined, False),
+        float(crop_factor),
+        _as_bool(bbox_fill, False),
+        int(drop_size),
+        _as_bool(contour_fill, False),
+    )
+    segs_values = _node_output_tuple(mask_to_segs_result)
+    if len(segs_values) < 1:
+        raise RuntimeError("[EasyUseAnima] MaskToSEGS returned no SEGS.")
+    segs = segs_values[0]
+
+    if not _segs_has_items(segs):
+        logger.info("[EasyUseAnima] SAM3 Detailer detected no SEGS for prompt %r.", sam3_text)
+        return (image, segs, mask, image)
+
+    detailed_image = _run_impact_detailer(
+        image=image,
+        segs=segs,
+        model=model,
+        clip=clip,
+        vae=vae,
+        guide_size=guide_size,
+        guide_size_for=guide_size_for,
+        max_size=max_size,
+        seed=seed,
+        steps=steps,
+        cfg=cfg,
+        sampler_name=sampler_name,
+        scheduler=scheduler,
+        positive=positive,
+        negative=negative,
+        denoise=denoise,
+        feather=feather,
+        noise_mask=noise_mask,
+        force_inpaint=force_inpaint,
+        wildcard=wildcard,
+        cycle=cycle,
+        alignment=alignment,
+        preserve_conditioning_metadata=preserve_conditioning_metadata,
+        fail_on_unsupported_opt=fail_on_unsupported_opt,
+        detailer_hook=detailer_hook,
+        inpaint_model=inpaint_model,
+        noise_mask_feather=noise_mask_feather,
+        scheduler_func_opt=scheduler_func_opt,
+        tiled_encode=tiled_encode,
+        tiled_decode=tiled_decode,
+    )[0]
+
+    return (detailed_image, segs, mask, image)
+
+
+__all__ = ()

--- a/easyuse_anima/image/upscale.py
+++ b/easyuse_anima/image/upscale.py
@@ -1,0 +1,33 @@
+"""Private image upscale operations shared by feature and node adapters."""
+
+from __future__ import annotations
+
+from ..infrastructure.comfy.invocation import _common_upscale_image
+from .scaling import _image_scale_by_multiple_size, _normalize_image_scale_options
+
+
+def _upscale_image_by_multiple(
+    image,
+    scale_by=1.5,
+    upscale_method="bicubic",
+    multiple="32",
+    max_long_edge=0,
+):
+    upscale_method, multiple, max_long_edge = _normalize_image_scale_options(
+        upscale_method,
+        multiple,
+        max_long_edge,
+    )
+    samples = image.movedim(-1, 1)
+    width, height, applied_scale = _image_scale_by_multiple_size(
+        int(samples.shape[3]),
+        int(samples.shape[2]),
+        scale_by,
+        multiple,
+        max_long_edge,
+    )
+    scaled = _common_upscale_image(samples, width, height, str(upscale_method))
+    return (scaled.movedim(1, -1), width, height, applied_scale)
+
+
+__all__ = ()

--- a/easyuse_anima/nodes/image_nodes.py
+++ b/easyuse_anima/nodes/image_nodes.py
@@ -7,10 +7,8 @@ from ..image.geometry import _alignment_value
 from ..image.scaling import (
     IMAGE_SCALE_MULTIPLES,
     IMAGE_UPSCALE_METHODS,
-    _image_scale_by_multiple_size,
-    _normalize_image_scale_options,
 )
-from ..infrastructure.comfy.invocation import _common_upscale_image
+from ..image.upscale import _upscale_image_by_multiple
 
 
 class EasyUseAnimaImageScaleByMultiple:
@@ -67,21 +65,13 @@ class EasyUseAnimaImageScaleByMultiple:
     CATEGORY = "EasyUse Anima/Image"
 
     def upscale(self, image, scale_by=1.5, upscale_method="bicubic", multiple="32", max_long_edge=0):
-        upscale_method, multiple, max_long_edge = _normalize_image_scale_options(
+        return _upscale_image_by_multiple(
+            image,
+            scale_by,
             upscale_method,
             multiple,
             max_long_edge,
         )
-        samples = image.movedim(-1, 1)
-        width, height, applied_scale = _image_scale_by_multiple_size(
-            int(samples.shape[3]),
-            int(samples.shape[2]),
-            scale_by,
-            multiple,
-            max_long_edge,
-        )
-        scaled = _common_upscale_image(samples, width, height, str(upscale_method))
-        return (scaled.movedim(1, -1), width, height, applied_scale)
 
 
 class EasyUseAnimaDetailerAlignHook:

--- a/easyuse_anima/nodes/impact_detailer_nodes.py
+++ b/easyuse_anima/nodes/impact_detailer_nodes.py
@@ -2,19 +2,12 @@
 
 from __future__ import annotations
 
-import logging
-
-from ..common.values import _as_bool
-from ..image.detailer import _EasyUseAnimaAlignedDetailerHook
-from ..image.geometry import _alignment_value
-from ..image.sam3 import _call_impact_detailer, _find_impact_detailer_class
+from ..image.sam3_detailer import _run_impact_detailer
 from ..infrastructure.comfy.capabilities import (
     _comfy_sampler_names,
     _impact_scheduler_names,
 )
 from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
-
-logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
 def _missing_host_helper(name: str):
@@ -207,23 +200,7 @@ class _EasyUseAnimaImpactDetailerDelegate:
         tiled_encode=False,
         tiled_decode=False,
     ):
-        alignment_text = str(alignment or "impact")
-        alignment_int = _alignment_value(alignment_text)
-
-        if not _as_bool(preserve_conditioning_metadata, True):
-            logger.warning(
-                "[EasyUseAnima] preserve_conditioning_metadata=false is reserved for a native backend; "
-                "the Impact backend leaves conditioning handling to Impact Pack."
-            )
-
-        effective_detailer_hook = detailer_hook
-        if alignment_int is not None:
-            effective_detailer_hook = _EasyUseAnimaAlignedDetailerHook(detailer_hook, alignment_int)
-
-        detailer_cls = _find_impact_detailer_class()
-        detailer = detailer_cls()
-        result = _call_impact_detailer(
-            detailer,
+        return _run_impact_detailer(
             image=image,
             segs=segs,
             model=model,
@@ -245,22 +222,16 @@ class _EasyUseAnimaImpactDetailerDelegate:
             force_inpaint=force_inpaint,
             wildcard=wildcard,
             cycle=cycle,
-            detailer_hook=effective_detailer_hook,
+            alignment=alignment,
+            preserve_conditioning_metadata=preserve_conditioning_metadata,
+            fail_on_unsupported_opt=fail_on_unsupported_opt,
+            detailer_hook=detailer_hook,
             inpaint_model=inpaint_model,
             noise_mask_feather=noise_mask_feather,
             scheduler_func_opt=scheduler_func_opt,
             tiled_encode=tiled_encode,
             tiled_decode=tiled_decode,
         )
-        if isinstance(result, dict):
-            value = result.get("result")
-            if isinstance(value, tuple) and value:
-                return (value[0],)
-        if isinstance(result, tuple):
-            if not result:
-                raise RuntimeError("[EasyUseAnima] Impact DetailerForEach returned an empty tuple.")
-            return (result[0],)
-        return (result,)
 
 
 __all__ = ()

--- a/easyuse_anima/nodes/sam3_nodes.py
+++ b/easyuse_anima/nodes/sam3_nodes.py
@@ -2,29 +2,15 @@
 
 from __future__ import annotations
 
-import logging
-
 from ..aio.resources import (
     _load_checkpoint_with_comfy,
     _preferred_checkpoint_default,
 )
-from ..common.values import _as_bool
-from ..image.sam3 import (
-    _context_value,
-    _empty_mask_for_image,
-    _empty_segs_for_image,
-    _find_impact_mask_to_segs_class,
-    _find_sam3_detect_class,
-    _format_sam3_detection_prompt,
-    _sam3_context,
-    _segs_has_items,
-)
-from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..image.sam3 import _sam3_context
+from ..image.sam3_detailer import _run_sam3_detailer
 from ..infrastructure.comfy.resources import _comfy_checkpoint_names
 from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from .impact_detailer_nodes import _EasyUseAnimaImpactDetailerDelegate
-
-logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
 def _missing_host_helper(name: str):
@@ -37,15 +23,6 @@ def _comfy_max_resolution() -> int:
         _missing_host_helper,
     )
     return helper()
-
-
-def _encode_with_comfy_clip(clip, text: str):
-    helper = resolve_comfy_host_helper(
-        "_encode_with_comfy_clip",
-        _missing_host_helper,
-    )
-    return helper(clip, text)
-
 
 
 class EasyUseAnimaSAM3Context:
@@ -239,57 +216,20 @@ class EasyUseAnimaSAM3Detailer:
         tiled_encode=False,
         tiled_decode=False,
     ):
-        empty_mask = _empty_mask_for_image(image)
-        empty_segs = _empty_segs_for_image(image)
-        if not _as_bool(enabled, True):
-            return (image, empty_segs, empty_mask, image)
-
-        sam3_model = _context_value(ctx_SAM3, "model")
-        sam3_clip = _context_value(ctx_SAM3, "clip")
-        if sam3_model is None or sam3_clip is None:
-            raise RuntimeError(
-                "[EasyUseAnima] ctx_SAM3 must contain SAM3 model and CLIP. "
-                "Use the AiO SAM3 detailer path or a compatible rgthree context."
-            )
-
-        sam3_text = _format_sam3_detection_prompt(detect_prompt, detect_count)
-        conditioning = _encode_with_comfy_clip(sam3_clip, sam3_text)
-
-        sam3_cls = _find_sam3_detect_class()
-        sam3_result = sam3_cls.execute(
-            model=sam3_model,
+        return _run_sam3_detailer(
+            enabled=enabled,
             image=image,
-            conditioning=conditioning,
-            threshold=float(threshold),
-            refine_iterations=int(refine_iterations),
-            individual_masks=_as_bool(individual_masks, False),
-        )
-        sam3_values = _node_output_tuple(sam3_result)
-        if len(sam3_values) < 1:
-            raise RuntimeError("[EasyUseAnima] SAM3_Detect returned no mask.")
-        mask = sam3_values[0]
-
-        mask_to_segs_cls = _find_impact_mask_to_segs_class()
-        mask_to_segs_result = mask_to_segs_cls.doit(
-            mask,
-            _as_bool(combined, False),
-            float(crop_factor),
-            _as_bool(bbox_fill, False),
-            int(drop_size),
-            _as_bool(contour_fill, False),
-        )
-        segs_values = _node_output_tuple(mask_to_segs_result)
-        if len(segs_values) < 1:
-            raise RuntimeError("[EasyUseAnima] MaskToSEGS returned no SEGS.")
-        segs = segs_values[0]
-
-        if not _segs_has_items(segs):
-            logger.info("[EasyUseAnima] SAM3 Detailer detected no SEGS for prompt %r.", sam3_text)
-            return (image, segs, mask, image)
-
-        detailed_image = _EasyUseAnimaImpactDetailerDelegate().doit(
-            image=image,
-            segs=segs,
+            ctx_SAM3=ctx_SAM3,
+            detect_prompt=detect_prompt,
+            detect_count=detect_count,
+            threshold=threshold,
+            refine_iterations=refine_iterations,
+            individual_masks=individual_masks,
+            combined=combined,
+            crop_factor=crop_factor,
+            bbox_fill=bbox_fill,
+            drop_size=drop_size,
+            contour_fill=contour_fill,
             model=model,
             clip=clip,
             vae=vae,
@@ -318,9 +258,7 @@ class EasyUseAnimaSAM3Detailer:
             scheduler_func_opt=scheduler_func_opt,
             tiled_encode=tiled_encode,
             tiled_decode=tiled_decode,
-        )[0]
-
-        return (detailed_image, segs, mask, image)
+        )
 
 
 __all__ = ()

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -15,7 +15,7 @@
   },
   "expected_counts": {
     "production_consumer_slots": 23,
-    "unique_production_modules": 16,
+    "unique_production_modules": 17,
     "root_monkeypatch_test_files": 0,
     "canonical_monkeypatch_test_files": 3
   },
@@ -112,17 +112,17 @@
           "root_observation": "call_time"
         },
         {
+          "module": "easyuse_anima.image.sam3_detailer",
+          "binder": null,
+          "root_observation": "call_time"
+        },
+        {
           "module": "easyuse_anima.nodes.prompt_data_nodes",
           "binder": null,
           "root_observation": "call_time"
         },
         {
           "module": "easyuse_anima.nodes.regional_nodes",
-          "binder": null,
-          "root_observation": "call_time"
-        },
-        {
-          "module": "easyuse_anima.nodes.sam3_nodes",
           "binder": null,
           "root_observation": "call_time"
         },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -11447,6 +11447,42 @@
       },
       {
         "alias": null,
+        "bound_name": "_run_sam3_detailer",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.sam3_detailer:_run_sam3_detailer",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_run_sam3_detailer",
+        "optional": false,
+        "requested": "..image.sam3_detailer",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_upscale_image_by_multiple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.upscale:_upscale_image_by_multiple",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_upscale_image_by_multiple",
+        "optional": false,
+        "requested": "..image.upscale",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/image/upscale.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_node_output_tuple",
         "branch_context": [],
         "classification": "internal",
@@ -11454,7 +11490,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 11,
+        "line": 13,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -11472,7 +11508,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 12,
+        "line": 14,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -11480,42 +11516,6 @@
         "scope": "<module>",
         "source": "easyuse_anima/aio/legacy_generation.py",
         "target": "easyuse_anima/infrastructure/comfy/wiring.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "EasyUseAnimaImageScaleByMultiple",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
-        "kind": "static_from",
-        "line": 13,
-        "name": "EasyUseAnimaImageScaleByMultiple",
-        "optional": false,
-        "requested": "..nodes.image_nodes",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/legacy_generation.py",
-        "target": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "EasyUseAnimaSAM3Detailer",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
-        "kind": "static_from",
-        "line": 14,
-        "name": "EasyUseAnimaSAM3Detailer",
-        "optional": false,
-        "requested": "..nodes.sam3_nodes",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/legacy_generation.py",
-        "target": "easyuse_anima/nodes/sam3_nodes.py"
       },
       {
         "alias": null,
@@ -19438,6 +19438,292 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 9,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_EasyUseAnimaAlignedDetailerHook",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".detailer:_EasyUseAnimaAlignedDetailerHook",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_EasyUseAnimaAlignedDetailerHook",
+        "optional": false,
+        "requested": ".detailer",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/detailer.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_alignment_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".geometry:_alignment_value",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_alignment_value",
+        "optional": false,
+        "requested": ".geometry",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_call_impact_detailer",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_call_impact_detailer",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_call_impact_detailer",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_context_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_context_value",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_context_value",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_empty_mask_for_image",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_empty_mask_for_image",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_empty_mask_for_image",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_empty_segs_for_image",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_empty_segs_for_image",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_empty_segs_for_image",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_impact_detailer_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_find_impact_detailer_class",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_find_impact_detailer_class",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_impact_mask_to_segs_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_find_impact_mask_to_segs_class",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_find_impact_mask_to_segs_class",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_sam3_detect_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_find_sam3_detect_class",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_find_sam3_detect_class",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_format_sam3_detection_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_format_sam3_detection_prompt",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_format_sam3_detection_prompt",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_segs_has_items",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sam3:_segs_has_items",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_segs_has_items",
+        "optional": false,
+        "requested": ".sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3_detailer.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/image/scaling.py"
       },
       {
@@ -19598,6 +19884,77 @@
         "scope": "<module>",
         "source": "easyuse_anima/image/scaling.py",
         "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/upscale.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_common_upscale_image",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_common_upscale_image",
+        "kind": "static_from",
+        "line": 5,
+        "name": "_common_upscale_image",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/upscale.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_image_scale_by_multiple_size",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".scaling:_image_scale_by_multiple_size",
+        "kind": "static_from",
+        "line": 6,
+        "name": "_image_scale_by_multiple_size",
+        "optional": false,
+        "requested": ".scaling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/upscale.py",
+        "target": "easyuse_anima/image/scaling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_image_scale_options",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".scaling:_normalize_image_scale_options",
+        "kind": "static_from",
+        "line": 6,
+        "name": "_normalize_image_scale_options",
+        "optional": false,
+        "requested": ".scaling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/upscale.py",
+        "target": "easyuse_anima/image/scaling.py"
       },
       {
         "alias": null,
@@ -21783,57 +22140,21 @@
       },
       {
         "alias": null,
-        "bound_name": "_image_scale_by_multiple_size",
+        "bound_name": "_upscale_image_by_multiple",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "..image.scaling:_image_scale_by_multiple_size",
+        "imported": "..image.upscale:_upscale_image_by_multiple",
         "kind": "static_from",
-        "line": 7,
-        "name": "_image_scale_by_multiple_size",
+        "line": 11,
+        "name": "_upscale_image_by_multiple",
         "optional": false,
-        "requested": "..image.scaling",
+        "requested": "..image.upscale",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/nodes/image_nodes.py",
-        "target": "easyuse_anima/image/scaling.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_normalize_image_scale_options",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.scaling:_normalize_image_scale_options",
-        "kind": "static_from",
-        "line": 7,
-        "name": "_normalize_image_scale_options",
-        "optional": false,
-        "requested": "..image.scaling",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/image_nodes.py",
-        "target": "easyuse_anima/image/scaling.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_common_upscale_image",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..infrastructure.comfy.invocation:_common_upscale_image",
-        "kind": "static_from",
-        "line": 13,
-        "name": "_common_upscale_image",
-        "optional": false,
-        "requested": "..infrastructure.comfy.invocation",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/image_nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+        "target": "easyuse_anima/image/upscale.py"
       },
       {
         "alias": null,
@@ -21854,110 +22175,21 @@
       },
       {
         "alias": null,
-        "bound_name": "logging",
+        "bound_name": "_run_impact_detailer",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
+        "imported": "..image.sam3_detailer:_run_impact_detailer",
+        "kind": "static_from",
         "line": 5,
-        "name": null,
+        "name": "_run_impact_detailer",
         "optional": false,
-        "requested": "logging",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_as_bool",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..common.values:_as_bool",
-        "kind": "static_from",
-        "line": 7,
-        "name": "_as_bool",
-        "optional": false,
-        "requested": "..common.values",
+        "requested": "..image.sam3_detailer",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "target": "easyuse_anima/common/values.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_EasyUseAnimaAlignedDetailerHook",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.detailer:_EasyUseAnimaAlignedDetailerHook",
-        "kind": "static_from",
-        "line": 8,
-        "name": "_EasyUseAnimaAlignedDetailerHook",
-        "optional": false,
-        "requested": "..image.detailer",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "target": "easyuse_anima/image/detailer.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_alignment_value",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.geometry:_alignment_value",
-        "kind": "static_from",
-        "line": 9,
-        "name": "_alignment_value",
-        "optional": false,
-        "requested": "..image.geometry",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "target": "easyuse_anima/image/geometry.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_call_impact_detailer",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_call_impact_detailer",
-        "kind": "static_from",
-        "line": 10,
-        "name": "_call_impact_detailer",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_find_impact_detailer_class",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_find_impact_detailer_class",
-        "kind": "static_from",
-        "line": 10,
-        "name": "_find_impact_detailer_class",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
+        "target": "easyuse_anima/image/sam3_detailer.py"
       },
       {
         "alias": null,
@@ -21968,7 +22200,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 11,
+        "line": 6,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "..infrastructure.comfy.capabilities",
@@ -21986,7 +22218,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 11,
+        "line": 6,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "..infrastructure.comfy.capabilities",
@@ -22004,7 +22236,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 15,
+        "line": 10,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -25705,23 +25937,6 @@
       },
       {
         "alias": null,
-        "bound_name": "logging",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
-        "line": 5,
-        "name": null,
-        "optional": false,
-        "requested": "logging",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "alias": null,
         "bound_name": "_load_checkpoint_with_comfy",
         "branch_context": [],
         "classification": "internal",
@@ -25729,7 +25944,7 @@
         "conditional": false,
         "imported": "..aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "..aio.resources",
@@ -25747,7 +25962,7 @@
         "conditional": false,
         "imported": "..aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "..aio.resources",
@@ -25758,132 +25973,6 @@
       },
       {
         "alias": null,
-        "bound_name": "_as_bool",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..common.values:_as_bool",
-        "kind": "static_from",
-        "line": 11,
-        "name": "_as_bool",
-        "optional": false,
-        "requested": "..common.values",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/common/values.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_context_value",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_context_value",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_context_value",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_empty_mask_for_image",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_empty_mask_for_image",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_empty_mask_for_image",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_empty_segs_for_image",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_empty_segs_for_image",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_empty_segs_for_image",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_find_impact_mask_to_segs_class",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_find_impact_mask_to_segs_class",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_find_impact_mask_to_segs_class",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_find_sam3_detect_class",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_find_sam3_detect_class",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_find_sam3_detect_class",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_format_sam3_detection_prompt",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..image.sam3:_format_sam3_detection_prompt",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_format_sam3_detection_prompt",
-        "optional": false,
-        "requested": "..image.sam3",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
         "bound_name": "_sam3_context",
         "branch_context": [],
         "classification": "internal",
@@ -25891,7 +25980,7 @@
         "conditional": false,
         "imported": "..image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 12,
+        "line": 9,
         "name": "_sam3_context",
         "optional": false,
         "requested": "..image.sam3",
@@ -25902,39 +25991,21 @@
       },
       {
         "alias": null,
-        "bound_name": "_segs_has_items",
+        "bound_name": "_run_sam3_detailer",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "..image.sam3:_segs_has_items",
+        "imported": "..image.sam3_detailer:_run_sam3_detailer",
         "kind": "static_from",
-        "line": 12,
-        "name": "_segs_has_items",
+        "line": 10,
+        "name": "_run_sam3_detailer",
         "optional": false,
-        "requested": "..image.sam3",
+        "requested": "..image.sam3_detailer",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_node_output_tuple",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
-        "kind": "static_from",
-        "line": 22,
-        "name": "_node_output_tuple",
-        "optional": false,
-        "requested": "..infrastructure.comfy.invocation",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+        "target": "easyuse_anima/image/sam3_detailer.py"
       },
       {
         "alias": null,
@@ -25945,7 +26016,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 23,
+        "line": 11,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -25963,7 +26034,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 24,
+        "line": 12,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -25981,7 +26052,7 @@
         "conditional": false,
         "imported": ".impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 25,
+        "line": 13,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".impact_detailer_nodes",
@@ -67996,19 +68067,19 @@
       },
       {
         "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/image/upscale.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
         "to": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
         "from": "easyuse_anima/aio/legacy_generation.py",
         "to": "easyuse_anima/infrastructure/comfy/wiring.py"
-      },
-      {
-        "from": "easyuse_anima/aio/legacy_generation.py",
-        "to": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "from": "easyuse_anima/aio/legacy_generation.py",
-        "to": "easyuse_anima/nodes/sam3_nodes.py"
       },
       {
         "from": "easyuse_anima/aio/legacy_generation.py",
@@ -68395,12 +68466,44 @@
         "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/image/detailer.py"
+      },
+      {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/image/sam3_detailer.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
         "from": "easyuse_anima/image/scaling.py",
         "to": "easyuse_anima/common/values.py"
       },
       {
         "from": "easyuse_anima/image/scaling.py",
         "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/image/upscale.py",
+        "to": "easyuse_anima/image/scaling.py"
+      },
+      {
+        "from": "easyuse_anima/image/upscale.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
         "from": "easyuse_anima/infrastructure/comfy/provider.py",
@@ -68500,23 +68603,11 @@
       },
       {
         "from": "easyuse_anima/nodes/image_nodes.py",
-        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+        "to": "easyuse_anima/image/upscale.py"
       },
       {
         "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "to": "easyuse_anima/common/values.py"
-      },
-      {
-        "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "to": "easyuse_anima/image/detailer.py"
-      },
-      {
-        "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "to": "easyuse_anima/image/geometry.py"
-      },
-      {
-        "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "to": "easyuse_anima/image/sam3.py"
+        "to": "easyuse_anima/image/sam3_detailer.py"
       },
       {
         "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
@@ -68752,15 +68843,11 @@
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
-        "to": "easyuse_anima/common/values.py"
-      },
-      {
-        "from": "easyuse_anima/nodes/sam3_nodes.py",
         "to": "easyuse_anima/image/sam3.py"
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
-        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+        "to": "easyuse_anima/image/sam3_detailer.py"
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
@@ -70203,7 +70290,19 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/image/sam3_detailer.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/image/scaling.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/image/upscale.py"
         ]
       },
       {
@@ -70749,7 +70848,7 @@
     ]
   },
   "inventory": {
-    "module_count": 177,
+    "module_count": 179,
     "modules": [
       {
         "functions": [
@@ -72745,7 +72844,7 @@
         "is_package": false,
         "loc": 1095,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "c9414010fdd6ebd11567dc827d3c2f01143bfb03",
+        "normalized_git_blob_sha1": "5880f1c30c1543d8327da04a1ec18f5e3dd2ccce",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
@@ -76418,6 +76517,52 @@
         "functions": [
           {
             "async": false,
+            "end_line": 28,
+            "kind": "function",
+            "line": 27,
+            "loc": 2,
+            "qualified_name": "_missing_host_helper"
+          },
+          {
+            "async": false,
+            "end_line": 36,
+            "kind": "function",
+            "line": 31,
+            "loc": 6,
+            "qualified_name": "_encode_with_comfy_clip"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "function",
+            "line": 39,
+            "loc": 86,
+            "qualified_name": "_run_impact_detailer"
+          },
+          {
+            "async": false,
+            "end_line": 251,
+            "kind": "function",
+            "line": 127,
+            "loc": 125,
+            "qualified_name": "_run_sam3_detailer"
+          }
+        ],
+        "is_package": false,
+        "loc": 254,
+        "module": "easyuse_anima.image.sam3_detailer",
+        "normalized_git_blob_sha1": "15299662869cb5a83fdfdbd77dc3547dba8c3f84",
+        "path": "easyuse_anima/image/sam3_detailer.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
+          "global_count": 2
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
             "end_line": 19,
             "kind": "function",
             "line": 15,
@@ -76458,6 +76603,28 @@
           "class_count": 0,
           "function_count": 4,
           "global_count": 3
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 30,
+            "kind": "function",
+            "line": 9,
+            "loc": 22,
+            "qualified_name": "_upscale_image_by_multiple"
+          }
+        ],
+        "is_package": false,
+        "loc": 33,
+        "module": "easyuse_anima.image.upscale",
+        "normalized_git_blob_sha1": "210e20378eacfc9fea291ada7d6e905c1d07a43e",
+        "path": "easyuse_anima/image/upscale.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
         }
       },
       {
@@ -77622,41 +77789,41 @@
         "functions": [
           {
             "async": false,
-            "end_line": 62,
+            "end_line": 60,
             "kind": "method",
-            "line": 32,
+            "line": 30,
             "loc": 31,
             "qualified_name": "EasyUseAnimaImageScaleByMultiple.INPUT_TYPES"
           },
           {
             "async": false,
-            "end_line": 84,
+            "end_line": 74,
             "kind": "method",
-            "line": 69,
-            "loc": 16,
+            "line": 67,
+            "loc": 8,
             "qualified_name": "EasyUseAnimaImageScaleByMultiple.upscale"
           },
           {
             "async": false,
-            "end_line": 116,
+            "end_line": 106,
             "kind": "method",
-            "line": 99,
+            "line": 89,
             "loc": 18,
             "qualified_name": "EasyUseAnimaDetailerAlignHook.INPUT_TYPES"
           },
           {
             "async": false,
-            "end_line": 125,
+            "end_line": 115,
             "kind": "method",
-            "line": 123,
+            "line": 113,
             "loc": 3,
             "qualified_name": "EasyUseAnimaDetailerAlignHook.build"
           }
         ],
         "is_package": false,
-        "loc": 131,
+        "loc": 121,
         "module": "easyuse_anima.nodes.image_nodes",
-        "normalized_git_blob_sha1": "5dd0df22eb511b2454fbba95c636b0c72b5c907b",
+        "normalized_git_blob_sha1": "a3051fc3fd6d1b406c8e5f4d711f7f2a4b081d91",
         "path": "easyuse_anima/nodes/image_nodes.py",
         "top_level": {
           "class_count": 2,
@@ -77668,46 +77835,46 @@
         "functions": [
           {
             "async": false,
-            "end_line": 21,
+            "end_line": 14,
             "kind": "function",
-            "line": 20,
+            "line": 13,
             "loc": 2,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 29,
+            "end_line": 22,
             "kind": "function",
-            "line": 24,
+            "line": 17,
             "loc": 6,
             "qualified_name": "_comfy_max_resolution"
           },
           {
             "async": false,
-            "end_line": 170,
+            "end_line": 163,
             "kind": "method",
-            "line": 42,
+            "line": 35,
             "loc": 129,
             "qualified_name": "_EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES"
           },
           {
             "async": false,
-            "end_line": 263,
+            "end_line": 234,
             "kind": "method",
-            "line": 177,
-            "loc": 87,
+            "line": 170,
+            "loc": 65,
             "qualified_name": "_EasyUseAnimaImpactDetailerDelegate.doit"
           }
         ],
         "is_package": false,
-        "loc": 266,
+        "loc": 237,
         "module": "easyuse_anima.nodes.impact_detailer_nodes",
-        "normalized_git_blob_sha1": "ce6551a48a8fcb596d046724ca0644ca27d88622",
+        "normalized_git_blob_sha1": "c05becd71b3a36014d0c897dc2d6011b2156dc32",
         "path": "easyuse_anima/nodes/impact_detailer_nodes.py",
         "top_level": {
           "class_count": 1,
           "function_count": 2,
-          "global_count": 2
+          "global_count": 1
         }
       },
       {
@@ -78372,70 +78539,62 @@
         "functions": [
           {
             "async": false,
-            "end_line": 31,
+            "end_line": 17,
             "kind": "function",
-            "line": 30,
+            "line": 16,
             "loc": 2,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 39,
+            "end_line": 25,
             "kind": "function",
-            "line": 34,
+            "line": 20,
             "loc": 6,
             "qualified_name": "_comfy_max_resolution"
           },
           {
             "async": false,
-            "end_line": 47,
-            "kind": "function",
-            "line": 42,
-            "loc": 6,
-            "qualified_name": "_encode_with_comfy_clip"
-          },
-          {
-            "async": false,
-            "end_line": 75,
+            "end_line": 52,
             "kind": "method",
-            "line": 65,
+            "line": 42,
             "loc": 11,
             "qualified_name": "EasyUseAnimaSAM3Context.INPUT_TYPES"
           },
           {
             "async": false,
-            "end_line": 84,
+            "end_line": 61,
             "kind": "method",
-            "line": 82,
+            "line": 59,
             "loc": 3,
             "qualified_name": "EasyUseAnimaSAM3Context.load"
           },
           {
             "async": false,
-            "end_line": 191,
+            "end_line": 168,
             "kind": "method",
-            "line": 101,
+            "line": 78,
             "loc": 91,
             "qualified_name": "EasyUseAnimaSAM3Detailer.INPUT_TYPES"
           },
           {
             "async": false,
-            "end_line": 323,
+            "end_line": 261,
             "kind": "method",
-            "line": 198,
-            "loc": 126,
+            "line": 175,
+            "loc": 87,
             "qualified_name": "EasyUseAnimaSAM3Detailer.doit"
           }
         ],
         "is_package": false,
-        "loc": 326,
+        "loc": 264,
         "module": "easyuse_anima.nodes.sam3_nodes",
-        "normalized_git_blob_sha1": "2aede23aed23964b3a8beb13143c206b76c8221a",
+        "normalized_git_blob_sha1": "985a37f0680e79d7095d3b6f51b8a218c05c7ecd",
         "path": "easyuse_anima/nodes/sam3_nodes.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 3,
-          "global_count": 2
+          "function_count": 2,
+          "global_count": 1
         }
       },
       {
@@ -99056,6 +99215,28 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/image/sam3_detailer.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/image/scaling.py"
       },
       {
@@ -99090,6 +99271,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/image/scaling.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/image/upscale.py"
       },
       {
         "branch_context": [],
@@ -100034,17 +100226,6 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
@@ -100235,17 +100416,6 @@
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
-        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/nodes/sam3_nodes.py"
@@ -103963,7 +104133,9 @@
       "easyuse_anima/image/detailer.py",
       "easyuse_anima/image/geometry.py",
       "easyuse_anima/image/sam3.py",
+      "easyuse_anima/image/sam3_detailer.py",
       "easyuse_anima/image/scaling.py",
+      "easyuse_anima/image/upscale.py",
       "easyuse_anima/infrastructure/__init__.py",
       "easyuse_anima/infrastructure/comfy/__init__.py",
       "easyuse_anima/infrastructure/comfy/capabilities.py",
@@ -104142,7 +104314,9 @@
       "easyuse_anima/image/detailer.py",
       "easyuse_anima/image/geometry.py",
       "easyuse_anima/image/sam3.py",
+      "easyuse_anima/image/sam3_detailer.py",
       "easyuse_anima/image/scaling.py",
+      "easyuse_anima/image/upscale.py",
       "easyuse_anima/infrastructure/__init__.py",
       "easyuse_anima/infrastructure/comfy/__init__.py",
       "easyuse_anima/infrastructure/comfy/capabilities.py",
@@ -105473,6 +105647,15 @@
         "scope": "<module>"
       },
       {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 24,
+        "module": "easyuse_anima/image/sam3_detailer.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "TypeVar",
         "column": 5,
         "context": "assign:_T",
@@ -105563,15 +105746,6 @@
         "scope": "<module>"
       },
       {
-        "callee": "logging.getLogger",
-        "column": 9,
-        "context": "assign:logger",
-        "kind": "import_time_call",
-        "line": 17,
-        "module": "easyuse_anima/nodes/impact_detailer_nodes.py",
-        "scope": "<module>"
-      },
-      {
         "callee": "_AnyType",
         "column": 12,
         "context": "assign:_ANY_TYPE",
@@ -105587,15 +105761,6 @@
         "kind": "import_time_call",
         "line": 24,
         "module": "easyuse_anima/nodes/naia_nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "logging.getLogger",
-        "column": 9,
-        "context": "assign:logger",
-        "kind": "import_time_call",
-        "line": 27,
-        "module": "easyuse_anima/nodes/sam3_nodes.py",
         "scope": "<module>"
       },
       {

--- a/tests/fixtures/python_size_complexity_contract.v1.json
+++ b/tests/fixtures/python_size_complexity_contract.v1.json
@@ -151,6 +151,13 @@
       "decomposition_boundary": "E-09 initialization, rollback, repeated-call identity, and terminal shutdown checks remain serialized by one lock."
     },
     {
+      "path": "easyuse_anima/image/sam3_detailer.py",
+      "qualified_name": "_run_sam3_detailer",
+      "baseline_loc": 125,
+      "owner_issue": 188,
+      "decomposition_boundary": "Keep SAM3 detection, mask-to-SEGS conversion, empty-result handling, and Impact delegation ordered at the shared image operation boundary."
+    },
+    {
       "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
       "qualified_name": "AtomicJsonStore.replace_from",
       "baseline_loc": 140,
@@ -191,13 +198,6 @@
       "baseline_loc": 184,
       "owner_issue": 188,
       "decomposition_boundary": "Keep seed reservation and Prompt Data node output assembly ordered until a typed request owns both."
-    },
-    {
-      "path": "easyuse_anima/nodes/sam3_nodes.py",
-      "qualified_name": "EasyUseAnimaSAM3Detailer.doit",
-      "baseline_loc": 126,
-      "owner_issue": 188,
-      "decomposition_boundary": "Separate SAM3 detection from detailer result assembly only through the canonical image adapter."
     },
     {
       "path": "easyuse_anima/prompt/advanced.py",

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -200,14 +200,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
             return stage_sampler
 
-        class ScaleByMultiple:
-            def __init__(self):
-                trace.append("construct:scaler")
-
-            def upscale(self, *args):
-                trace.append("call:upscale")
-                test_case.assertEqual(args, (image, 1.5, "lanczos", "64", 2048))
-                return scaled_image, 128, 192, 1.5
+        def upscale_image_by_multiple(*args):
+            trace.append("call:upscale")
+            test_case.assertEqual(args, (image, 1.5, "lanczos", "64", 2048))
+            return scaled_image, 128, 192, 1.5
 
         def encode(source_vae, source_image):
             trace.append(f"call:encode:{source_image.name}")
@@ -269,7 +265,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         helpers = {
             "_as_bool": as_bool,
             "_aio_stage_sampler_settings": stage_sampler_settings,
-            "EasyUseAnimaImageScaleByMultiple": ScaleByMultiple,
+            "_upscale_image_by_multiple": upscale_image_by_multiple,
             "_encode_image_with_comfy_vae": encode,
             "_apply_aio_spectrum_model_patches_for_comfy_sampler": apply_patch,
             "_sample_latent_with_aio_backend": sample,
@@ -325,7 +321,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             [
                 "call:_as_bool",
                 "call:_aio_stage_sampler_settings",
-                "construct:scaler",
                 "call:upscale",
                 "call:encode:scaled_image",
                 "call:patch",
@@ -343,10 +338,9 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         model = _Token("model")
         stage_sampler = {"backend": "spectrum_mod_guidance_advanced"}
 
-        class ScaleByMultiple:
-            def upscale(self, *args):
-                trace.append("upscale")
-                return _Token("scaled"), 64, 96, 1.0
+        def upscale_image_by_multiple(*args):
+            trace.append("upscale")
+            return _Token("scaled"), 64, 96, 1.0
 
         def sample(*args):
             trace.append("sample")
@@ -360,7 +354,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         helpers = {
             "_as_bool": lambda value, default: True,
             "_aio_stage_sampler_settings": lambda *args, **kwargs: stage_sampler,
-            "EasyUseAnimaImageScaleByMultiple": ScaleByMultiple,
+            "_upscale_image_by_multiple": upscale_image_by_multiple,
             "_encode_image_with_comfy_vae": lambda vae, image: _Token("latent"),
             "_sample_latent_with_aio_backend": sample,
             "_cleanup_aio_ephemeral_model": cleanup,
@@ -775,14 +769,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
             return stage_model
 
-        class Detailer:
-            def __init__(self):
-                trace.append("construct:detailer")
-
-            def doit(self, **kwargs):
-                trace.append("call:doit")
-                captured_kwargs.update(kwargs)
-                return detailed_image, segs, object(), object()
+        def run_sam3_detailer(**kwargs):
+            trace.append("call:doit")
+            captured_kwargs.update(kwargs)
+            return detailed_image, segs, object(), object()
 
         def cleanup(current_model, original_model):
             trace.append("call:cleanup")
@@ -806,7 +796,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_as_float": as_float,
             "_aio_stage_sampler_settings": stage_sampler_settings,
             "_apply_aio_spectrum_model_patches_for_comfy_sampler": apply_patch,
-            "EasyUseAnimaSAM3Detailer": Detailer,
+            "_run_sam3_detailer": run_sam3_detailer,
             "_cleanup_aio_ephemeral_model": cleanup,
             "_segs_has_items": segs_has_items,
             "_prompt_data_json_safe": json_safe,
@@ -914,10 +904,9 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         }
 
         def execute(overrides, trace):
-            class Detailer:
-                def doit(self, **kwargs):
-                    trace.append("doit")
-                    return _Token("output"), ((1, 1), ["seg"])
+            def run_sam3_detailer(**kwargs):
+                trace.append("doit")
+                return _Token("output"), ((1, 1), ["seg"])
 
             helpers = {
                 "_as_bool": lambda value, default: bool(value),
@@ -927,7 +916,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "_apply_aio_spectrum_model_patches_for_comfy_sampler": (
                     lambda *args: stage_model
                 ),
-                "EasyUseAnimaSAM3Detailer": Detailer,
+                "_run_sam3_detailer": run_sam3_detailer,
                 "_cleanup_aio_ephemeral_model": (
                     lambda current, original: trace.append("cleanup")
                 ),
@@ -960,22 +949,21 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             execute({"_aio_stage_sampler_settings": fail_planner}, planner_trace)
         self.assertNotIn("cleanup", planner_trace)
 
-        class_trace = []
+        operation_trace = []
 
-        def fail_class():
-            class_trace.append("construct")
-            raise LookupError("class failed")
+        def fail_operation(**kwargs):
+            operation_trace.append("operation")
+            raise LookupError("operation failed")
 
-        with self.assertRaisesRegex(LookupError, "class failed"):
-            execute({"EasyUseAnimaSAM3Detailer": fail_class}, class_trace)
-        self.assertEqual(class_trace[-1:], ["cleanup"])
+        with self.assertRaisesRegex(LookupError, "operation failed"):
+            execute({"_run_sam3_detailer": fail_operation}, operation_trace)
+        self.assertEqual(operation_trace[-1:], ["cleanup"])
 
         cleanup_trace = []
 
-        class FailingDetailer:
-            def doit(self, **kwargs):
-                cleanup_trace.append("doit")
-                raise ValueError("detailer failed")
+        def failing_detailer(**kwargs):
+            cleanup_trace.append("doit")
+            raise ValueError("detailer failed")
 
         def fail_cleanup(current, original):
             cleanup_trace.append("cleanup")
@@ -984,7 +972,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
             execute(
                 {
-                    "EasyUseAnimaSAM3Detailer": FailingDetailer,
+                    "_run_sam3_detailer": failing_detailer,
                     "_cleanup_aio_ephemeral_model": fail_cleanup,
                 },
                 cleanup_trace,

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -1719,7 +1719,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
             return "high_latent"
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", side_effect=fake_sample),
@@ -1774,7 +1774,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
             return "high_latent"
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", side_effect=fake_sample),
@@ -1822,7 +1822,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
@@ -1884,7 +1884,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as comfy_patch,
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent"),
@@ -1926,7 +1926,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
@@ -1963,7 +1963,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
+            patch.object(legacy_generation, "_upscale_image_by_multiple", return_value=("scaled_image", 640, 960, 1.25)),
             patch.object(legacy_generation, "_encode_image_with_comfy_vae", side_effect=["high_latent_image", "corrected_latent"]) as encode,
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
             patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent"),
@@ -2018,7 +2018,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="detail_model") as comfy_patch,
-            patch.object(nodes.EasyUseAnimaSAM3Detailer, "doit", return_value=("detailed_image", ((1, 1), ["seg"]), "mask", "raw_image")) as detailer,
+            patch.object(legacy_generation, "_run_sam3_detailer", return_value=("detailed_image", ((1, 1), ["seg"]), "mask", "raw_image")) as detailer,
             patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             image, metadata = nodes._run_aio_detailer_target(

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -1,9 +1,11 @@
 import unittest
+from unittest.mock import patch
 
 from easyuse_anima.image.scaling import (
     _image_scale_by_multiple_size,
     _normalize_image_scale_options,
 )
+from easyuse_anima.nodes import image_nodes
 from easyuse_anima.nodes.image_nodes import EasyUseAnimaImageScaleByMultiple
 
 
@@ -112,6 +114,26 @@ class ImageScaleByMultipleTests(unittest.TestCase):
         self.assertEqual(tuple(output.shape), (1, 1152, 1504, 3))
         self.assertAlmostEqual(applied_scale, 1.4933127413127414)
         self.assertEqual(output.dtype, image.dtype)
+
+    def test_node_adapter_delegates_to_shared_operation(self):
+        expected = (object(), 128, 192, 1.5)
+        image = object()
+
+        with patch.object(
+            image_nodes,
+            "_upscale_image_by_multiple",
+            return_value=expected,
+        ) as upscale:
+            result = EasyUseAnimaImageScaleByMultiple().upscale(
+                image,
+                1.5,
+                "lanczos",
+                "64",
+                2048,
+            )
+
+        self.assertIs(result, expected)
+        upscale.assert_called_once_with(image, 1.5, "lanczos", "64", 2048)
 
 
 if __name__ == "__main__":

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -31,7 +31,9 @@ from easyuse_anima.common import serialization as common_serialization
 from easyuse_anima.common import values as common_values
 from easyuse_anima.image import detailer as image_detailer
 from easyuse_anima.image import geometry as image_geometry
+from easyuse_anima.image import sam3_detailer as image_sam3_detailer
 from easyuse_anima.image import scaling as image_scaling
+from easyuse_anima.image import upscale as image_upscale
 from easyuse_anima.infrastructure.comfy import capabilities as comfy_capabilities
 from easyuse_anima.infrastructure.comfy import invocation as comfy_invocation
 from easyuse_anima.infrastructure.comfy import resources as comfy_resources
@@ -42,7 +44,6 @@ from easyuse_anima.naia import resolution as naia_resolution
 from easyuse_anima.nodes import (
     aio_nodes,
     image_nodes,
-    impact_detailer_nodes,
     input_types,
     lora_nodes,
     naia_nodes,
@@ -2318,7 +2319,7 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             image_detailer._EasyUseAnimaAlignedDetailerHook,
         )
         self.assertIs(
-            impact_detailer_nodes._EasyUseAnimaAlignedDetailerHook,
+            image_sam3_detailer._EasyUseAnimaAlignedDetailerHook,
             image_detailer._EasyUseAnimaAlignedDetailerHook,
         )
         aligned_hook = image_nodes.EasyUseAnimaDetailerAlignHook().build(
@@ -2339,7 +2340,14 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             nodes.EasyUseAnimaDetailerAlignHook,
             image_nodes.EasyUseAnimaDetailerAlignHook,
         )
-        self.assertIs(image_nodes._common_upscale_image, comfy_invocation._common_upscale_image)
+        self.assertIs(
+            image_upscale._common_upscale_image,
+            comfy_invocation._common_upscale_image,
+        )
+        self.assertIs(
+            image_nodes._upscale_image_by_multiple,
+            image_upscale._upscale_image_by_multiple,
+        )
 
     def test_package_loaded_root_nodes_image_objects_are_direct_canonical_aliases(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
@@ -2349,14 +2357,15 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             package_name = package_nodes.__package__
             package_scaling = sys.modules[f"{package_name}.easyuse_anima.image.scaling"]
             package_detailer = sys.modules[f"{package_name}.easyuse_anima.image.detailer"]
+            package_sam3_detailer = sys.modules[
+                f"{package_name}.easyuse_anima.image.sam3_detailer"
+            ]
+            package_upscale = sys.modules[f"{package_name}.easyuse_anima.image.upscale"]
             package_invocation = sys.modules[
                 f"{package_name}.easyuse_anima.infrastructure.comfy.invocation"
             ]
             package_node_adapters = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.image_nodes"
-            ]
-            package_impact_adapters = sys.modules[
-                f"{package_name}.easyuse_anima.nodes.impact_detailer_nodes"
             ]
             for name in self.RETAINED_SCALING_ALIASES:
                 with self.subTest(name=name):
@@ -2387,7 +2396,7 @@ class ImageNodeMoveContractTests(unittest.TestCase):
                 package_detailer._EasyUseAnimaAlignedDetailerHook,
             )
             self.assertIs(
-                package_impact_adapters._EasyUseAnimaAlignedDetailerHook,
+                package_sam3_detailer._EasyUseAnimaAlignedDetailerHook,
                 package_detailer._EasyUseAnimaAlignedDetailerHook,
             )
             aligned_hook = package_node_adapters.EasyUseAnimaDetailerAlignHook().build(
@@ -2406,8 +2415,12 @@ class ImageNodeMoveContractTests(unittest.TestCase):
                     canonical_class = getattr(package_node_adapters, name)
                     self.assertIs(getattr(package_nodes, name), canonical_class)
             self.assertIs(
-                package_node_adapters._common_upscale_image,
+                package_upscale._common_upscale_image,
                 package_invocation._common_upscale_image,
+            )
+            self.assertIs(
+                package_node_adapters._upscale_image_by_multiple,
+                package_upscale._upscale_image_by_multiple,
             )
 
 

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -762,9 +762,42 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 3)
-        self.assertEqual(report["inventory"]["module_count"], 177)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 177)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 177)
+        self.assertEqual(report["inventory"]["module_count"], 179)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 179)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 179)
+        runtime_edges = {
+            (edge["source"], edge.get("target"))
+            for edge in report["imports"]["edges"]
+            if edge["classification"] == "internal"
+        }
+        self.assertNotIn(
+            (
+                "easyuse_anima/aio/legacy_generation.py",
+                "easyuse_anima/nodes/image_nodes.py",
+            ),
+            runtime_edges,
+        )
+        self.assertNotIn(
+            (
+                "easyuse_anima/aio/legacy_generation.py",
+                "easyuse_anima/nodes/sam3_nodes.py",
+            ),
+            runtime_edges,
+        )
+        self.assertIn(
+            (
+                "easyuse_anima/aio/legacy_generation.py",
+                "easyuse_anima/image/upscale.py",
+            ),
+            runtime_edges,
+        )
+        self.assertIn(
+            (
+                "easyuse_anima/aio/legacy_generation.py",
+                "easyuse_anima/image/sam3_detailer.py",
+            ),
+            runtime_edges,
+        )
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -7,9 +7,9 @@ from unittest.mock import Mock, patch
 import nodes
 from easyuse_anima.aio import resources as aio_resources
 from easyuse_anima.image import sam3 as sam3_service
+from easyuse_anima.image import sam3_detailer as sam3_detailer_service
 from easyuse_anima.infrastructure.comfy import capabilities
-from easyuse_anima.nodes import impact_detailer_nodes
-from easyuse_anima.nodes import sam3_nodes
+from easyuse_anima.nodes import impact_detailer_nodes, sam3_nodes
 from tests.comfy_host_fakes import patch_comfy_helper
 
 
@@ -60,6 +60,8 @@ class SAM3MoveTests(unittest.TestCase):
             "_find_impact_mask_to_segs_class",
             "_find_sam3_detect_class",
             "_format_sam3_detection_prompt",
+            "_run_impact_detailer",
+            "_run_sam3_detailer",
         )
         for name in retired_service_names:
             with self.subTest(retired=name):
@@ -153,6 +155,13 @@ class SAM3MoveTests(unittest.TestCase):
             self.assertIs(sam3_service._find_impact_detailer_class(), sentinel)
         find.assert_called_once_with("DetailerForEach")
 
+    def test_detailer_missing_host_helper_error_is_preserved(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SAM3 node Comfy host helper is unavailable: _encode_with_comfy_clip",
+        ):
+            sam3_detailer_service._missing_host_helper("_encode_with_comfy_clip")
+
     def test_context_node_keeps_call_time_checkpoint_loader(self):
         with patch.object(
             sam3_nodes,
@@ -169,8 +178,8 @@ class SAM3MoveTests(unittest.TestCase):
 
     def test_disabled_detailer_preserves_original_outputs(self):
         with (
-            patch.object(sam3_nodes, "_empty_mask_for_image", return_value="empty-mask"),
-            patch.object(sam3_nodes, "_empty_segs_for_image", return_value="empty-segs"),
+            patch.object(sam3_detailer_service, "_empty_mask_for_image", return_value="empty-mask"),
+            patch.object(sam3_detailer_service, "_empty_segs_for_image", return_value="empty-segs"),
         ):
             result = sam3_nodes.EasyUseAnimaSAM3Detailer().doit(
                 **self._detailer_kwargs(enabled=False)
@@ -181,22 +190,20 @@ class SAM3MoveTests(unittest.TestCase):
     def test_detector_mask_and_impact_delegation_arguments_are_preserved(self):
         sam3_detect = SimpleNamespace(execute=Mock(return_value=("mask",)))
         mask_to_segs = SimpleNamespace(doit=Mock(return_value=(((64, 64), ["seg"]),)))
+        detail = Mock(return_value=("detailed-image",))
+        detailer_cls = Mock(return_value=SimpleNamespace(doit=detail))
 
         with (
-            patch.object(sam3_nodes, "_empty_mask_for_image", return_value="empty-mask"),
-            patch.object(sam3_nodes, "_empty_segs_for_image", return_value="empty-segs"),
+            patch.object(sam3_detailer_service, "_empty_mask_for_image", return_value="empty-mask"),
+            patch.object(sam3_detailer_service, "_empty_segs_for_image", return_value="empty-segs"),
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",
                 return_value="conditioning",
             ) as encode,
-            patch.object(sam3_nodes, "_find_sam3_detect_class", return_value=sam3_detect),
-            patch.object(sam3_nodes, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
-            patch.object(
-                sam3_nodes._EasyUseAnimaImpactDetailerDelegate,
-                "doit",
-                return_value=("detailed-image",),
-            ) as detail,
+            patch.object(sam3_detailer_service, "_find_sam3_detect_class", return_value=sam3_detect),
+            patch.object(sam3_detailer_service, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
+            patch.object(sam3_detailer_service, "_find_impact_detailer_class", return_value=detailer_cls),
         ):
             result = sam3_nodes.EasyUseAnimaSAM3Detailer().doit(**self._detailer_kwargs())
 
@@ -220,21 +227,54 @@ class SAM3MoveTests(unittest.TestCase):
         mask_to_segs = SimpleNamespace(doit=Mock(return_value=(((64, 64), []),)))
 
         with (
-            patch.object(sam3_nodes, "_empty_mask_for_image", return_value="empty-mask"),
-            patch.object(sam3_nodes, "_empty_segs_for_image", return_value="empty-segs"),
+            patch.object(sam3_detailer_service, "_empty_mask_for_image", return_value="empty-mask"),
+            patch.object(sam3_detailer_service, "_empty_segs_for_image", return_value="empty-segs"),
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",
                 return_value="conditioning",
             ),
-            patch.object(sam3_nodes, "_find_sam3_detect_class", return_value=sam3_detect),
-            patch.object(sam3_nodes, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
-            patch.object(sam3_nodes._EasyUseAnimaImpactDetailerDelegate, "doit") as detail,
+            patch.object(sam3_detailer_service, "_find_sam3_detect_class", return_value=sam3_detect),
+            patch.object(sam3_detailer_service, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
+            patch.object(sam3_detailer_service, "_run_impact_detailer") as detail,
         ):
             result = sam3_nodes.EasyUseAnimaSAM3Detailer().doit(**self._detailer_kwargs())
 
         self.assertEqual(result, ("input-image", ((64, 64), []), "mask", "input-image"))
         detail.assert_not_called()
+
+    def test_impact_node_adapter_delegates_to_shared_operation(self):
+        kwargs = self._detailer_kwargs()
+        for key in (
+            "enabled",
+            "ctx_SAM3",
+            "detect_prompt",
+            "detect_count",
+            "threshold",
+            "refine_iterations",
+            "individual_masks",
+            "combined",
+            "crop_factor",
+            "bbox_fill",
+            "drop_size",
+            "contour_fill",
+        ):
+            kwargs.pop(key)
+        kwargs["segs"] = "detail-segs"
+
+        with patch.object(
+            impact_detailer_nodes,
+            "_run_impact_detailer",
+            return_value=("detailed-image",),
+        ) as run:
+            result = impact_detailer_nodes._EasyUseAnimaImpactDetailerDelegate().doit(**kwargs)
+
+        self.assertEqual(result, ("detailed-image",))
+        self.assertEqual(run.call_args.kwargs["image"], "input-image")
+        self.assertEqual(run.call_args.kwargs["segs"], "detail-segs")
+        self.assertEqual(run.call_args.kwargs["scheduler"], "scheduler")
+        self.assertEqual(run.call_args.kwargs["alignment"], "impact")
+        self.assertEqual(run.call_args.kwargs["noise_mask_feather"], 0)
 
     def test_impact_call_filters_unknown_keywords_without_changing_order(self):
         class Detailer:


### PR DESCRIPTION
## 목적과 변경 경계

Issue #593의 FC-02C cohesive Move입니다. AiO legacy generation이 node adapter class를 직접 호출하던 back-reference를 제거하고, image-owned private execution operation으로 scaler와 SAM3/Impact 실행을 이동합니다.

Base: `dev@3833f2ea380ff743945dc2f8012f3be3e8c0624d`
Head: `d6b446b35f7d1d8a89b6e8971f2afcf91c853e1e`

## 주요 변경

- `easyuse_anima.image.upscale._upscale_image_by_multiple`로 image scaling 실행을 이동
- `easyuse_anima.image.sam3_detailer._run_sam3_detailer` 및 `_run_impact_detailer`로 공유 실행을 이동
- image/SAM3/Impact node adapter는 기존 schema/signature를 유지한 채 private operation에 위임
- AiO legacy generation은 node class import/생성 없이 동일 private operation을 호출
- analyzer, size ledger, compatibility ledger와 direct owner tests를 실제 import/call-time owner에 맞춤

## 보존 계약

- dynamic host lookup과 monkeypatch seam
- input schema, defaults, return/error ordering과 message
- AiO metadata 및 ephemeral cleanup
- node class/handler identity와 public export surface
- import-time no-host 동작
- E-09 runtime/lifecycle boundary

## 검증

- Image scale: 12 PASS
- SAM3 move: 10 PASS
- AiO highres/detailer stage: 9 PASS
- AiO legacy direct success/failure boundary: 4 PASS
- image/Comfy adapter move contracts: 4 PASS
- compatibility ledger: 7 PASS
- analyzer/import/package-skeleton/size/runtime-state/test-ownership focused gates: PASS
- changed-file compile, targeted Ruff, JSON parse, `git diff --check`: PASS
- official full on final SHA: 1,475 Python tests + 120 frontend files PASS
- package promotion: 321 files, tracked `.comfyignore`, archive creation PASS
- live smoke: 미실행(FC-02C trigger 없음)

## 위험과 rollback

동작과 public surface는 유지하며 owner/import 방향만 이동합니다. 회귀 시 이 squash commit 하나를 revert하면 기존 node-adapter 경로로 복귀합니다. host helper는 기존과 동일하게 call-time resolution을 유지합니다.

## Next

merge 후 별도 FC-02D Contract/tool gate를 진행합니다. FC-03 production은 FC-02D 완료 전 시작하지 않습니다.