### PR TITLE
PTC-01: 전체 Python 수렴 계약 고정

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -13,7 +13,9 @@ completed lane.
   [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md)
 - Technical completion owner: completed Issue
   [#593](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/593)
-- READY backend refactor task: none. FC-06 waits for an ordinary release event.
+- Total Python Convergence Contract:
+  [`python-total-convergence-contract.md`](python-total-convergence-contract.md)
+- READY backend refactor task: PTC-02 after the PTC-01 Contract merge.
 - Parent architecture: completed Issue
   [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185)
 - Compatibility/release ledger: Issue
@@ -30,20 +32,23 @@ COMPLETE FC-04A canonical API application/E-09 lifecycle Contract
 COMPLETE FC-04B canonical API application cohesive Move
 COMPLETE FC-05 technical architecture completion
 
-READY    none for backend refactoring
+COMPLETE PTC-01 total production inventory/target Contract
+READY    PTC-02 AiO generation normalization Move
 
 EVENT    ordinary release N
   ->     later H/D-14 compatibility re-audit
 ```
 
-FC-01 through FC-05 temporarily superseded the earlier `no READY task` state to close
-the initial architecture Definition of Done. That technical work is now complete, so
-the current `no READY task` state is authoritative until the FC-06 release event.
+FC-01 through FC-05 closed the initial ownership and lifecycle Definition of Done.
+PTC-01 adds the mandatory per-file convergence and legacy-root removal layer; PTC-02 is
+the current READY task. Release events remain separate from this technical sequence.
 
 ## Current code boundary
 
-The backend is functionally validated and technically complete at
-`dev@bb1452c9996293f1f77bb361e7317ddb2664ae19`.
+The FC backend boundary was functionally validated at
+`dev@bb1452c9996293f1f77bb361e7317ddb2664ae19`. PTC-01 is based on
+`dev@39997c5423847d4280737f0d78d353d3c6273e07` and extends that boundary without
+reopening completed feature, lifecycle or security work.
 
 ### Completed boundaries
 
@@ -62,22 +67,21 @@ The backend is functionally validated and technically complete at
 - sensitive settings responses use safe logging and `no-store` under the completed
   TRUSTED_DEPLOYMENT_ONLY security boundary.
 
-### Technical completion
+### FC technical completion and PTC extension
 
-FC-05 reconciles every original Definition-of-Done row and records the integrated
-full, owner, package/no-host, lifecycle, 0.5.2 compatibility and isolated ComfyUI
-API/node execution gates. No technical backend refactor task remains READY.
+FC-05 reconciled the original ownership/lifecycle Definition-of-Done rows and recorded
+the integrated full, owner, package/no-host, lifecycle, 0.5.2 compatibility and
+isolated ComfyUI API/node execution gates. PTC now completes the broader objective:
+every Python file has an explicit disposition, oversized modules are closed, and legacy
+root import paths are removed after canonical callers are proven.
 
-### Compatibility boundary
+### Legacy import boundary
 
-Actual root-shim removal remains event-gated:
-
-- final forms need an ordinary published release N;
-- consumer and harm evidence must be considered;
-- public removal needs breaking-change approval, release notes and rollback;
-- low-cost shims may be deliberately retained.
-
-Technical architecture completion does not require deleting every public shim.
+Root `__init__.py` remains the permanent ComfyUI entrypoint. The other nine root Python
+modules and seven `anima_prompt` compatibility modules are planned PTC-09B deletions,
+after PTC-09A fixes canonical entrypoint/caller ownership and proves the E-09 lifecycle
+identity sequence. The cutover intentionally stops supporting those legacy import paths;
+it must not recreate equivalent compatibility facades in a new package.
 
 ## Fixed owner model
 
@@ -86,7 +90,7 @@ The target owner matrix remains:
 | Surface | Owner and durable responsibility |
 | --- | --- |
 | Root `__init__.py` | permanent ComfyUI entrypoint; exported mappings and one guarded startup path |
-| Root compatibility files | explicit aliases/facades only; no new feature, I/O, cache or lifecycle logic |
+| Legacy root files until PTC-09B | transitional exact aliases/facades only; migrate callers to canonical owners, then delete without replacement facade |
 | `bootstrap.py` | sole lifecycle/composition owner, RuntimeConfig, initialize/shutdown and concrete wiring |
 | `runtime.py` | installed RuntimeServices identity and process runtime access |
 | `registration.py` | pure node mapping composition |
@@ -122,8 +126,11 @@ its lifecycle Contract proved these invariants.
 ## Core current documents
 
 - [`backend-final-convergence-roadmap.md`](backend-final-convergence-roadmap.md):
-  FC-01 through FC-07, technical versus compatibility completion, optional large-module
-  disposition, validation and Codex resume instruction.
+  completed FC ownership/lifecycle convergence, active PTC queue, release events,
+  validation and Codex resume instruction.
+- [`python-total-convergence-contract.md`](python-total-convergence-contract.md):
+  explicit 183-file disposition, 31 size-exception decisions, exact target tree,
+  root canonical cutover and the blocking completion definition.
 - [`python-backend.md`](python-backend.md): target architecture, phases and original
   Definition of Done.
 - [`python-api-papi01-e09-lifecycle-gate.md`](python-api-papi01-e09-lifecycle-gate.md):
@@ -180,5 +187,6 @@ Read only when needed:
 - Compatibility decisions: Issue #186 plus the shim registry
 - Feature behavior: owning Issue
 
-No document here independently authorizes root deletion, a public breaking change,
-release publication, tags or Registry actions.
+Only the staged PTC-09A/PTC-09B Contract authorizes removal of the reviewed legacy import
+paths. No document here independently authorizes release publication, tags or Registry
+actions.

--- a/docs/architecture/backend-final-convergence-roadmap.md
+++ b/docs/architecture/backend-final-convergence-roadmap.md
@@ -2,9 +2,10 @@
 
 ## Status and authority
 
-- Status: technical convergence complete; compatibility retirement remains event-gated.
-- Technical completion owner: completed Issue #593.
-- Parent architecture: completed Issue #185.
+- Status: FC ownership/lifecycle convergence complete; mandatory Total Python
+  Convergence extension active.
+- Technical completion owner: reactivated Issue #593.
+- Parent architecture: reactivated Issue #185.
 - Compatibility ledger: Issue #186 and ADR-002.
 - Lifecycle authority: E-09 / Issue #187.
 - Current released baseline: 0.6.2.
@@ -13,34 +14,33 @@
 - FC-01 audit base: `81e07c6c12c21f84ba0642c93d6655c8936b7c3b`.
 - Completed final-convergence lanes: FC-01, FC-02A through FC-02D, FC-03A,
   FC-03B, FC-04A, FC-04B and FC-05.
-- Current READY technical task: none. FC-06 starts only with the next ordinary
-  release event.
+- Completed extension lane: PTC-01 inventory/target Contract.
+- Current READY technical task: PTC-02 AiO generation normalization Move.
 
-This document supersedes the `no READY task` conclusion only for the initial backend
-architecture Definition of Done. It does not reopen completed Phase F/G or security
-work, and it does not authorize P-API-02, root deletion, release, tag, or Registry work.
+The FC results remain valid for their original ownership/lifecycle Definition of Done.
+[`python-total-convergence-contract.md`](python-total-convergence-contract.md) adds the
+blocking per-file, size-exception and final root-cutover requirements. It does not reopen
+completed Phase F/G or security work. Root deletion is authorized only in PTC-09B after
+the production-free PTC-09A lifecycle/caller Contract; release, tag and Registry remain
+separate operations.
 
-## 1. Current stop after technical completion
+## 1. Total-convergence extension after FC completion
 
-FC-01 through FC-05 close the original technical Definition of Done. The complete
-role-aware owner gate, canonical API application, bootstrap-owned E-09 lifecycle and
-integrated validation now have executable owners. The optional large-module lane is
-not a blocker unless a future audit finds an actual owner or import violation.
+FC-01 through FC-05 close the original ownership/lifecycle Definition of Done. The
+complete role-aware owner gate, canonical API application, bootstrap-owned E-09
+lifecycle and integrated validation remain authoritative.
 
-The remaining stop is compatibility/release policy, not unfinished architecture:
+PTC-01 found the broader completion gap: the former optional large-module lane did not
+classify all 183 shipped files, did not close all 31 size exceptions, and retained 16
+legacy import modules. The accepted target now requires zero unclassified files, 16
+responsibility-owned canonical additions and removal of every non-entrypoint root/
+`anima_prompt` compatibility module after canonical caller cutover.
 
-- the final canonical-plus-shim tree has not shipped in the next ordinary release N;
-- root `api.py` remains an explicit compatibility binder because the entrypoint and
-  current route consumers still use it;
-- no consumer/harm evidence or reviewed breaking-change approval authorizes public
-  removal; and
-- P-API-02, D-14, release, tag and Registry work remain event-gated.
+## 2. FC completion and current total-convergence completion
 
-## 2. Two completion states
+### FC technical architecture completion (historical)
 
-### Technical architecture completion
-
-This state may be reached before release N:
+This state was reached before release N:
 
 - `easyuse_anima` owns all production implementation;
 - root Python files are the permanent entrypoint or explicit compatibility
@@ -52,17 +52,18 @@ This state may be reached before release N:
   remain compatible;
 - full, package/archive, no-host, lifecycle and representative host/API gates pass.
 
-### Compatibility retirement completion
+### Total Python convergence completion (current)
 
-This state is event-gated:
+This state is blocking technical work, independent of release timing:
 
-- an ordinary release publishes the final canonical-plus-shim forms as release N;
-- support-window, consumer, harm and rollback evidence are collected;
-- eligible private shims may be removed first;
-- public removal requires a reviewed breaking-change Issue and release note;
-- low-cost public shims may be deliberately retained indefinitely.
-
-Technical completion does not require deletion of every public shim.
+- all 183 current Python source files have one executable disposition;
+- all 31 size exceptions have one explicit disposition and task/retain evidence;
+- 16 responsibility-owned canonical files are added by the approved split tasks;
+- the nine non-entrypoint root files and seven `anima_prompt` compatibility files are
+  removed by PTC-09B after canonical caller and E-09 lifecycle proof;
+- the final shipped Python target remains 183 files with root `__init__.py` as the only
+  root production Python file;
+- no replacement compatibility facade recreates a deleted legacy import path.
 
 ## 3. Ordered execution queue
 
@@ -655,11 +656,12 @@ reused without repeating the same broad gates after this documentation-only audi
 | 0.5.2 compatibility | Node, AiO generation/schema, profile, settings and API compatibility owners passed on merged `dev`; the official full covers the remaining workflow fixtures. |
 | Isolated ComfyUI | The canonical test install matched the merged source hashes, loaded once, served the settings route, exposed `EasyUseAnimaWildcard`, and completed a queued Wildcard-to-text workflow with `blue flower`; the owned server was then stopped with no listener or child process left. |
 
-Verdict: **technical architecture completion is recorded.** Rows 1 through 13,
-15 through 18 and 20 are complete; row 14 remains the FC-06 Registry publication
-event and row 19 is a deliberate retain. There is no READY backend refactor task.
+Verdict at the FC-05 checkpoint: **technical architecture completion was recorded.**
+Rows 1 through 13, 15 through 18 and 20 were complete; row 14 remained the FC-06
+Registry publication event and row 19 was a deliberate retain. PTC-01 later extended
+the completion definition, so PTC-02 is now the READY backend refactor task.
 
-## 9. Optional MD lane — large-module disposition
+## 9. Superseded optional MD lane — large-module disposition
 
 After FC-01, audit the current G-05 exception ledger without changing production.
 Classify each exception as:
@@ -679,8 +681,9 @@ Priority review candidates:
 - `easyuse_anima/nodes/prompt_advanced_nodes.py`
 - `easyuse_anima/prompt/advanced.py`
 
-Do not split the E-09 bootstrap lifecycle, the atomic JSON transaction owner or root
-compatibility shims merely to satisfy a line threshold.
+Do not split the E-09 bootstrap lifecycle or the atomic JSON transaction owner merely
+to satisfy a line threshold. Legacy root modules are removed only through the
+PTC-09A/PTC-09B canonical caller cutover.
 
 A split is allowed only when it has:
 
@@ -690,22 +693,25 @@ A split is allowed only when it has:
 - one bounded rollback unit;
 - no new generic `utils`, `misc` or service-locator module.
 
-The MD lane is not an FC-05 blocker unless it finds an owner/import violation or a
-module that prevents FC-03/FC-04 convergence.
+The following historical FC rule is superseded by PTC-01: the MD lane was not an FC-05
+blocker unless it found an owner/import violation or a module that prevented FC-03/FC-04
+convergence.
 
 ## 10. Release N and H/D-14
 
 ### FC-06 — Ordinary release N
 
-Do not publish solely to start a shim clock. The next normal feature/bug release that
-contains the final canonical-plus-shim forms becomes release N. Record exact tag, SHA,
-archive hash, identity parity, internal root-import scan and validate/pack/read-back.
+Do not publish solely for PTC. An ordinary pre-PTC feature/bug release remains valid but
+does not satisfy total convergence. The first post-PTC release must record the exact tag,
+SHA, archive hash, absence of the sixteen legacy paths, canonical entrypoint identity,
+internal root-import scan and validate/pack/read-back.
 
 ### FC-07 — Later compatibility re-audit
 
-Run only after an ADR-002 event changes. Consider private shims first. Public removal
-requires breaking-change approval, impact, release notes and rollback. Deliberate
-long-term retention of low-cost shims is a valid completed outcome.
+This is now a historical compatibility re-audit lane. PTC-01 supersedes its release-window
+prerequisite for the sixteen explicitly inventoried legacy paths. Issue #186 remains an
+evidence ledger until PTC-09B/PTC-10 prove canonical callers, delete the paths and close
+the rollback boundary; unrelated compatibility surfaces still follow ADR-002.
 
 ## 11. Validation efficiency
 
@@ -746,21 +752,27 @@ owner. Stop and request focused technical PRO review only when:
 
 ## 13. Codex resume instruction
 
-No backend refactor task is READY. Do not reopen completed FC-01 through FC-05 work.
+PTC-02 is READY after PTC-01 merges. Read only current policy/universal efficiency,
+[`python-total-convergence-contract.md`](python-total-convergence-contract.md)'s PTC-02
+card, Issue #593's latest checkpoint, the four allowed production files and direct tests.
+Do not rerun FC-01 through FC-05 or the external reference audit.
 
-Start FC-06 only when an independently justified ordinary feature or bug-fix release is
-ready. Backend completion or starting a shim-support clock is not a release trigger.
+Complete and merge one PTC task before starting the next. Root/API compatibility removal
+does not start before PTC-09A fixes the canonical entrypoint and E-09 lifecycle sequence.
+An ordinary bug-fix release may proceed in its own lane when independently required, but
+it does not complete or replace the PTC queue and must not recreate removed shims.
 
-At that event, read only:
+## 14. Mandatory Total Python Convergence queue
 
-- `current-policies.md`;
-- `codex-execution-efficiency.md` universal rules;
-- this document's FC-06 and validation sections;
-- Issue #186's latest compatibility checkpoint;
-- `MAINTAINING.md` release procedure; and
-- current `main`/`dev`, version, changelog, package and Registry metadata.
+The executable disposition, target tree, task cards, root cutover gate and corrected
+Definition of Done are owned by
+[`python-total-convergence-contract.md`](python-total-convergence-contract.md).
 
-Use a separate release task card to integrate the validated candidate into `main`, bump
-the version, validate the exact archive, create the immutable tag, publish and read back
-the Registry state. FC-06 does not authorize P-API-02, root removal, lifecycle changes or
-FC-07/H/D-14. When no ordinary release event exists, make no FC code or release change.
+```text
+COMPLETE  PTC-01 inventory/target Contract
+READY     PTC-02 AiO generation normalization Move
+NEXT      PTC-03 -> PTC-04 -> PTC-05 -> PTC-06 -> PTC-07A -> PTC-07B
+          -> PTC-08 -> PTC-09A -> PTC-09B -> PTC-10
+```
+
+FC-06 release and Registry publication remain separate from this technical queue.

--- a/docs/architecture/python-total-convergence-contract.md
+++ b/docs/architecture/python-total-convergence-contract.md
@@ -1,0 +1,289 @@
+# Python Total Convergence Contract
+
+## Status and authority
+
+- Status: PTC-01 Contract complete; PTC-02 is the next implementation task.
+- Base: `39997c5423847d4280737f0d78d353d3c6273e07`.
+- Technical owner: Issue #593; parent architecture owner: Issue #185.
+- Lifecycle authority: E-09 / Issue #187.
+- Compatibility inventory: Issue #186 and
+  [`python-compatibility-shims.md`](python-compatibility-shims.md).
+- Machine-readable owner:
+  `tests/fixtures/python_file_disposition_contract.v1.json`.
+
+This Contract extends, rather than discards, FC-01 through FC-05. Those tasks completed
+canonical ownership, role-aware imports, typed boundaries, API application composition
+and E-09 lifecycle ownership. They did not classify every shipped Python file or make
+large-module disposition a completion blocker.
+
+The completion meaning is now stricter: every shipped production `.py` has one reviewed
+role, final owner and disposition, every reviewed size exception has a final verdict,
+and the repository root contains only the ComfyUI entrypoint. Legacy root and
+`anima_prompt` import paths are intentionally retired after their callers and tests use
+canonical modules. This import-path break is accepted; node IDs, workflows, settings,
+profiles and HTTP behavior are not.
+
+## Review verdict
+
+`ROADMAP_EXTENSION_REQUIRED` is accepted with one user-directed correction.
+
+- Retain the current 16-group import gate, canonical API application, root entrypoint,
+  E-09 lifecycle and completed FC evidence.
+- Make the former optional large-module lane blocking.
+- Classify all 183 baseline production files explicitly.
+- Add 16 responsibility-owned canonical modules through cohesive Move tasks.
+- Delete the 9 non-entrypoint root modules and 7 `anima_prompt` compatibility modules
+  after a canonical entrypoint/caller cutover.
+- Do not keep a new compatibility facade merely to preserve the removed import paths.
+
+The target count remains 183: 183 baseline files, plus 16 canonical targets, minus 16
+legacy compatibility files.
+
+## Structural references
+
+No external repository is a template. The pinned references establish useful and
+rejected patterns only.
+
+| Reference | Commit | Accepted | Rejected |
+| --- | --- | --- | --- |
+| [ComfyUI-Easy-Use](https://github.com/yolain/ComfyUI-Easy-Use/tree/595e0738a9e3f8d0d9c4d875461b2d2c9e7559c7) | `595e0738` | broad feature, node and route topology | root import-time configuration/file work and dynamic scanning |
+| [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack/tree/429d0159ad429e64d2b3916e6e7be9c22d025c3c) | `429d0159` | explicit companion custom-node boundary | root star imports, import-time workers and global server/model coupling |
+| [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes/tree/eb356e6cd5dedac54bb84bc54b8da8f185fa8472) | `eb356e6c` | domain-grouped small related nodes | allowing a domain file to grow without an executable disposition |
+| [rgthree-comfy](https://github.com/rgthree/rgthree-comfy/tree/6b76ee6f2c5a007710b5a16f97c94330d6ecc871) | `6b76ee6f` | independent files for complex public nodes and route families | import-time cleanup/scanning and weaker lifecycle ownership |
+
+EasyUse Anima deliberately keeps stronger executable architecture gates, deterministic
+registration, compatibility inventory during the migration, package/no-host proof and
+the E-09 single lifecycle owner.
+
+## Baseline and final disposition
+
+| Disposition | Baseline files | Final files | Meaning |
+| --- | ---: | ---: | --- |
+| `permanent_entrypoint` | 1 | 1 | root `__init__.py` only |
+| `cohesive_retain` | 157 | 157 | current canonical path and owner remain |
+| `split` | 9 | 25 | current facade/class owner remains and 16 exact targets are added |
+| `delete` | 16 | 0 | canonical callers replace legacy import paths, then files are removed |
+| **Total** | **183** | **183** | zero unclassified shipped Python files |
+
+The fixture lists all 183 baseline paths explicitly. It has no wildcard/default entry.
+Each split records its exact targets, role, G-06 owner group, direct tests, task and
+rollback unit. Each deletion records the canonical replacement owner, current
+compatibility-registry key, caller-migration tests, task and rollback unit.
+
+### Mandatory split boundaries
+
+| Task | Current owner | Added canonical targets |
+| --- | --- | --- |
+| PTC-02 | `aio/generation_normalization.py` | `generation_normalization_core.py`, `generation_normalization_model.py`, `generation_normalization_stages.py` |
+| PTC-03 | `aio/legacy_generation.py` | `legacy_detailer.py`, `legacy_upscale.py` |
+| PTC-04 | `prompt/advanced.py`, `prompt/regional.py` | `advanced_fields.py`, `advanced_builder.py`, `regional_builder.py` |
+| PTC-05 | `prompt/artist_mix.py` | `artist_mix_config.py`, `artist_mix_planning.py`, `artist_mix_conditioning.py` |
+| PTC-06 | `nodes/naia_nodes.py` | `naia/random_prompt.py` |
+| PTC-07A | Advanced and Regional node adapters | `prompt_advanced_execution.py`, `regional_conditioning_adapter.py` |
+| PTC-07B | PromptData and Artist Mix node adapters | `prompt_data_conditioning_adapter.py`, `artist_mix_conditioning_adapter.py` |
+
+Public node class definitions remain in their current canonical node modules. Helper
+movement must not change class identity, `__module__`, registration mappings, socket
+order or workflow class IDs.
+
+### Mandatory legacy retirement
+
+| Legacy path | Canonical replacement owner |
+| --- | --- |
+| `api.py` | `easyuse_anima/api/application.py` plus bootstrap-owned composition |
+| `api_contract.py` | canonical `easyuse_anima/api` request/response/error modules |
+| `autocomplete_dataset.py` | `easyuse_anima/autocomplete/dataset.py` |
+| `autocomplete_index.py` | `easyuse_anima/autocomplete/index.py` |
+| `nodes.py` | `easyuse_anima/registration.py` and symbol-owning canonical modules |
+| `prompt_translation.py` | `easyuse_anima/translation/service.py` |
+| `settings.py` | `easyuse_anima/settings/service.py` and repository/schema owners |
+| `storage.py` | `easyuse_anima/infrastructure/filesystem/atomic_json.py` |
+| `wildcard_engine.py` | `easyuse_anima/wildcard/service.py` and symbol-owning modules |
+| `anima_prompt/` seven modules | matching `easyuse_anima/prompt/anima/` modules |
+
+PTC-09B removes these paths only after production and test callers use canonical
+owners. A deleted aggregator does not create a replacement aggregator: private helper
+tests import the exact symbol owner, while ComfyUI loads the root `__init__.py` and
+canonical registration/application owners.
+
+## Size-exception closure
+
+The 11 module and 20 function exceptions in
+`python_size_complexity_contract.v1.json` are linked exactly once by ID. The final
+verdicts are:
+
+- split: AiO normalization and legacy orchestration, NAIA/Advanced/PromptData/Regional
+  node adapters, Advanced/Artist Mix services, and Regional output construction;
+- move then cohesive retain: DiT correction normalization, legacy USDU execution and
+  Artist Mix config projection;
+- cohesive retain: `bootstrap.initialize`, atomic JSON transaction, save-output stage,
+  Spectrum sampling, Torch Compile recommendation, SAM3 detailer and declarative node
+  schemas;
+- delete after canonical cutover: root `nodes.py`.
+
+The checker rejects an unlinked exception, a final owner outside the target plan, a
+large retain without an executable direct contract, and any growth still rejected by
+the existing size ratchet.
+
+## Machine-readable rules
+
+`tools/check_python_file_dispositions.py` reuses four authoritative sources:
+
+1. `python_backend_baseline.json` for the shipped production inventory;
+2. `python_test_ownership_contract.v1.json` for canonical role/test/package owners;
+3. `python_size_complexity_contract.v1.json` for reviewed overages; and
+4. `python-compatibility-shims.md` for current legacy surfaces.
+
+It fails closed on:
+
+- missing, duplicate or unclassified production paths;
+- a planned target present without the task status update;
+- a completed target missing from the analyzer inventory;
+- owner-group ambiguity or an ownerless new target;
+- target collisions;
+- missing task, direct test or rollback for structural work;
+- missing compatibility-registry linkage for a legacy deletion;
+- any of the 31 size exceptions not classified exactly once; and
+- new generic `util`, `utils`, `helper`, `helpers` or `misc` buckets.
+
+Tests, tools, fixtures, runners and manual/live matrices remain support artifacts. PTC-08
+adds their separate support-ownership Contract; they are not rearranged to mirror the
+production package.
+
+## Preserved contracts
+
+Every implementation task preserves:
+
+- public node IDs, display mappings, class definitions, input/output schemas and saved
+  workflows;
+- API routes, payloads, status/error mapping and request correlation;
+- settings/profile/workflow schema, migrations, revisions and atomic persistence;
+- deterministic registration and package/no-host imports;
+- optional provider and external custom-node failure containment;
+- repeated initialize runtime identity and route refresh;
+- bootstrap as the only lifecycle owner, one lock, one atexit registration and terminal
+  idempotent shutdown;
+- the exact translation executor identity, executor shutdown as cleanup item 1, fixed
+  seven-step cleanup, expected-identity rollback and original startup error; and
+- no route deregistration/marker clear, file-I/O limiter cleanup, provider close, reset
+  API or hot reinitialize.
+
+Root/canonical object identity is preserved only until PTC-09B. After that task,
+canonical identities and ComfyUI entrypoint behavior are preserved; removed root import
+paths intentionally fail instead of silently recreating a compatibility layer.
+
+## Ordered execution
+
+```text
+COMPLETE  FC-01 through FC-05
+COMPLETE  PTC-01  total inventory, target and deletion Contract
+READY     PTC-02  AiO generation normalization Move
+NEXT      PTC-03  AiO legacy orchestration Move
+          PTC-04  Advanced/Regional Prompt service Move
+          PTC-05  Artist Mix service Move
+          PTC-06  NAIA node/service vertical Move
+          PTC-07A Advanced/Regional node-adapter Move
+          PTC-07B PromptData/ArtistMix node-adapter Move
+          PTC-08  size and support-ownership closure Contract
+          PTC-09A root canonical-entrypoint/caller cutover Contract
+          PTC-09B canonical cutover and 16-file legacy deletion
+          PTC-10  total Python convergence audit
+EVENT     ordinary release; no automatic compatibility shim recreation
+```
+
+One task is merged before the next starts. PTC-02 through PTC-07B are behavior-preserving
+Move PRs. PTC-08 and PTC-09A are production-free Contracts. PTC-09B is one cohesive
+entrypoint/import-surface change with a single rollback boundary. PTC-10 changes only
+contracts, ledgers and current documentation unless it finds a production correction.
+
+## First implementation card
+
+```text
+Task ID: PTC-02
+Owner: Issue #593, parent #185
+Class: MOVE
+Base: merged PTC-01 SHA
+Goal: split version/core, model-patch and stage/output normalization from the stable
+      generation_normalization.py facade without changing normalized values or order.
+Allowed production:
+  easyuse_anima/aio/generation_normalization.py
+  easyuse_anima/aio/generation_normalization_core.py
+  easyuse_anima/aio/generation_normalization_model.py
+  easyuse_anima/aio/generation_normalization_stages.py
+Allowed tests/contracts:
+  tests/test_aio_generation_settings.py
+  tests/test_aio_generation_migrations.py
+  tests/fixtures/python_file_disposition_contract.v1.json
+  tests/fixtures/python_backend_baseline.json
+  tests/fixtures/python_size_complexity_contract.v1.json
+  direct import/test-owner/analyzer fixtures only when changed output requires it
+Forbidden:
+  defaults, version dispatch, future-key, error, schema or serialized-output changes
+  node/API/root/lifecycle changes
+  generic helper modules
+Preserve:
+  exact normalization result, key insertion/removal order, version/default projection,
+  direct imports and facade identity
+Focused:
+  changed-file syntax/static
+  AioGenerationSettingsTests
+  AioGenerationMigrationsTests
+  file-disposition, size, import-owner and analyzer gates
+  git diff --check
+Promotion:
+  official full once on final SHA
+  comfy validate, actual pack and archive/import closure because shipped paths change
+Live:
+  not triggered without host-visible behavior
+Rollback:
+  revert the one cohesive PTC-02 Move PR
+Stop:
+  exact normalization parity requires a default, migration, error or schema change
+Next:
+  PTC-03 only
+```
+
+## Root cutover gate
+
+PTC-09A must resolve the exact E-09-safe sequence before deletion:
+
+```text
+ComfyUI imports root __init__.py
+  -> canonical API application is composed once by the existing bootstrap owner
+  -> initialize receives or resolves the canonical registrar
+  -> runtime cleanup plan observes the same translation executor
+  -> repeated initialize refreshes routes without duplicate lifecycle state
+```
+
+The Contract compares only designs that keep bootstrap as the single production
+composition/lifecycle owner. It may adjust the private bootstrap/application interface
+and the root entrypoint call, but may not introduce a second lock, atexit, cleanup
+registry, reset API, hot reinitialize, route deregistration or canonical-to-root import.
+Use focused high-reasoning review only if direct evidence leaves multiple designs that
+satisfy every E-09 gate.
+
+PTC-09B then migrates root-importing tests to exact canonical owners, updates package
+and compatibility fixtures, changes root `__init__.py` to the selected canonical call,
+and deletes the 16 legacy files. Because entrypoint, registration and archive closure
+change, it requires official full, validate/pack/archive, extracted no-host import and
+one representative isolated ComfyUI API/node execution smoke.
+
+## Final Definition of Done
+
+- [ ] Every shipped production `.py` is classified exactly once; unclassified count is
+      zero.
+- [ ] The final target tree has 183 files: one root entrypoint and 182 canonical package
+      files.
+- [ ] No root production `.py` remains except `__init__.py`; `anima_prompt/` is absent.
+- [ ] Every retained file has an exact role and G-06 owner.
+- [ ] Every split/delete has an implemented task, direct test and rollback unit.
+- [ ] All 11 module and 20 function exceptions have a final owner and no unexplained
+      overage remains.
+- [ ] No generic bucket or service locator is introduced.
+- [ ] All canonical production paths pass the role-aware import gate with no cycle.
+- [ ] Public node/workflow/API/data behavior and all E-09 invariants pass.
+- [ ] Support ownership has zero orphan test/tool/fixture/runner entries.
+- [ ] Official full passes once on the final candidate.
+- [ ] Validate, actual pack/archive/CRC/import closure and no-host import pass.
+- [ ] The root-entrypoint change passes representative isolated ComfyUI execution.
+- [ ] Release/tag/Registry evidence remains a separate release operation.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -14,8 +14,9 @@ lane when neither exists.
    - run package/live/benchmark only when triggered.
 3. Current final-convergence status and event queue:
    [`../architecture/backend-final-convergence-roadmap.md`](../architecture/backend-final-convergence-roadmap.md)
-4. Compatibility/release ledger: Issue #186. Technical owner #593 and parent #185 are
-   completed.
+4. Total Python Convergence Contract:
+   [`../architecture/python-total-convergence-contract.md`](../architecture/python-total-convergence-contract.md).
+   Active owner #593 and parent #185; compatibility inventory remains Issue #186.
 5. Target architecture and original Definition of Done:
    [`../architecture/python-backend.md`](../architecture/python-backend.md)
 6. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
@@ -40,34 +41,26 @@ COMPLETE  FC-04A canonical API application/E-09 lifecycle Contract
 COMPLETE  FC-04B canonical API application cohesive Move
 COMPLETE  FC-05 technical architecture completion
 
-READY     none for backend refactoring
+COMPLETE  PTC-01 total production inventory/target Contract
+READY     PTC-02 AiO generation normalization Move
 
 EVENT     next ordinary release N
-LATER     H/D-14 compatibility re-audit
+LATER     PTC-09A/B canonical root cutover and legacy removal
 ```
 
-## Technical completion and remaining event
+## FC completion and active total convergence
 
-FC-05 closes the original backend Definition of Done at
-`dev@bb1452c9996293f1f77bb361e7317ddb2664ae19`. The complete owner gate, canonical API
-application, E-09 lifecycle, typed/migration compatibility and integrated validation
-have executable owners. There is no READY backend implementation task.
+FC-05 closes the original ownership/lifecycle Definition of Done. PTC-01 adds the
+broader blocking goal: every shipped Python file and size exception has a final owner,
+16 responsibility-owned canonical modules are extracted, and all 16 non-entrypoint
+legacy root/`anima_prompt` modules are removed after a canonical caller cutover.
 
-Actual shim deletion remains release/consumer gated and is not required for technical
-architecture completion.
+## Current execution boundary
 
-## Current event-wait boundary
-
-No backend refactor task is READY. Do not reopen FC-01 through FC-05 or create a release
-only to start a compatibility clock.
-
-When an independently justified ordinary feature or bug-fix release is ready, FC-06
-reads only the roadmap's FC-06/validation sections, Issue #186's latest checkpoint,
-`MAINTAINING.md`, and the current `main`/`dev`, version, changelog, package and Registry
-metadata. Use a separate release task card and preserve the fixed guards below.
-
-Without that release event, new bugs and features use their own owning Issue and do not
-reactivate the backend convergence queue.
+PTC-02 is READY after PTC-01 merges. Do not repeat FC-01 through FC-05. Follow the exact
+PTC-02 allowed files, focused tests and stop condition in the Total Python Convergence
+Contract. Root deletion is not an early cleanup task; PTC-09A first fixes the canonical
+entrypoint and E-09-safe application/registrar sequence.
 
 ## Fixed lifecycle and compatibility guards
 
@@ -81,7 +74,8 @@ Later FC tasks must preserve:
 - expected-identity rollback and original startup error;
 - route marker retention and no route deregistration;
 - no file-I/O limiter or provider/client cleanup invention;
-- root/canonical identity and 0.5.2 workflow/profile/settings/API compatibility.
+- canonical identity and 0.5.2 workflow/profile/settings/API behavior. Root import-path
+  identity is preserved only until the reviewed PTC-09B cutover.
 
 FC-03 may migrate patch ownership but does not change behavior. FC-04 application
 construction remains outside `initialize()` unless a separate reviewed Behavior Contract
@@ -145,5 +139,6 @@ Read only when a current task touches the boundary:
 - Registry scanner safety: [`docs/development/registry-scanner-safety.md`](registry-scanner-safety.md)
 - workflows: `../Anima AiO/Workflow_Management.md`
 
-No roadmap document alone authorizes root deletion, public breaking changes, release,
-tag or Registry publication.
+The Total Python Convergence Contract authorizes only the staged PTC-09B root import-path
+break after PTC-09A. No roadmap document alone authorizes release, tag or Registry
+publication.

--- a/tests/fixtures/python_file_disposition_contract.v1.json
+++ b/tests/fixtures/python_file_disposition_contract.v1.json
@@ -1,0 +1,3929 @@
+{
+  "schema_version": 1,
+  "baseline_commit": "39997c5423847d4280737f0d78d353d3c6273e07",
+  "inventory_owner": {
+    "path": "tests/fixtures/python_backend_baseline.json",
+    "expected_baseline_files": 183,
+    "expected_target_files": 183
+  },
+  "linked_contracts": {
+    "compatibility_registry": "docs/architecture/python-compatibility-shims.md",
+    "import_owner_map": "tests/fixtures/python_test_ownership_contract.v1.json",
+    "size_ledger": "tests/fixtures/python_size_complexity_contract.v1.json"
+  },
+  "allowed_dispositions": [
+    "cohesive_retain",
+    "delete",
+    "merge",
+    "move",
+    "permanent_entrypoint",
+    "split"
+  ],
+  "allowed_statuses": [
+    "complete",
+    "planned"
+  ],
+  "entries": [
+    {
+      "path": "__init__.py",
+      "role": "comfyui-entrypoint",
+      "owner_group": "entrypoint",
+      "disposition": "permanent_entrypoint",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "__init__.py",
+          "role": "comfyui-entrypoint",
+          "owner_group": "entrypoint"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": "__init__.py",
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/__init__.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/__init__.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/correction.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/correction.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/knowledge.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/knowledge.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/models.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/models.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/normalize.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/normalize.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/ordering.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/ordering.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "anima_prompt/parser.py",
+      "role": "legacy-anima-prompt-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_anima_prompt_compatibility.py"
+      ],
+      "compatibility_registry_key": "anima_prompt/",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/prompt/anima/parser.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "api.py",
+      "role": "legacy-api-application-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_api_contract.py",
+        "tests/test_python_api_application_lifecycle_contract.py",
+        "tests/test_python_api_facade_lifecycle_contract.py",
+        "tests/test_python_bootstrap.py"
+      ],
+      "compatibility_registry_key": "api.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/api/application.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "api_contract.py",
+      "role": "legacy-api-contract-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_api_contract_compatibility.py"
+      ],
+      "compatibility_registry_key": "api_contract.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/api/responses.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "autocomplete_dataset.py",
+      "role": "legacy-autocomplete-dataset-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_autocomplete_dataset_compatibility.py"
+      ],
+      "compatibility_registry_key": "autocomplete_dataset.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/autocomplete/dataset.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "autocomplete_index.py",
+      "role": "legacy-autocomplete-index-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_autocomplete_index.py"
+      ],
+      "compatibility_registry_key": "autocomplete_index.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/autocomplete/index.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/__init__.py",
+      "role": "package-facade",
+      "owner_group": "package",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/__init__.py",
+          "role": "package-facade",
+          "owner_group": "package"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/__init__.py",
+      "role": "package-facade",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/__init__.py",
+          "role": "package-facade",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/conditioning.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/conditioning.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/first_pass_cache.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/first_pass_cache.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_defaults.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_defaults.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_detailer.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_detailer.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_detailer_stage.py",
+      "role": "aio-pipeline-stage",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_detailer_stage.py",
+          "role": "aio-pipeline-stage",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_features.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_features.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_first_pass.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_first_pass.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_highres.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_highres.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_lifecycle.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_lifecycle.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_migrations.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_migrations.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_normalization.py",
+      "role": "aio-settings-normalization-facade",
+      "owner_group": "aio",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_normalization.py",
+          "role": "aio-settings-normalization-facade",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/generation_normalization_core.py",
+          "role": "aio-core-settings-normalizer",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/generation_normalization_model.py",
+          "role": "aio-model-settings-normalizer",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/generation_normalization_stages.py",
+          "role": "aio-stage-settings-normalizer",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_aio_generation_migrations.py",
+        "tests/test_aio_generation_settings.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-02",
+      "rollback_unit": "Revert the cohesive PTC-02 normalization Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/aio/generation_normalization.py::_normalize_aio_dit_corrections_settings",
+          "verdict": "move_retain_cohesive",
+          "final_owner": "easyuse_anima/aio/generation_normalization_model.py"
+        },
+        {
+          "id": "function:easyuse_anima/aio/generation_normalization.py::_normalize_aio_generation_settings",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/aio/generation_normalization.py"
+        },
+        {
+          "id": "module:easyuse_anima/aio/generation_normalization.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/aio/generation_normalization.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/aio/generation_output.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_output.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_pipeline.py",
+      "role": "aio-pipeline-stage",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_pipeline.py",
+          "role": "aio-pipeline-stage",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_postprocess_stage.py",
+      "role": "aio-pipeline-stage",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_postprocess_stage.py",
+          "role": "aio-pipeline-stage",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_sampling.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_sampling.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_save_output_stage.py",
+      "role": "aio-pipeline-stage",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_save_output_stage.py",
+          "role": "aio-pipeline-stage",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_aio_stage_pipeline_contract.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/aio/generation_save_output_stage.py::AIOSaveOutputStage.run",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/aio/generation_save_output_stage.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/aio/generation_settings.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_settings.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_upscale_stage.py",
+      "role": "aio-pipeline-stage",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_upscale_stage.py",
+          "role": "aio-pipeline-stage",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/generation_values.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/generation_values.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/input_context.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/input_context.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/input_defaults.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/input_defaults.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/legacy_generation.py",
+      "role": "aio-legacy-orchestration-facade",
+      "owner_group": "aio",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/legacy_detailer.py",
+          "role": "aio-legacy-detailer-adapter",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/legacy_generation.py",
+          "role": "aio-legacy-orchestration-facade",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/legacy_upscale.py",
+          "role": "aio-legacy-upscale-adapter",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_aio_stage_pipeline_contract.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-03",
+      "rollback_unit": "Revert the cohesive PTC-03 legacy orchestration Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/aio/legacy_generation.py::_run_aio_generation_pipeline",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/aio/legacy_generation.py"
+        },
+        {
+          "id": "function:easyuse_anima/aio/legacy_generation.py::_run_aio_usdu_upscale_stage",
+          "verdict": "move_retain_cohesive",
+          "final_owner": "easyuse_anima/aio/legacy_upscale.py"
+        },
+        {
+          "id": "module:easyuse_anima/aio/legacy_generation.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/aio/legacy_generation.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/aio/model_preparation.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/model_preparation.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/negpip.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/negpip.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/output.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/output.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/output_settings.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/output_settings.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/ports.py",
+      "role": "domain-contract",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/ports.py",
+          "role": "domain-contract",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/postprocess.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/postprocess.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/preview.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/preview.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/resources.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/resources.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/sampling.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/sampling.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_aio_stage_pipeline_contract.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/aio/sampling.py::_sample_latent_with_spectrum_mod_guidance_advanced",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/aio/sampling.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/aio/torch_compile_diagnostics.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/torch_compile_diagnostics.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/aio/torch_compile_recommendation.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/torch_compile_recommendation.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_aio_torch_compile_recommendation.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/aio/torch_compile_recommendation.py::recommend_torch_compile",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/aio/torch_compile_recommendation.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/aio/usdu.py",
+      "role": "aio-feature-module",
+      "owner_group": "aio",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/aio/usdu.py",
+          "role": "aio-feature-module",
+          "owner_group": "aio"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/__init__.py",
+      "role": "package-facade",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/__init__.py",
+          "role": "package-facade",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/application.py",
+      "role": "api-application-composition",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/application.py",
+          "role": "api-application-composition",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/application_compatibility.py",
+      "role": "api-application-composition",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/application_compatibility.py",
+          "role": "api-application-composition",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/application_routes.py",
+      "role": "api-application-composition",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/application_routes.py",
+          "role": "api-application-composition",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/dependencies.py",
+      "role": "api-boundary-contract",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/dependencies.py",
+          "role": "api-boundary-contract",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/errors.py",
+      "role": "api-boundary-contract",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/errors.py",
+          "role": "api-boundary-contract",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/file_io.py",
+      "role": "api-file-io-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/file_io.py",
+          "role": "api-file-io-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/requests.py",
+      "role": "api-boundary-contract",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/requests.py",
+          "role": "api-boundary-contract",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/responses.py",
+      "role": "api-boundary-contract",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/responses.py",
+          "role": "api-boundary-contract",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/router.py",
+      "role": "api-route-registrar",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/router.py",
+          "role": "api-route-registrar",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/__init__.py",
+      "role": "package-facade",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/__init__.py",
+          "role": "package-facade",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/aio_profile_mutations.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/aio_profile_mutations.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/aio_torch_compile.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/aio_torch_compile.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/autocomplete.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/autocomplete.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/long_text_settings.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/long_text_settings.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/lora_catalog.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/lora_catalog.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/lora_preview.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/lora_preview.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/lora_profile_fix.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/lora_profile_fix.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/profile_lists.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/profile_lists.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/profile_loads.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/profile_loads.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/profile_saves.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/profile_saves.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/settings.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/settings.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/translation.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/translation.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/translation_execution.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/translation_execution.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/api/routes/wildcards.py",
+      "role": "api-route-adapter",
+      "owner_group": "api",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/api/routes/wildcards.py",
+          "role": "api-route-adapter",
+          "owner_group": "api"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/__init__.py",
+      "role": "package-facade",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/__init__.py",
+          "role": "package-facade",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/classification.py",
+      "role": "autocomplete-feature-module",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/classification.py",
+          "role": "autocomplete-feature-module",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/contracts.py",
+      "role": "domain-contract",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/contracts.py",
+          "role": "domain-contract",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/dataset.py",
+      "role": "autocomplete-feature-module",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/dataset.py",
+          "role": "autocomplete-feature-module",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/index.py",
+      "role": "autocomplete-feature-module",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/index.py",
+          "role": "autocomplete-feature-module",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/ports.py",
+      "role": "domain-contract",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/ports.py",
+          "role": "domain-contract",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/search.py",
+      "role": "autocomplete-feature-module",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/search.py",
+          "role": "autocomplete-feature-module",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/autocomplete/service.py",
+      "role": "feature-service",
+      "owner_group": "autocomplete",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/autocomplete/service.py",
+          "role": "feature-service",
+          "owner_group": "autocomplete"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/bootstrap.py",
+      "role": "lifecycle-composition-root",
+      "owner_group": "runtime-bootstrap",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/bootstrap.py",
+          "role": "lifecycle-composition-root",
+          "owner_group": "runtime-bootstrap"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_python_bootstrap.py",
+        "tests/test_python_runtime_lifecycle_contract.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/bootstrap.py::initialize",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/bootstrap.py"
+        },
+        {
+          "id": "module:easyuse_anima/bootstrap.py",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/bootstrap.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/common/__init__.py",
+      "role": "package-facade",
+      "owner_group": "common",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/common/__init__.py",
+          "role": "package-facade",
+          "owner_group": "common"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/common/serialization.py",
+      "role": "common-feature-module",
+      "owner_group": "common",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/common/serialization.py",
+          "role": "common-feature-module",
+          "owner_group": "common"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/common/values.py",
+      "role": "common-feature-module",
+      "owner_group": "common",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/common/values.py",
+          "role": "common-feature-module",
+          "owner_group": "common"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/errors.py",
+      "role": "common-feature-module",
+      "owner_group": "common",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/errors.py",
+          "role": "common-feature-module",
+          "owner_group": "common"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/__init__.py",
+      "role": "package-facade",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/__init__.py",
+          "role": "package-facade",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/detailer.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/detailer.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/geometry.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/geometry.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/sam3.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/sam3.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/sam3_detailer.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/sam3_detailer.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_sam3_nodes.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/image/sam3_detailer.py::_run_sam3_detailer",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/image/sam3_detailer.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/image/scaling.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/scaling.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/image/upscale.py",
+      "role": "image-feature-module",
+      "owner_group": "image",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/image/upscale.py",
+          "role": "image-feature-module",
+          "owner_group": "image"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/__init__.py",
+      "role": "package-facade",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/__init__.py",
+          "role": "package-facade",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/__init__.py",
+      "role": "package-facade",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/__init__.py",
+          "role": "package-facade",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/capabilities.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/capabilities.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/invocation.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/invocation.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/provider.py",
+      "role": "provider-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/provider.py",
+          "role": "provider-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/resources.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/resources.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/comfy/wiring.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/comfy/wiring.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/filesystem/__init__.py",
+      "role": "package-facade",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/filesystem/__init__.py",
+          "role": "package-facade",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_python_repository_filesystem_contract.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/infrastructure/filesystem/atomic_json.py::AtomicJsonStore.replace_from",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/infrastructure/filesystem/atomic_json.py"
+        },
+        {
+          "id": "module:easyuse_anima/infrastructure/filesystem/atomic_json.py",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/infrastructure/filesystem/atomic_json.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/infrastructure/filesystem/paths.py",
+      "role": "infrastructure-adapter",
+      "owner_group": "infrastructure",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/infrastructure/filesystem/paths.py",
+          "role": "infrastructure-adapter",
+          "owner_group": "infrastructure"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/lora/__init__.py",
+      "role": "package-facade",
+      "owner_group": "lora",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/lora/__init__.py",
+          "role": "package-facade",
+          "owner_group": "lora"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/lora/metadata.py",
+      "role": "lora-feature-module",
+      "owner_group": "lora",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/lora/metadata.py",
+          "role": "lora-feature-module",
+          "owner_group": "lora"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/lora/preset.py",
+      "role": "lora-feature-module",
+      "owner_group": "lora",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/lora/preset.py",
+          "role": "lora-feature-module",
+          "owner_group": "lora"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/naia/__init__.py",
+      "role": "package-facade",
+      "owner_group": "naia",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/naia/__init__.py",
+          "role": "package-facade",
+          "owner_group": "naia"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/naia/client.py",
+      "role": "naia-feature-module",
+      "owner_group": "naia",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/naia/client.py",
+          "role": "naia-feature-module",
+          "owner_group": "naia"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/naia/resolution.py",
+      "role": "naia-feature-module",
+      "owner_group": "naia",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/naia/resolution.py",
+          "role": "naia-feature-module",
+          "owner_group": "naia"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/__init__.py",
+      "role": "package-facade",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/__init__.py",
+          "role": "package-facade",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/aio_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/aio_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/image_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/image_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/impact_detailer_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/impact_detailer_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_node_contracts.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/nodes/impact_detailer_nodes.py::_EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/nodes/impact_detailer_nodes.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/nodes/input_types.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/input_types.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/lora_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/lora_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/naia_nodes.py",
+      "role": "naia-node-schema-adapter",
+      "owner_group": "nodes",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/naia/random_prompt.py",
+          "role": "naia-random-prompt-service",
+          "owner_group": "naia"
+        },
+        {
+          "path": "easyuse_anima/nodes/naia_nodes.py",
+          "role": "naia-node-schema-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_naia_settings.py",
+        "tests/test_node_contracts.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-06",
+      "rollback_unit": "Revert the cohesive PTC-06 NAIA vertical Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/nodes/naia_nodes.py::EasyUseAnimaNAIARandomPrompt.INPUT_TYPES",
+          "verdict": "cohesive_retain",
+          "final_owner": "easyuse_anima/nodes/naia_nodes.py"
+        },
+        {
+          "id": "function:easyuse_anima/nodes/naia_nodes.py::EasyUseAnimaNAIARandomPrompt.request",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/naia/random_prompt.py"
+        },
+        {
+          "id": "module:easyuse_anima/nodes/naia_nodes.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/naia_nodes.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+      "role": "prompt-advanced-node-schema-adapter",
+      "owner_group": "nodes",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/prompt_advanced_execution.py",
+          "role": "prompt-advanced-execution-adapter",
+          "owner_group": "nodes"
+        },
+        {
+          "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+          "role": "prompt-advanced-node-schema-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_studio_seed_cutover.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-07A",
+      "rollback_unit": "Revert the cohesive PTC-07A advanced node-adapter Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/nodes/prompt_advanced_nodes.py::EasyUseAnimaPromptStudioAdvanced.build",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/prompt_advanced_execution.py"
+        },
+        {
+          "id": "function:easyuse_anima/nodes/prompt_advanced_nodes.py::EasyUseAnimaPromptStudioAdvancedV2._build_with_seed",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/prompt_advanced_execution.py"
+        },
+        {
+          "id": "module:easyuse_anima/nodes/prompt_advanced_nodes.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/prompt_advanced_nodes.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_data_nodes.py",
+      "role": "prompt-data-node-schema-adapter",
+      "owner_group": "nodes",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/artist_mix_conditioning_adapter.py",
+          "role": "artist-mix-node-conditioning-adapter",
+          "owner_group": "nodes"
+        },
+        {
+          "path": "easyuse_anima/nodes/prompt_data_conditioning_adapter.py",
+          "role": "prompt-data-node-conditioning-adapter",
+          "owner_group": "nodes"
+        },
+        {
+          "path": "easyuse_anima/nodes/prompt_data_nodes.py",
+          "role": "prompt-data-node-schema-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-07B",
+      "rollback_unit": "Revert the cohesive PTC-07B prompt-data adapter Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "module:easyuse_anima/nodes/prompt_data_nodes.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/prompt_data_nodes.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/nodes/prompt_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/prompt_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/regional_nodes.py",
+      "role": "regional-node-schema-adapter",
+      "owner_group": "nodes",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/regional_conditioning_adapter.py",
+          "role": "regional-node-conditioning-adapter",
+          "owner_group": "nodes"
+        },
+        {
+          "path": "easyuse_anima/nodes/regional_nodes.py",
+          "role": "regional-node-schema-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_studio_regional.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-07A",
+      "rollback_unit": "Revert the cohesive PTC-07A regional node-adapter Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "module:easyuse_anima/nodes/regional_nodes.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/nodes/regional_nodes.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/nodes/sam3_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/sam3_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/seed_adapters.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/seed_adapters.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/nodes/wildcard_nodes.py",
+      "role": "comfyui-node-adapter",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/nodes/wildcard_nodes.py",
+          "role": "comfyui-node-adapter",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/__init__.py",
+      "role": "package-facade",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/__init__.py",
+          "role": "package-facade",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/aio.py",
+      "role": "profiles-feature-module",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/aio.py",
+          "role": "profiles-feature-module",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/contract.py",
+      "role": "profiles-feature-module",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/contract.py",
+          "role": "profiles-feature-module",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/lora.py",
+      "role": "profiles-feature-module",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/lora.py",
+          "role": "profiles-feature-module",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/mutation.py",
+      "role": "profiles-feature-module",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/mutation.py",
+          "role": "profiles-feature-module",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/profiles/repository.py",
+      "role": "persistence-repository",
+      "owner_group": "profiles",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/profiles/repository.py",
+          "role": "persistence-repository",
+          "owner_group": "profiles"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/__init__.py",
+      "role": "package-facade",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/__init__.py",
+          "role": "package-facade",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/advanced.py",
+      "role": "advanced-prompt-service-facade",
+      "owner_group": "prompt",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/advanced.py",
+          "role": "advanced-prompt-service-facade",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/advanced_builder.py",
+          "role": "advanced-prompt-data-builder",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/advanced_fields.py",
+          "role": "advanced-field-normalization-service",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_prompt_corrector.py",
+        "tests/test_prompt_studio_seed_cutover.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-04",
+      "rollback_unit": "Revert the cohesive PTC-04 advanced prompt service Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/prompt/advanced.py::_build_advanced_prompt_data",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/advanced_builder.py"
+        },
+        {
+          "id": "module:easyuse_anima/prompt/advanced.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/advanced.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/__init__.py",
+      "role": "package-facade",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/__init__.py",
+          "role": "package-facade",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/correction.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/correction.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/knowledge.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/knowledge.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/models.py",
+      "role": "domain-contract",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/models.py",
+          "role": "domain-contract",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/normalize.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/normalize.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/ordering.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/ordering.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/anima/parser.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/anima/parser.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "role": "artist-mix-service-facade",
+      "owner_group": "prompt",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/artist_mix.py",
+          "role": "artist-mix-service-facade",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/artist_mix_conditioning.py",
+          "role": "artist-mix-conditioning-service",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/artist_mix_config.py",
+          "role": "artist-mix-config-service",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/artist_mix_planning.py",
+          "role": "artist-mix-planning-service",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-05",
+      "rollback_unit": "Revert the cohesive PTC-05 Artist Mix service Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/prompt/artist_mix.py::_encode_artist_clustered",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/artist_mix_conditioning.py"
+        },
+        {
+          "id": "function:easyuse_anima/prompt/artist_mix.py::_encode_prompt_data_positive_conditioning",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/artist_mix_conditioning.py"
+        },
+        {
+          "id": "function:easyuse_anima/prompt/artist_mix.py::_prompt_data_artist_mix_config",
+          "verdict": "move_retain_cohesive",
+          "final_owner": "easyuse_anima/prompt/artist_mix_config.py"
+        },
+        {
+          "id": "module:easyuse_anima/prompt/artist_mix.py",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/artist_mix.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/prompt/artist_mix_primitives.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/artist_mix_primitives.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/conditioning.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/conditioning.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/contracts.py",
+      "role": "domain-contract",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/contracts.py",
+          "role": "domain-contract",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/correction.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/correction.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/data.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/data.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/fields.py",
+      "role": "prompt-feature-module",
+      "owner_group": "prompt",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/fields.py",
+          "role": "prompt-feature-module",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/prompt/regional.py",
+      "role": "regional-prompt-service-facade",
+      "owner_group": "prompt",
+      "disposition": "split",
+      "status": "planned",
+      "targets": [
+        {
+          "path": "easyuse_anima/prompt/regional.py",
+          "role": "regional-prompt-service-facade",
+          "owner_group": "prompt"
+        },
+        {
+          "path": "easyuse_anima/prompt/regional_builder.py",
+          "role": "regional-prompt-output-builder",
+          "owner_group": "prompt"
+        }
+      ],
+      "direct_contracts": [
+        "tests/test_prompt_corrector.py",
+        "tests/test_prompt_studio_regional.py",
+        "tests/test_workflows.py"
+      ],
+      "compatibility_registry_key": null,
+      "task_id": "PTC-04",
+      "rollback_unit": "Revert the cohesive PTC-04 regional prompt service Move PR.",
+      "replacement_owner": null,
+      "size_exception_verdicts": [
+        {
+          "id": "function:easyuse_anima/prompt/regional.py::_build_regional_outputs",
+          "verdict": "split",
+          "final_owner": "easyuse_anima/prompt/regional_builder.py"
+        }
+      ]
+    },
+    {
+      "path": "easyuse_anima/registration.py",
+      "role": "node-registration-owner",
+      "owner_group": "nodes",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/registration.py",
+          "role": "node-registration-owner",
+          "owner_group": "nodes"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/runtime.py",
+      "role": "runtime-services-owner",
+      "owner_group": "runtime-bootstrap",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/runtime.py",
+          "role": "runtime-services-owner",
+          "owner_group": "runtime-bootstrap"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/__init__.py",
+      "role": "package-facade",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/__init__.py",
+          "role": "package-facade",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/compatibility.py",
+      "role": "seed-feature-module",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/compatibility.py",
+          "role": "seed-feature-module",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/execution_identity.py",
+      "role": "seed-feature-module",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/execution_identity.py",
+          "role": "seed-feature-module",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/execution_session.py",
+      "role": "seed-feature-module",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/execution_session.py",
+          "role": "seed-feature-module",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/reservation.py",
+      "role": "seed-feature-module",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/reservation.py",
+          "role": "seed-feature-module",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/seed/service.py",
+      "role": "feature-service",
+      "owner_group": "seed",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/seed/service.py",
+          "role": "feature-service",
+          "owner_group": "seed"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/settings/__init__.py",
+      "role": "package-facade",
+      "owner_group": "settings",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/settings/__init__.py",
+          "role": "package-facade",
+          "owner_group": "settings"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/settings/repository.py",
+      "role": "persistence-repository",
+      "owner_group": "settings",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/settings/repository.py",
+          "role": "persistence-repository",
+          "owner_group": "settings"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/settings/schema.py",
+      "role": "domain-contract",
+      "owner_group": "settings",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/settings/schema.py",
+          "role": "domain-contract",
+          "owner_group": "settings"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/settings/service.py",
+      "role": "feature-service",
+      "owner_group": "settings",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/settings/service.py",
+          "role": "feature-service",
+          "owner_group": "settings"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/__init__.py",
+      "role": "package-facade",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/__init__.py",
+          "role": "package-facade",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/contracts.py",
+      "role": "domain-contract",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/contracts.py",
+          "role": "domain-contract",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/markers.py",
+      "role": "translation-feature-module",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/markers.py",
+          "role": "translation-feature-module",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/ports.py",
+      "role": "domain-contract",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/ports.py",
+          "role": "domain-contract",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/provider_registry.py",
+      "role": "provider-adapter",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/provider_registry.py",
+          "role": "provider-adapter",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/providers/__init__.py",
+      "role": "package-facade",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/providers/__init__.py",
+          "role": "package-facade",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/providers/google.py",
+      "role": "translation-feature-module",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/providers/google.py",
+          "role": "translation-feature-module",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/translation/service.py",
+      "role": "feature-service",
+      "owner_group": "translation",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/translation/service.py",
+          "role": "feature-service",
+          "owner_group": "translation"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/__init__.py",
+      "role": "package-facade",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/__init__.py",
+          "role": "package-facade",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/expansion.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/expansion.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/library.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/library.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/mode.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/mode.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/models.py",
+      "role": "domain-contract",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/models.py",
+          "role": "domain-contract",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/ports.py",
+      "role": "domain-contract",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/ports.py",
+          "role": "domain-contract",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/seed.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/seed.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/selector.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/selector.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/service.py",
+      "role": "feature-service",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/service.py",
+          "role": "feature-service",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/snapshot.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/snapshot.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/wildcard/sources.py",
+      "role": "wildcard-feature-module",
+      "owner_group": "wildcard",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/wildcard/sources.py",
+          "role": "wildcard-feature-module",
+          "owner_group": "wildcard"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "easyuse_anima/workflow.py",
+      "role": "workflow-query-service",
+      "owner_group": "settings",
+      "disposition": "cohesive_retain",
+      "status": "complete",
+      "targets": [
+        {
+          "path": "easyuse_anima/workflow.py",
+          "role": "workflow-query-service",
+          "owner_group": "settings"
+        }
+      ],
+      "direct_contracts": [],
+      "compatibility_registry_key": null,
+      "task_id": null,
+      "rollback_unit": null,
+      "replacement_owner": null,
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "nodes.py",
+      "role": "legacy-node-and-helper-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_node_contracts.py",
+        "tests/test_python_compatibility_surface.py"
+      ],
+      "compatibility_registry_key": "nodes.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/registration.py",
+      "size_exception_verdicts": [
+        {
+          "id": "module:nodes.py",
+          "verdict": "delete_after_canonical_cutover",
+          "final_owner": "easyuse_anima/registration.py"
+        }
+      ]
+    },
+    {
+      "path": "prompt_translation.py",
+      "role": "legacy-translation-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_prompt_translation.py"
+      ],
+      "compatibility_registry_key": "prompt_translation.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/translation/service.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "settings.py",
+      "role": "legacy-settings-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "compatibility_registry_key": "settings.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/settings/service.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "storage.py",
+      "role": "legacy-storage-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_storage.py"
+      ],
+      "compatibility_registry_key": "storage.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "size_exception_verdicts": []
+    },
+    {
+      "path": "wildcard_engine.py",
+      "role": "legacy-wildcard-facade",
+      "owner_group": "compatibility",
+      "disposition": "delete",
+      "status": "planned",
+      "targets": [],
+      "direct_contracts": [
+        "tests/test_wildcards.py"
+      ],
+      "compatibility_registry_key": "wildcard_engine.py",
+      "task_id": "PTC-09B",
+      "rollback_unit": "Revert the cohesive PTC-09B canonical entrypoint and legacy retirement PR.",
+      "replacement_owner": "easyuse_anima/wildcard/service.py",
+      "size_exception_verdicts": []
+    }
+  ]
+}

