### PR TITLE
docs: close backend roadmap navigation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,17 +3,18 @@
 These documents define the target backend architecture, migration rules and reviewed
 cross-surface contracts. They do not imply that every target state is implemented.
 
-Read the bounded execution policy first, then only the active task, its owning Issue,
-direct source and direct tests.
+Read the bounded execution policy first, then only the current READY or event task, its
+owning Issue, direct source and direct tests. When neither exists, do not reopen a
+completed lane.
 
-## Active sequencing
+## Current sequencing
 
-- Active final-convergence plan:
+- Final-convergence completion and event plan:
   [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md)
-- Active owner: Issue
+- Technical completion owner: completed Issue
   [#593](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/593)
-- First READY task: FC-01 original Definition-of-Done closure audit.
-- Parent architecture: Issue
+- READY backend refactor task: none. FC-06 waits for an ordinary release event.
+- Parent architecture: completed Issue
   [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185)
 - Compatibility/release ledger: Issue
   [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
@@ -35,9 +36,9 @@ EVENT    ordinary release N
   ->     later H/D-14 compatibility re-audit
 ```
 
-The prior `no READY task` conclusion was correct for completed F/G/security work and
-compatibility deletion. It did not mean that the initial architecture Definition of
-Done had been fully reconciled.
+FC-01 through FC-05 temporarily superseded the earlier `no READY task` state to close
+the initial architecture Definition of Done. That technical work is now complete, so
+the current `no READY task` state is authoritative until the FC-06 release event.
 
 ## Current code boundary
 
@@ -118,7 +119,7 @@ All final-convergence work preserves:
 FC-03 changes patch ownership only. FC-04 moved application construction only after
 its lifecycle Contract proved these invariants.
 
-## Core active documents
+## Core current documents
 
 - [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md):
   FC-01 through FC-07, technical versus compatibility completion, optional large-module

--- a/docs/architecture/backend-final-convergence-roadmap.md
+++ b/docs/architecture/backend-final-convergence-roadmap.md
@@ -3,8 +3,8 @@
 ## Status and authority
 
 - Status: technical convergence complete; compatibility retirement remains event-gated.
-- Active owner: Issue #593.
-- Parent architecture: Issue #185.
+- Technical completion owner: completed Issue #593.
+- Parent architecture: completed Issue #185.
 - Compatibility ledger: Issue #186 and ADR-002.
 - Lifecycle authority: E-09 / Issue #187.
 - Current released baseline: 0.6.2.
@@ -746,24 +746,21 @@ owner. Stop and request focused technical PRO review only when:
 
 ## 13. Codex resume instruction
 
-```text
-Start Issue #593 / FC-01 from latest origin/dev.
+No backend refactor task is READY. Do not reopen completed FC-01 through FC-05 work.
 
-Read only:
-- current-policies.md
-- codex-execution-efficiency.md universal rules
-- this document's FC-01 and validation sections
-- Issue #593 latest checkpoint
-- python-backend.md Overall Definition of Done
-- current import-boundary checker/ledger
-- G-06 test ownership map
-- P-API-01 completed inventory/revisit events
-- compatibility registry and direct evidence named by those documents
+Start FC-06 only when an independently justified ordinary feature or bug-fix release is
+ready. Backend completion or starting a shim-support clock is not a release trigger.
 
-Do not implement FC-02+ during FC-01. Do not reopen completed F/G/security lanes.
-Do not start P-API-02, root removal, release, tag or Registry work.
+At that event, read only:
 
-Produce one closure matrix, confirm or correct the next task boundaries, run only direct
-consistency/focused checks and git diff check, then create a dev-targeted Draft PR.
-Documentation-only FC-01 does not trigger official full/package/live.
-```
+- `current-policies.md`;
+- `codex-execution-efficiency.md` universal rules;
+- this document's FC-06 and validation sections;
+- Issue #186's latest compatibility checkpoint;
+- `MAINTAINING.md` release procedure; and
+- current `main`/`dev`, version, changelog, package and Registry metadata.
+
+Use a separate release task card to integrate the validated candidate into `main`, bump
+the version, validate the exact archive, create the immutable tag, publish and read back
+the Registry state. FC-06 does not authorize P-API-02, root removal, lifecycle changes or
+FC-07/H/D-14. When no ordinary release event exists, make no FC code or release change.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,8 @@
 # EasyUse Anima Development Entry
 
 Use this file as the first development-doc entry point for a new Codex session. Read
-only the active task section and its direct owners.
+only the current READY or event task and its direct owners; do not reopen a completed
+lane when neither exists.
 
 ## Read order
 
@@ -11,9 +12,10 @@ only the active task section and its direct owners.
    - use focused edit-loop tests;
    - run official full once on the final candidate SHA;
    - run package/live/benchmark only when triggered.
-3. Active final-convergence queue:
+3. Current final-convergence status and event queue:
    [`../architecture/backend-final-convergence-roadmap.md`](../architecture/backend-final-convergence-roadmap.md)
-4. Active owner: Issue #593.
+4. Compatibility/release ledger: Issue #186. Technical owner #593 and parent #185 are
+   completed.
 5. Target architecture and original Definition of Done:
    [`../architecture/python-backend.md`](../architecture/python-backend.md)
 6. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
@@ -54,46 +56,18 @@ have executable owners. There is no READY backend implementation task.
 Actual shim deletion remains release/consumer gated and is not required for technical
 architecture completion.
 
-## FC-01 direct reading scope
+## Current event-wait boundary
 
-```text
-docs/architecture/backend-final-convergence-roadmap.md      # FC-01 only
-docs/architecture/python-backend.md                         # Overall DoD
-docs/architecture/python-phase-fg-completion-audit.md
-docs/architecture/python-api-papi01-e09-lifecycle-gate.md
-docs/architecture/python-compatibility-shims.md
-tools/check_python_import_boundaries.py
-tests/fixtures/python_import_boundary_contract.v2.json
-tests/fixtures/python_test_ownership_contract.v1.json
-```
+No backend refactor task is READY. Do not reopen FC-01 through FC-05 or create a release
+only to start a compatibility clock.
 
-Read direct tests or analyzer output only when the closure matrix needs to verify a
-specific row. Do not read every production package during FC-01.
+When an independently justified ordinary feature or bug-fix release is ready, FC-06
+reads only the roadmap's FC-06/validation sections, Issue #186's latest checkpoint,
+`MAINTAINING.md`, and the current `main`/`dev`, version, changelog, package and Registry
+metadata. Use a separate release task card and preserve the fixed guards below.
 
-## FC-01 boundary
-
-Production, test, tool and fixture changes are forbidden unless the audit proves that
-existing deterministic evidence cannot express one required row.
-
-Classify every original Definition-of-Done item as:
-
-```text
-complete
-technical gap
-compatibility event
-deliberate retain
-```
-
-Required outputs:
-
-- one compact closure matrix;
-- exact gap between import-boundary and G-06 owner coverage;
-- confirmed FC-02 owner/role model;
-- confirmed FC-03 root patch-owner migration boundary;
-- confirmed FC-04 E-09 application/lifecycle boundary;
-- corrected next task card if the evidence disproves an assumption.
-
-Do not implement FC-02 or later work in the FC-01 PR.
+Without that release event, new bugs and features use their own owning Issue and do not
+reactivate the backend convergence queue.
 
 ## Fixed lifecycle and compatibility guards
 
@@ -132,7 +106,7 @@ The broad quick/full profiles are not edit-loop commands.
 
 ### Promotion
 
-- Documentation-only FC-01 reuses current valid code evidence.
+- Documentation-only roadmap/navigation corrections reuse current valid code evidence.
 - Run official full once when code, tests, tools or shared fixtures change.
 - Run validate/pack/archive for import, entrypoint, registration, dependency, archive or
   release changes.


### PR DESCRIPTION
## 목적과 변경 경계

FC-05 기술 완료 뒤에도 닫힌 #593/FC-01을 현재 active owner와 resume task로 가리키던 navigation을 정리합니다.

- production, test, tool, fixture 변경 없음
- 과거 FC-01~FC-05 task card와 evidence는 보존
- 현재 READY backend task는 없음
- FC-06은 독립적으로 정당화된 ordinary feature/bug-fix release가 있을 때만 시작
- #186을 compatibility/release ledger로 유지
- root 제거, lifecycle 변경, release/tag/Registry 작업 없음

## Base -> Head

- 9e5da8d6c9bf15fcc5afb94a45e4b51b65a5dc48 -> 6215d7336ddf715f29605e1d2365ce113198b19e

## 검증

- runtime lifecycle document owner 1 PASS
- architecture entrypoint owner 1 PASS
- development/Registry-safety entrypoint owner 1 PASS
- stale current-navigation 검색 0건
- git diff --check PASS
- docs-only이고 production tree가 동일하므로 official full/package/live 재사용

## 위험과 rollback

문서 navigation만 변경합니다. rollback은 세 문서 commit을 되돌리면 됩니다.

## Next

ordinary release event 전에는 backend convergence 작업을 재개하지 않습니다.