### PR TITLE
chore: EasyUse Anima 1.0.0 릴리즈 준비

### DIFF
--- a/.github/registry/changelogs/1.0.0.txt
+++ b/.github/registry/changelogs/1.0.0.txt
@@ -1,0 +1,9 @@
+EasyUse Anima 1.0.0 establishes a stable ComfyUI node, workflow, HTTP, and saved-data surface on the fully canonical backend.
+
+Changes:
+1. Custom Python integrations can no longer import the legacy root-level modules or anima_prompt package. Integrations that need internal owners must import the exact canonical module under easyuse_anima.
+2. Existing public node identifiers, socket order, HTTP routes and payloads, settings, profiles, and saved workflows remain compatible.
+3. Fixed Prompt Studio highlight wrapping so highlighted text and the editable text use the same line width when no scrollbar is present.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser. If third-party Python code imports the removed root modules or anima_prompt package, update those imports before installing 1.0.0. Ordinary ComfyUI workflows do not require migration.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "1.0.0",
+      "deprecated": false,
+      "changelog_file": "changelogs/1.0.0.txt"
+    },
+    {
       "version": "0.6.2",
       "deprecated": false,
       "changelog_file": "changelogs/0.6.2.txt"

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -7,7 +7,8 @@ This repository is prepared for future ComfyUI Manager / Comfy Registry registra
 - Keep `pyproject.toml` version in semantic version format: `X.Y.Z`.
 - Patch version: bug fixes and documentation-only changes.
 - Minor version: backward-compatible node inputs, UI, or behavior additions.
-- Major version: breaking node class names, input names, output types, or workflow behavior.
+- Major version: breaking node class names, input names, output types, workflow
+  behavior, HTTP/data contracts, or supported Python import/API surfaces.
 - Once a version is published to Comfy Registry, do not rewrite that release. Publish a newer version instead.
 
 ## Branch Rules

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,42 @@
 # Release Notes
 
+## 1.0.0
+
+### Changed
+
+- EasyUse Anima now keeps its Python implementation under the canonical
+  `easyuse_anima` package, with the repository root reserved for the ComfyUI
+  entrypoint.
+- The legacy root modules `api`, `api_contract`, `autocomplete_dataset`,
+  `autocomplete_index`, `nodes`, `prompt_translation`, `settings`, `storage`,
+  and `wildcard_engine`, together with the legacy `anima_prompt` package, have
+  been removed. Third-party Python integrations must import the matching
+  canonical owners under `easyuse_anima`.
+
+### Fixed
+
+- Prompt Studio highlight overlays now wrap at the same width as the editable
+  text when no scrollbar is present, preventing highlighted and transparent
+  text from splitting onto different lines.
+### Compatibility
+
+- Existing ComfyUI workflows, public node identifiers, input and output socket
+  order, HTTP routes and payloads, settings, profiles, and saved data remain
+  compatible.
+- Python import compatibility is intentionally broken only for the removed
+  legacy root modules and `anima_prompt` package. Ordinary ComfyUI workflows do
+  not require migration.
+- The stable 1.0 public contract is the ComfyUI entrypoint, mapped nodes,
+  workflows, HTTP payloads, settings, profiles, and saved data. The
+  `easyuse_anima` package root does not re-export private implementation names;
+  advanced Python integrations import the exact canonical owner they use.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+- Before installing 1.0.0, update third-party Python code that imports a
+  removed legacy module to use its canonical `easyuse_anima` owner.
+
 ## 0.6.2
 
 ### Fixed

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -35,13 +35,16 @@ COMPLETE FC-05 technical architecture completion
 COMPLETE PTC-01 through PTC-09B total structure, support and root cutover
 COMPLETE PTC-10 final audit and dead-adapter retirement
 
-EVENT    ordinary release N
+READY    FC-06 ordinary release N as EasyUse Anima 1.0.0
 ```
 
 FC-01 through FC-05 closed the initial ownership and lifecycle Definition of Done.
 PTC-01 through PTC-09B complete the per-file, size, support-ownership and E-09-safe
-root cutover. PTC-10 closes the two unregistered runtime-closure residuals. Release
-events remain separate from this sequence.
+root cutover. PTC-10 closes the two unregistered runtime-closure residuals. The
+selected release N is 1.0.0 because the retired legacy Python imports are an explicit
+breaking boundary. Version 1.0 defines the stable public contract at the ComfyUI
+entrypoint, node, workflow, HTTP and persisted-data boundaries; exact canonical modules
+remain directly importable without a broad package-root re-export.
 
 ## Current code boundary
 

--- a/docs/architecture/backend-final-convergence-roadmap.md
+++ b/docs/architecture/backend-final-convergence-roadmap.md
@@ -2,8 +2,8 @@
 
 ## Status and authority
 
-- Status: FC ownership/lifecycle convergence complete; mandatory Total Python
-  Convergence extension active.
+- Status: FC ownership/lifecycle convergence and Total Python Convergence complete;
+  FC-06 release N selected as EasyUse Anima 1.0.0.
 - Technical completion owner: reactivated Issue #593.
 - Parent architecture: reactivated Issue #185.
 - Compatibility ledger: Issue #186 and ADR-002.
@@ -79,7 +79,7 @@ FC-01        original Definition-of-Done closure audit
   -> FC-04B  cohesive production application Move
   -> FC-05   technical completion audit
 
-EVENT FC-06  next ordinary release N
+READY FC-06  ordinary release N as EasyUse Anima 1.0.0
   -> FC-07   later H/D-14 compatibility re-audit
 ```
 
@@ -706,6 +706,13 @@ Do not publish solely for PTC. An ordinary pre-PTC feature/bug release remains v
 does not satisfy total convergence. The first post-PTC release must record the exact tag,
 SHA, archive hash, absence of the sixteen legacy paths, canonical entrypoint identity,
 internal root-import scan and validate/pack/read-back.
+
+EasyUse Anima 1.0.0 is the selected release N. The major version makes the exact legacy
+Python import-path retirement explicit and establishes the stable public contract at
+the ComfyUI entrypoint, node, workflow, HTTP and persisted-data boundaries. Canonical
+implementation modules remain directly importable without adding a broad package-root
+export. Public node identifiers, socket ordering, workflows, HTTP routes/payloads,
+settings, profiles and persisted data do not change.
 
 ### FC-07 — Later compatibility re-audit
 

--- a/docs/development/1.0.0.md
+++ b/docs/development/1.0.0.md
@@ -1,0 +1,72 @@
+# EasyUse Anima 1.0.0 Release Plan
+
+## Decision
+
+Version 1.0.0 is the first ordinary release after Total Python Convergence. It defines
+the stable public surface at the ComfyUI entrypoint, mapped-node, workflow, HTTP and
+persisted-data boundaries. The canonical `easyuse_anima` package owns implementation;
+its package root intentionally does not re-export private internals.
+
+The major version is intentional. PTC-09B removed the exact legacy root and
+`anima_prompt` imports after proving that the repository, package entrypoint and direct
+tests use canonical owners. Those deleted paths are not recreated by a facade, alias,
+module hook or compatibility package.
+
+## Compatibility boundary
+
+Existing ComfyUI behavior remains compatible:
+
+- public node identifiers and display mappings;
+- input/output sockets and saved workflow values;
+- settings, profiles and versioned migrations;
+- HTTP routes, request/result/error payloads and request correlation;
+- bootstrap/runtime identity and the E-09 shutdown contract.
+
+The breaking boundary applies only to third-party Python code importing these legacy
+paths:
+
+```text
+api.py                      -> exact easyuse_anima.api application/route owner
+api_contract.py             -> easyuse_anima.api.requests
+autocomplete_dataset.py     -> exact easyuse_anima.autocomplete feature owner
+autocomplete_index.py       -> easyuse_anima.autocomplete.index
+nodes.py                    -> easyuse_anima.registration and easyuse_anima.nodes
+prompt_translation.py       -> easyuse_anima.translation
+settings.py                 -> easyuse_anima.settings
+storage.py                  -> easyuse_anima.infrastructure.filesystem
+wildcard_engine.py          -> easyuse_anima.wildcard
+anima_prompt/*              -> easyuse_anima.prompt.anima
+```
+
+The root ComfyUI package continues to export only `NODE_CLASS_MAPPINGS`,
+`NODE_DISPLAY_NAME_MAPPINGS`, and `WEB_DIRECTORY`. Advanced Python integrations use the
+exact canonical module that owns the required contract; importing `easyuse_anima` alone
+does not publish every internal symbol.
+
+## User-visible fix
+
+Prompt Studio highlighted text and editable transparent text now use the same wrapping
+width when the textarea has no scrollbar. This prevents the two layers from breaking
+onto different lines.
+
+## Release task card
+
+```text
+Task / Issue: #186 / FC-06 release N
+Base: origin/dev@659a6e00edf444773658071d7bf3910fe7d9d701
+Goal: publish the completed canonical package as EasyUse Anima 1.0.0
+Allowed: version metadata, Registry/GitHub changelog, release/navigation documents
+Forbidden: production behavior, retired-shim recreation, lifecycle or schema changes
+Preserve: node/workflow/HTTP/data behavior and every E-09 lifecycle invariant
+Focused: release-copy contract, metadata/changelog extraction, legacy-path retirement,
+         package skeleton, scanner safety and git diff check
+Promotion: official full once on the final candidate; validate/pack/archive;
+           reuse the unchanged PTC isolated-ComfyUI runtime evidence
+Publish: dev PR -> main PR -> annotated v1.0.0 tag -> GitHub Release -> Registry
+Rollback: revert release metadata before publication; after publication use 1.0.1
+Stop: version collision, unexpected archive surface, legacy path restored, failed full,
+      invalid Registry ownership/credentials or live read-back mismatch
+```
+
+After publication, Issue #186 records the exact main SHA, annotated tag, archive hash,
+legacy-path absence, validation evidence and Registry status before it is closed.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -41,26 +41,30 @@ COMPLETE  FC-04A canonical API application/E-09 lifecycle Contract
 COMPLETE  FC-04B canonical API application cohesive Move
 COMPLETE  FC-05 technical architecture completion
 
-COMPLETE  PTC-01 through PTC-09A total structure, support and cutover Contract
-READY     PTC-09B canonical cutover/legacy removal
-NEXT      PTC-10 final audit
+COMPLETE  PTC-01 through PTC-09B total structure, support and root cutover
+COMPLETE  PTC-10 final audit and dead-adapter retirement
 
-EVENT     next ordinary release N
+READY     FC-06 ordinary release N as EasyUse Anima 1.0.0
 ```
 
-## FC completion and active total convergence
+## FC and total-convergence completion
 
-FC-05 closes the original ownership/lifecycle Definition of Done. PTC-01 adds the
-broader blocking goal: every shipped Python file and size exception has a final owner,
-16 responsibility-owned canonical modules are extracted, and all 16 non-entrypoint
-legacy root/`anima_prompt` modules are removed after a canonical caller cutover.
+FC-05 closes the original ownership/lifecycle Definition of Done. PTC-01 through
+PTC-10 close the broader per-file goal: every shipped Python file and size exception
+has a final owner, responsibility-owned canonical modules are extracted, and all 16
+non-entrypoint legacy root/`anima_prompt` modules are removed after canonical caller
+and lifecycle proof.
 
 ## Current execution boundary
 
-PTC-09B is READY after the production-free PTC-09A Contract merges. Do not repeat FC-01
-through FC-05 or the completed PTC Move tasks. PTC-09B follows the fixed private
-bootstrap package-start sequence, migrates callers to canonical owners and deletes the
-exact 16 legacy paths without a replacement facade.
+The only current roadmap task is FC-06, the first ordinary post-PTC release. Version
+1.0.0 defines the stable ComfyUI entrypoint, node, workflow, HTTP and data surface and
+explicitly records the retired legacy Python imports as a breaking boundary. Exact
+canonical modules remain directly importable; the package root does not become a broad
+SDK re-export. Do not reopen the completed FC/PTC implementation queue or recreate a
+deleted compatibility facade.
+
+Release task card: [`1.0.0.md`](1.0.0.md).
 
 ## Fixed lifecycle and compatibility guards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "0.6.2"
+version = "1.0.0"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## 목적과 변경 경계

완료된 backend convergence/PTC 리팩터링을 첫 안정 계약인 EasyUse Anima 1.0.0 릴리즈로 준비합니다.

PTC-09B에서 16개 legacy root Python import path와 `anima_prompt` Python package가 의도적으로 제거되었습니다. 일반 ComfyUI 사용자가 의존하는 node ID, socket 순서, HTTP route/payload, settings/profile/saved-workflow 계약은 유지되지만, 비공개 Python import 소비자는 canonical `easyuse_anima` 모듈로 이전해야 하므로 0.6.3이 아닌 1.0.0 major release로 분류합니다.

- Base: `origin/dev@659a6e00edf444773658071d7bf3910fe7d9d701`
- Head: `50ae1457d5e8f2d418b5e5cc790965a01d301954`
- Production code 변경 없음
- 버전/Registry metadata, changelog, release 문서와 완료된 roadmap 상태만 갱신

## 주요 변경

- `pyproject.toml`과 Registry metadata에 1.0.0을 추가했습니다.
- 사용자용 changelog와 `RELEASE.md`에 breaking Python import migration 및 보존되는 ComfyUI 계약을 기록했습니다.
- Prompt Studio에서 scrollbar가 없을 때 highlight와 편집 텍스트의 줄바꿈 폭이 달라지던 수정 사항을 사용자용 changelog에 포함했습니다.
- PTC/FC 완료 상태와 1.0.0 release gate를 architecture/development 문서에 고정했습니다.

## 검증

- Registry release copy: 2/2 PASS
- Registry scanner safety: 8/8 PASS
- Legacy path retirement: 3/3 PASS
- Python package skeleton: 1/1 PASS
- TOML/JSON parse 및 release changelog extraction: PASS
- 최종 후보 SHA 공식 full 1회: PASS
  - Python 1,452 tests
  - frontend 120 JS files
  - TypeScript 6.0.3
  - import boundary 16 groups, 0 violations
  - Pyright baseline 증가 없음
- `comfy node validate`: PASS
- `comfy node pack`: PASS
  - archive SHA-256: `7EC7E8518B5078AF68C94A7816E76D63AA013B6FB220DC89CBF0AAAAA9075D8D`
  - 13,224,700 bytes / 323 entries / Python 181 files
  - 제거 대상 16개 legacy Python path 없음
  - root Python file은 `__init__.py`만 존재

PTC isolated ComfyUI package/API/registered-node runtime evidence는 production 및 registered surface가 바뀌지 않아 재사용합니다. 이 릴리즈 준비 PR에서는 package/live/browser를 반복 실행하지 않았습니다.

## 위험과 rollback

- 1.0.0 설치 전 third-party Python code가 legacy root module 또는 `anima_prompt`를 import하는지 확인해야 합니다.
- Registry 게시 전에는 이 PR을 revert하면 됩니다.
- immutable Registry 게시 후 문제가 확인되면 1.0.1을 발행하고, legacy private import가 필요한 사용자는 별도로 남아 있는 0.6.2를 사용할 수 있습니다.

## 다음 단계

dev 병합 후 별도 dev→main release PR, annotated `v1.0.0` tag, GitHub Release, Registry publish와 live read-back을 진행합니다.