--- a/tests/test_python_file_disposition_contract.py
+++ b/tests/test_python_file_disposition_contract.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = ROOT / "tools" / "check_python_file_dispositions.py"
+CONTRACT_PATH = (
+    ROOT / "tests" / "fixtures" / "python_file_disposition_contract.v1.json"
+)
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_file_disposition_checker", TOOL_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load file-disposition checker")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+class PythonFileDispositionContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.document = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+        linked = cls.document["linked_contracts"]
+        cls.owner_document = json.loads(
+            (ROOT / linked["import_owner_map"]).read_text(encoding="utf-8")
+        )
+        cls.size_document = json.loads(
+            (ROOT / linked["size_ledger"]).read_text(encoding="utf-8")
+        )
+        cls.compatibility_text = (ROOT / linked["compatibility_registry"]).read_text(
+            encoding="utf-8"
+        )
+        cls.inventory_document = json.loads(
+            (ROOT / cls.document["inventory_owner"]["path"]).read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def validate(self, document):
+        return checker.validate_contract(
+            document,
+            owner_document=self.owner_document,
+            size_document=self.size_document,
+            compatibility_text=self.compatibility_text,
+            repository_root=ROOT,
+        )
+
+    def test_repository_contract_passes_with_zero_unclassified_files(self):
+        self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
+        contract = self.validate(self.document)
+        self.assertEqual(contract["expected_baseline_files"], 183)
+        self.assertEqual(contract["expected_target_files"], 183)
+        self.assertEqual(len(contract["entries"]), 183)
+        self.assertEqual(len(contract["target_paths"]), 183)
+
+    def test_inventory_requires_every_source_exactly_once(self):
+        missing = copy.deepcopy(self.document)
+        missing["entries"].pop()
+        with self.assertRaises(checker.ContractError):
+            self.validate(missing)
+
+        duplicate = copy.deepcopy(self.document)
+        duplicate["entries"].insert(1, copy.deepcopy(duplicate["entries"][0]))
+        with self.assertRaises(checker.ContractError):
+            self.validate(duplicate)
+
+    def test_all_size_exceptions_require_exact_path_and_final_owner(self):
+        mutation = copy.deepcopy(self.document)
+        entry = next(
+            item
+            for item in mutation["entries"]
+            if item["path"] == "easyuse_anima/bootstrap.py"
+        )
+        entry["size_exception_verdicts"].pop()
+        with self.assertRaises(checker.ContractError):
+            self.validate(mutation)
+
+        mutation = copy.deepcopy(self.document)
+        entry = next(
+            item
+            for item in mutation["entries"]
+            if item["path"] == "easyuse_anima/prompt/artist_mix.py"
+        )
+        entry["size_exception_verdicts"][0]["final_owner"] = (
+            "easyuse_anima/prompt/not-a-target.py"
+        )
+        with self.assertRaises(checker.ContractError):
+            self.validate(mutation)
+
+    def test_compatibility_entries_reference_authoritative_registry(self):
+        mutation = copy.deepcopy(self.document)
+        entry = next(item for item in mutation["entries"] if item["path"] == "api.py")
+        entry["compatibility_registry_key"] = "missing-root-facade.py"
+        with self.assertRaises(checker.ContractError):
+            self.validate(mutation)
+
+    def test_target_owner_and_generic_bucket_fail_closed(self):
+        owner_mismatch = copy.deepcopy(self.document)
+        entry = next(
+            item
+            for item in owner_mismatch["entries"]
+            if item["path"] == "easyuse_anima/nodes/naia_nodes.py"
+        )
+        entry["targets"][1]["owner_group"] = "prompt"
+        with self.assertRaises(checker.ContractError):
+            self.validate(owner_mismatch)
+
+        generic_target = copy.deepcopy(self.document)
+        entry = next(
+            item
+            for item in generic_target["entries"]
+            if item["path"] == "easyuse_anima/prompt/advanced.py"
+        )
+        entry["targets"][1]["path"] = "easyuse_anima/prompt/helpers2.py"
+        generic_target["inventory_owner"]["expected_target_files"] = 183
+        with self.assertRaises(checker.ContractError):
+            self.validate(generic_target)
+
+    def test_planned_target_cannot_land_without_status_update(self):
+        contract = self.validate(self.document)
+        inventory = copy.deepcopy(self.inventory_document)
+        inventory["inventory"]["modules"].append(
+            {"path": "easyuse_anima/prompt/advanced_builder.py"}
+        )
+        violations = checker.check_current_inventory(inventory, contract)
+        self.assertIn(
+            "planned-target-already-present",
+            {violation["rule"] for violation in violations},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_python_file_dispositions.py
+++ b/tools/check_python_file_dispositions.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""Validate the blocking Total Python Convergence file-disposition plan.
+
+The plan reuses the analyzer inventory, G-06 test-owner map, G-05 size ledger,
+and compatibility registry.  It does not import production modules or maintain
+a second generated source inventory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT_PATH = (
+    REPOSITORY_ROOT
+    / "tests"
+    / "fixtures"
+    / "python_file_disposition_contract.v1.json"
+)
+CONTRACT_SCHEMA_VERSION = 1
+EXPECTED_DISPOSITIONS = (
+    "cohesive_retain",
+    "delete",
+    "merge",
+    "move",
+    "permanent_entrypoint",
+    "split",
+)
+EXPECTED_STATUSES = ("complete", "planned")
+EXPECTED_LINKED_CONTRACTS = {
+    "compatibility_registry": "docs/architecture/python-compatibility-shims.md",
+    "import_owner_map": "tests/fixtures/python_test_ownership_contract.v1.json",
+    "size_ledger": "tests/fixtures/python_size_complexity_contract.v1.json",
+}
+SPECIAL_OWNER_GROUPS = {"compatibility", "entrypoint", "package"}
+SIZE_VERDICTS = {
+    "cohesive_retain",
+    "delete_after_canonical_cutover",
+    "move_retain_cohesive",
+    "split",
+}
+GENERIC_TARGET_STEM = re.compile(r"^(?:helper|helpers|misc|util|utils)\d*$")
+
+
+class ContractError(ValueError):
+    """The checked-in disposition plan is invalid or incomplete."""
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_sorted_unique_strings(values: object, *, field: str) -> tuple[str, ...]:
+    if not isinstance(values, list) or not all(
+        isinstance(value, str) and value for value in values
+    ):
+        raise ContractError(f"{field} must be a list of non-empty strings")
+    if values != sorted(set(values)):
+        raise ContractError(f"{field} must be sorted and unique")
+    return tuple(values)
+
+
+def _load_owner_groups(document: object) -> dict[str, dict[str, object]]:
+    if not isinstance(document, dict) or not isinstance(document.get("groups"), list):
+        raise ContractError("test ownership contract must contain groups")
+    groups: dict[str, dict[str, object]] = {}
+    for raw_group in document["groups"]:
+        if not isinstance(raw_group, dict):
+            raise ContractError("test ownership groups must be objects")
+        name = raw_group.get("name")
+        paths = raw_group.get("production_paths")
+        owners = raw_group.get("owners")
+        if (
+            not isinstance(name, str)
+            or not name
+            or not isinstance(paths, list)
+            or not all(isinstance(path, str) and path for path in paths)
+            or not isinstance(owners, dict)
+            or not owners
+        ):
+            raise ContractError("test ownership group is malformed")
+        if name in groups:
+            raise ContractError(f"duplicate test ownership group: {name}")
+        if not owners.get("package_archive"):
+            raise ContractError(f"owner group lacks package/archive coverage: {name}")
+        groups[name] = raw_group
+    return groups
+
+
+def _matching_owner_groups(
+    path: str,
+    owner_groups: Mapping[str, Mapping[str, object]],
+) -> tuple[str, ...]:
+    matches: list[str] = []
+    for name, group in owner_groups.items():
+        for prefix in group["production_paths"]:
+            if (prefix.endswith("/") and path.startswith(prefix)) or path == prefix:
+                matches.append(name)
+                break
+    return tuple(sorted(matches))
+
+
+def _size_exception_records(document: object) -> dict[str, dict[str, object]]:
+    if not isinstance(document, dict):
+        raise ContractError("size ledger must be an object")
+    modules = document.get("module_exceptions")
+    functions = document.get("function_exceptions")
+    if not isinstance(modules, list) or not isinstance(functions, list):
+        raise ContractError("size ledger exception lists are missing")
+    records: dict[str, dict[str, object]] = {}
+    for raw in modules:
+        if not isinstance(raw, dict) or not isinstance(raw.get("path"), str):
+            raise ContractError("module size exception is malformed")
+        exception_id = f"module:{raw['path']}"
+        records[exception_id] = raw
+    for raw in functions:
+        if (
+            not isinstance(raw, dict)
+            or not isinstance(raw.get("path"), str)
+            or not isinstance(raw.get("qualified_name"), str)
+        ):
+            raise ContractError("function size exception is malformed")
+        exception_id = f"function:{raw['path']}::{raw['qualified_name']}"
+        records[exception_id] = raw
+    if len(records) != len(modules) + len(functions):
+        raise ContractError("size exception IDs must be unique")
+    return records
+
+
+def _validate_target(
+    raw_target: object,
+    *,
+    owner_groups: Mapping[str, Mapping[str, object]],
+) -> dict[str, str]:
+    if not isinstance(raw_target, dict) or set(raw_target) != {
+        "owner_group",
+        "path",
+        "role",
+    }:
+        raise ContractError("target keys must be owner_group, path and role")
+    path = raw_target["path"]
+    role = raw_target["role"]
+    owner_group = raw_target["owner_group"]
+    if not isinstance(path, str) or not path.endswith(".py"):
+        raise ContractError("target path must be a production Python path")
+    if not isinstance(role, str) or len(role.strip()) < 4:
+        raise ContractError(f"target role is not concrete: {path}")
+    if not isinstance(owner_group, str) or not owner_group:
+        raise ContractError(f"target owner_group is missing: {path}")
+    if owner_group not in SPECIAL_OWNER_GROUPS:
+        matches = _matching_owner_groups(path, owner_groups)
+        if matches != (owner_group,):
+            raise ContractError(
+                f"target owner mismatch: {path} declares {owner_group}, matches {matches}"
+            )
+    elif owner_group == "package" and path != "easyuse_anima/__init__.py":
+        raise ContractError("package owner is reserved for easyuse_anima/__init__.py")
+    elif owner_group == "entrypoint" and path != "__init__.py":
+        raise ContractError("entrypoint owner is reserved for root __init__.py")
+    elif owner_group == "compatibility" and (
+        path.startswith("easyuse_anima/") or path == "__init__.py"
+    ):
+        raise ContractError(f"canonical path cannot use compatibility owner: {path}")
+    return {"owner_group": owner_group, "path": path, "role": role}
+
+
+def _validate_entry_owner(
+    path: str,
+    owner_group: str,
+    owner_groups: Mapping[str, Mapping[str, object]],
+) -> None:
+    if owner_group not in SPECIAL_OWNER_GROUPS:
+        matches = _matching_owner_groups(path, owner_groups)
+        if matches != (owner_group,):
+            raise ContractError(
+                f"entry owner mismatch: {path} declares {owner_group}, matches {matches}"
+            )
+    elif owner_group == "package" and path != "easyuse_anima/__init__.py":
+        raise ContractError("package owner is reserved for easyuse_anima/__init__.py")
+    elif owner_group == "entrypoint" and path != "__init__.py":
+        raise ContractError("entrypoint owner is reserved for root __init__.py")
+    elif owner_group == "compatibility" and (
+        path.startswith("easyuse_anima/") or path == "__init__.py"
+    ):
+        raise ContractError(f"canonical path cannot use compatibility owner: {path}")
+
+
+def validate_contract(
+    document: object,
+    *,
+    owner_document: object,
+    size_document: object,
+    compatibility_text: str,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> dict[str, object]:
+    """Validate and normalize the static disposition document."""
+
+    expected_keys = {
+        "allowed_dispositions",
+        "allowed_statuses",
+        "baseline_commit",
+        "entries",
+        "inventory_owner",
+        "linked_contracts",
+        "schema_version",
+    }
+    if not isinstance(document, dict) or set(document) != expected_keys:
+        raise ContractError("contract keys do not match the PTC-01 schema")
+    if document["schema_version"] != CONTRACT_SCHEMA_VERSION:
+        raise ContractError("unsupported disposition contract schema_version")
+    baseline_commit = document["baseline_commit"]
+    if not isinstance(baseline_commit, str) or not re.fullmatch(
+        r"[0-9a-f]{40}", baseline_commit
+    ):
+        raise ContractError("baseline_commit must be a full Git SHA")
+    if tuple(document["allowed_dispositions"]) != EXPECTED_DISPOSITIONS:
+        raise ContractError("allowed dispositions must remain the reviewed PTC set")
+    if tuple(document["allowed_statuses"]) != EXPECTED_STATUSES:
+        raise ContractError("allowed statuses must remain complete/planned")
+    if document["linked_contracts"] != EXPECTED_LINKED_CONTRACTS:
+        raise ContractError("linked contracts must reuse the authoritative owners")
+
+    inventory_owner = document["inventory_owner"]
+    if not isinstance(inventory_owner, dict) or set(inventory_owner) != {
+        "expected_baseline_files",
+        "expected_target_files",
+        "path",
+    }:
+        raise ContractError("inventory_owner keys do not match the PTC-01 schema")
+    if inventory_owner["path"] != "tests/fixtures/python_backend_baseline.json":
+        raise ContractError("inventory must reuse python_backend_baseline.json")
+    expected_baseline_files = inventory_owner["expected_baseline_files"]
+    expected_target_files = inventory_owner["expected_target_files"]
+    if (
+        type(expected_baseline_files) is not int
+        or expected_baseline_files <= 0
+        or type(expected_target_files) is not int
+        or expected_target_files <= 0
+    ):
+        raise ContractError("inventory counts must be positive and monotonic")
+
+    owner_groups = _load_owner_groups(owner_document)
+    size_records = _size_exception_records(size_document)
+    entries = document["entries"]
+    if not isinstance(entries, list):
+        raise ContractError("entries must be a list")
+    normalized_entries: list[dict[str, object]] = []
+    entry_paths: list[str] = []
+    target_paths: list[str] = []
+    linked_size_ids: list[str] = []
+
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict) or set(raw_entry) != {
+            "compatibility_registry_key",
+            "direct_contracts",
+            "disposition",
+            "owner_group",
+            "path",
+            "role",
+            "rollback_unit",
+            "replacement_owner",
+            "size_exception_verdicts",
+            "status",
+            "targets",
+            "task_id",
+        }:
+            raise ContractError("entry keys do not match the PTC-01 schema")
+        path = raw_entry["path"]
+        role = raw_entry["role"]
+        owner_group = raw_entry["owner_group"]
+        disposition = raw_entry["disposition"]
+        status = raw_entry["status"]
+        if not isinstance(path, str) or not path.endswith(".py"):
+            raise ContractError("entry path must be a production Python path")
+        if not isinstance(role, str) or len(role.strip()) < 4:
+            raise ContractError(f"entry role is not concrete: {path}")
+        if not isinstance(owner_group, str) or not owner_group:
+            raise ContractError(f"entry owner_group is missing: {path}")
+        _validate_entry_owner(path, owner_group, owner_groups)
+        if disposition not in EXPECTED_DISPOSITIONS:
+            raise ContractError(f"unknown disposition: {path}")
+        if status not in EXPECTED_STATUSES:
+            raise ContractError(f"unknown disposition status: {path}")
+
+        target_values = raw_entry["targets"]
+        if not isinstance(target_values, list):
+            raise ContractError(f"entry targets must be a list: {path}")
+        targets = [
+            _validate_target(target, owner_groups=owner_groups)
+            for target in target_values
+        ]
+        if len({target["path"] for target in targets}) != len(targets):
+            raise ContractError(f"targets must be unique: {path}")
+        if disposition != "delete":
+            if not targets:
+                raise ContractError(f"retained entry must declare targets: {path}")
+            source_targets = [target for target in targets if target["path"] == path]
+            if len(source_targets) != 1 or (
+                owner_group != source_targets[0]["owner_group"]
+                or role != source_targets[0]["role"]
+            ):
+                raise ContractError(
+                    f"one target must preserve the current owner/role: {path}"
+                )
+
+        direct_contracts = _require_sorted_unique_strings(
+            raw_entry["direct_contracts"], field=f"{path}.direct_contracts"
+        )
+        for contract in direct_contracts:
+            if not (repository_root / contract).is_file():
+                raise ContractError(f"direct contract does not exist: {contract}")
+
+        registry_key = raw_entry["compatibility_registry_key"]
+        compatibility_surface = owner_group == "compatibility" or disposition == (
+            "permanent_entrypoint"
+        )
+        if compatibility_surface:
+            if not isinstance(registry_key, str) or not registry_key:
+                raise ContractError(f"compatibility registry key is missing: {path}")
+            if f"`{registry_key}`" not in compatibility_text:
+                raise ContractError(
+                    f"compatibility registry key is not authoritative: {registry_key}"
+                )
+        elif registry_key is not None:
+            raise ContractError(f"canonical entry cannot cite compatibility key: {path}")
+
+        task_id = raw_entry["task_id"]
+        rollback_unit = raw_entry["rollback_unit"]
+        replacement_owner = raw_entry["replacement_owner"]
+        if disposition in {"delete", "merge", "move", "split"}:
+            if not isinstance(task_id, str) or not task_id:
+                raise ContractError(f"structural disposition lacks task_id: {path}")
+            if not isinstance(rollback_unit, str) or len(rollback_unit.strip()) < 12:
+                raise ContractError(f"structural disposition lacks rollback unit: {path}")
+            if not direct_contracts:
+                raise ContractError(f"structural disposition lacks direct tests: {path}")
+        elif task_id is not None or rollback_unit is not None:
+            raise ContractError(f"retained entry must not invent a structural task: {path}")
+
+        if disposition == "delete":
+            if targets:
+                raise ContractError(f"delete must have no final target path: {path}")
+            if (
+                not isinstance(replacement_owner, str)
+                or not replacement_owner.startswith("easyuse_anima/")
+                or not replacement_owner.endswith(".py")
+            ):
+                raise ContractError(
+                    f"delete must name a canonical replacement owner: {path}"
+                )
+        elif replacement_owner is not None:
+            raise ContractError(f"non-delete entry cannot name replacement_owner: {path}")
+
+        if disposition == "split":
+            if len(targets) < 2 or path not in {target["path"] for target in targets}:
+                raise ContractError(f"split must retain a facade and add targets: {path}")
+        elif disposition in {
+            "cohesive_retain",
+            "permanent_entrypoint",
+        }:
+            if len(targets) != 1 or targets[0]["path"] != path:
+                raise ContractError(f"retained entry must keep one exact target: {path}")
+            if status != "complete":
+                raise ContractError(f"retained entry must already be complete: {path}")
+
+        size_values = raw_entry["size_exception_verdicts"]
+        if not isinstance(size_values, list):
+            raise ContractError(f"size_exception_verdicts must be a list: {path}")
+        size_ids: list[str] = []
+        for size_value in size_values:
+            if not isinstance(size_value, dict) or set(size_value) != {
+                "final_owner",
+                "id",
+                "verdict",
+            }:
+                raise ContractError(f"size verdict keys are malformed: {path}")
+            size_id = size_value["id"]
+            verdict = size_value["verdict"]
+            final_owner = size_value["final_owner"]
+            if size_id not in size_records:
+                raise ContractError(f"unknown size exception ID: {size_id}")
+            if size_records[size_id]["path"] != path:
+                raise ContractError(f"size exception linked to wrong path: {size_id}")
+            if verdict not in SIZE_VERDICTS:
+                raise ContractError(f"unknown size exception verdict: {size_id}")
+            allowed_final_owners = {target["path"] for target in targets}
+            if disposition == "delete":
+                allowed_final_owners.add(replacement_owner)
+            if final_owner not in allowed_final_owners:
+                raise ContractError(f"size final owner is not a target: {size_id}")
+            size_ids.append(size_id)
+        if size_ids != sorted(set(size_ids)):
+            raise ContractError(f"size verdicts must be sorted and unique: {path}")
+        if size_values and disposition != "split" and not direct_contracts:
+            raise ContractError(f"large retain lacks an executable contract: {path}")
+
+        entry_paths.append(path)
+        target_paths.extend(target["path"] for target in targets)
+        linked_size_ids.extend(size_ids)
+        normalized_entries.append(dict(raw_entry))
+
+    if entry_paths != sorted(set(entry_paths)):
+        raise ContractError("entries must be sorted and unique by path")
+    if len(entry_paths) != expected_baseline_files:
+        raise ContractError("entry count does not match expected_baseline_files")
+    if len(set(target_paths)) != len(target_paths):
+        raise ContractError("target paths collide across disposition entries")
+    if len(target_paths) != expected_target_files:
+        raise ContractError("target count does not match expected_target_files")
+    if sorted(linked_size_ids) != sorted(size_records):
+        raise ContractError("size ledger is not classified exactly once")
+
+    baseline_paths = set(entry_paths)
+    final_target_paths = set(target_paths)
+    for entry in normalized_entries:
+        replacement_owner = entry["replacement_owner"]
+        if replacement_owner is not None and replacement_owner not in final_target_paths:
+            raise ContractError(
+                f"replacement owner is not in the final target tree: {replacement_owner}"
+            )
+    for target_path in target_paths:
+        if target_path not in baseline_paths and GENERIC_TARGET_STEM.fullmatch(
+            Path(target_path).stem
+        ):
+            raise ContractError(f"generic target module is forbidden: {target_path}")
+
+    return {
+        "baseline_paths": tuple(entry_paths),
+        "entries": tuple(normalized_entries),
+        "expected_baseline_files": expected_baseline_files,
+        "expected_target_files": expected_target_files,
+        "owner_groups": owner_groups,
+        "target_paths": tuple(target_paths),
+    }
+
+
+def check_current_inventory(
+    inventory_document: object,
+    contract: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Compare planned/complete targets with the current analyzer inventory."""
+
+    if (
+        not isinstance(inventory_document, dict)
+        or not isinstance(inventory_document.get("inventory"), dict)
+        or not isinstance(inventory_document["inventory"].get("modules"), list)
+    ):
+        raise ContractError("analyzer inventory is malformed")
+    current_paths = {
+        module["path"]
+        for module in inventory_document["inventory"]["modules"]
+        if isinstance(module, dict) and isinstance(module.get("path"), str)
+    }
+    if len(current_paths) != len(inventory_document["inventory"]["modules"]):
+        raise ContractError("analyzer inventory contains duplicate or malformed paths")
+
+    expected_current = set(contract["baseline_paths"])
+    violations: list[dict[str, object]] = []
+    for entry in contract["entries"]:
+        path = entry["path"]
+        new_targets = {
+            target["path"] for target in entry["targets"] if target["path"] != path
+        }
+        if entry["disposition"] == "delete":
+            if entry["status"] == "complete":
+                expected_current.discard(path)
+            continue
+        if entry["status"] == "complete":
+            expected_current.update(new_targets)
+        else:
+            present = sorted(new_targets & current_paths)
+            if present:
+                violations.append(
+                    {
+                        "rule": "planned-target-already-present",
+                        "path": path,
+                        "targets": present,
+                    }
+                )
+    for path in sorted(expected_current - current_paths):
+        violations.append({"rule": "classified-path-missing", "path": path})
+    for path in sorted(current_paths - expected_current):
+        violations.append({"rule": "unclassified-production-path", "path": path})
+    return sorted(violations, key=lambda item: (str(item["path"]), item["rule"]))
+
+
+def check_repository(
+    root: Path = REPOSITORY_ROOT,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> list[dict[str, object]]:
+    document = _load_json(contract_path)
+    linked = document["linked_contracts"] if isinstance(document, dict) else {}
+    owner_document = _load_json(root / str(linked.get("import_owner_map", "")))
+    size_document = _load_json(root / str(linked.get("size_ledger", "")))
+    compatibility_text = (root / str(linked.get("compatibility_registry", ""))).read_text(
+        encoding="utf-8"
+    )
+    contract = validate_contract(
+        document,
+        owner_document=owner_document,
+        size_document=size_document,
+        compatibility_text=compatibility_text,
+        repository_root=root,
+    )
+    inventory_path = root / document["inventory_owner"]["path"]
+    return check_current_inventory(_load_json(inventory_path), contract)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPOSITORY_ROOT)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT_PATH)
+    args = parser.parse_args(argv)
+    try:
+        violations = check_repository(args.root.resolve(), args.contract.resolve())
+    except (ContractError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Python file-disposition contract error: {error}", file=sys.stderr)
+        return 2
+    if violations:
+        for violation in violations:
+            print(json.dumps(violation, sort_keys=True), file=sys.stderr)
+        return 1
+    print("Python file-disposition contract passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_python_quality.ps1
+++ b/tools/check_python_quality.ps1
@@ -101,6 +101,13 @@ try {
     if ($sizeComplexityExitCode -ne 0) {
         throw "Python size/complexity ratchet failed with exit code $sizeComplexityExitCode."
     }
+
+    Write-Host "`n== Python file-disposition contract (PTC-01) =="
+    & $pythonCommand (Join-Path $PSScriptRoot "check_python_file_dispositions.py")
+    $fileDispositionExitCode = $LASTEXITCODE
+    if ($fileDispositionExitCode -ne 0) {
+        throw "Python file-disposition contract failed with exit code $fileDispositionExitCode."
+    }
 }
 finally {
     Set-Location -LiteralPath $originalLocation


### PR DESCRIPTION
## 목적과 변경 경계

PRO의 `ROADMAP_EXTENSION_REQUIRED` 결론과 사용자 보정을 반영해 전체 Python 수렴을 완료 조건으로 고정합니다. root `__init__.py`만 영구 ComfyUI 진입점으로 남기고, 나머지 9개 root 모듈과 7개 `anima_prompt` 호환 모듈은 canonical caller 전환 뒤 PTC-09B에서 삭제합니다.

이 PR은 PTC-01 Contract이며 production 코드를 변경하지 않습니다.

## Base -> Head

- Base: `dev@39997c5423847d4280737f0d78d353d3c6273e07`
- Head: `9889539b671ac7f67b365e676003d50af8eec9b9`

## 주요 변경

- 183개 shipped Python 파일의 explicit disposition fixture 추가
- 31개 size/function exception을 정확히 한 번 final owner에 연결
- 최종 target을 183개로 고정: baseline 183 + canonical 16 - legacy 16
- missing/duplicate/unclassified/owner mismatch/target collision/generic bucket을 거부하는 fail-closed checker 추가
- 공식 Python quality runner에 PTC-01 gate 연결
- FC 완료 기록을 보존하면서 PTC-02..PTC-10 순서와 PTC-09A/B root cutover gate를 문서화

## 보존 계약

- node ID, workflow, API payload/error, settings/profile/schema 동작
- bootstrap 단일 E-09 lifecycle owner와 executor/cleanup identity
- PTC-09B 전까지 현재 root/canonical identity
- release/tag/Registry는 별도 작업

## 검증

- changed Python `py_compile`: PASS
- changed Python Ruff: PASS
- `tests.test_python_file_disposition_contract`: 6 PASS
- `git diff --check`: PASS
- official full: 1,496 Python tests PASS, frontend 120-file smoke PASS
- Pyright baseline, 16-group import, size/complexity, PTC-01 disposition gate: PASS
- package/live: production-free PTC-01이므로 미실행

기존 repository-wide Ruff 128건은 report-only baseline이며 이번 변경에는 새 finding이 없습니다.

## 위험과 rollback

가장 큰 의도적 변경은 PTC-09B 이후 레거시 root import path가 더 이상 지원되지 않는다는 점입니다. PTC-09A에서 canonical entrypoint/caller와 E-09 identity sequence를 먼저 고정하며, 각 PTC PR이 독립 rollback 단위입니다. 이 PR rollback은 Contract/checker/fixture 문서 커밋의 revert입니다.

## Next

PTC-01 merge 후 PTC-02 AiO generation normalization Move만 시작합니다.