### PR TITLE
fix(prompt): keep artist and highlight classifications consistent

### DIFF
--- a/easyuse_anima/prompt/anima/correction.py
+++ b/easyuse_anima/prompt/anima/correction.py
@@ -130,6 +130,7 @@ def _classify_with_artist_options(
     normalized: str,
     *,
     info,
+    validate_artist_tags: bool,
     artist_overrides: set[str],
     artist_exclusions: set[str],
 ):
@@ -139,7 +140,10 @@ def _classify_with_artist_options(
     if key in artist_overrides:
         return classify_tag(f"@{key}", info)
     if normalized.strip().startswith("@"):
-        return classify_tag(normalized, info)
+        validated_section = classify_tag(normalized.lstrip("@"), info)
+        if not validate_artist_tags or validated_section.value == "artist":
+            return classify_tag(normalized, info)
+        return classify_tag(normalized.lstrip("@"), None)
     return classify_tag(normalized, info)
 
 
@@ -168,11 +172,19 @@ def inspect_prompt(
         normalized = normalize_tag(syntax.tag_text)
         key = lookup_key(normalized)
         info = kb.lookup(normalized)
-        manual_known = key in override_keys
-        preserve_override_text = manual_known
+        explicit_artist = (
+            normalized.strip().startswith("@")
+            and key not in exclusion_keys
+        )
+        manual_known = (
+            key in override_keys
+            or (explicit_artist and not validate_artist_tags)
+        )
+        preserve_override_text = key in override_keys
         section = _classify_with_artist_options(
             normalized,
             info=info,
+            validate_artist_tags=validate_artist_tags,
             artist_overrides=override_keys,
             artist_exclusions=exclusion_keys,
         )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -52959,33 +52959,33 @@
           },
           {
             "async": false,
-            "end_line": 143,
+            "end_line": 147,
             "kind": "function",
             "line": 129,
-            "loc": 15,
+            "loc": 19,
             "qualified_name": "_classify_with_artist_options"
           },
           {
             "async": false,
-            "end_line": 217,
+            "end_line": 229,
             "kind": "function",
-            "line": 146,
-            "loc": 72,
+            "line": 150,
+            "loc": 80,
             "qualified_name": "inspect_prompt"
           },
           {
             "async": false,
-            "end_line": 275,
+            "end_line": 287,
             "kind": "function",
-            "line": 220,
+            "line": 232,
             "loc": 56,
             "qualified_name": "correct_prompt"
           }
         ],
         "is_package": false,
-        "loc": 275,
+        "loc": 287,
         "module": "easyuse_anima.prompt.anima.correction",
-        "normalized_git_blob_sha1": "8423904dbfed4d46030a689f0db9f54912976682",
+        "normalized_git_blob_sha1": "aa386be64f20c13e08fa4085ed95ab65b805643d",
         "path": "easyuse_anima/prompt/anima/correction.py",
         "top_level": {
           "class_count": 1,

--- a/tests/fixtures/python_support_ownership_contract.v1.json
+++ b/tests/fixtures/python_support_ownership_contract.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "baseline_commit": "a0b0dc1f599fcf01ec0f25fc75a23f7524f165ab",
   "inventory": {
-    "expected_files": 208,
+    "expected_files": 209,
     "manual_matrix_source": "tests/fixtures/python_test_ownership_contract.v1.json",
     "patterns": [
       "tests/**/*.json",
@@ -932,6 +932,17 @@
         "prompt"
       ],
       "purpose": "Deterministic Node smoke contract for frontend prompt studio execution projection smoke."
+    },
+    {
+      "execution_mode": "node-smoke",
+      "generated": false,
+      "kind": "test",
+      "owner": "tests/frontend_prompt_studio_highlight_revision_smoke.mjs",
+      "path": "tests/frontend_prompt_studio_highlight_revision_smoke.mjs",
+      "production_groups": [
+        "prompt"
+      ],
+      "purpose": "Deterministic Node smoke contract for text-owned Prompt Studio highlight revisions."
     },
     {
       "execution_mode": "node-smoke",

--- a/tests/frontend_prompt_studio_classic_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_classic_values_smoke.mjs
@@ -48,10 +48,14 @@ const nodeHooksUrl = dataModule(
   },
 );
 const { registerPromptStudioNodeHooks } = await import(nodeHooksUrl);
+const highlightRevisionUrl = dataModule(
+  "../web/js/prompt_studio/highlight_revision.js",
+);
 const highlightUiUrl = dataModule(
   "../web/js/prompt_studio/highlight_ui.js",
   {
     "./highlight.js": highlightUrl,
+    "./highlight_revision.js": highlightRevisionUrl,
     "./settings.js": settingsUrl,
     "./widgets.js": highlightWidgetsUrl,
   },

--- a/tests/frontend_prompt_studio_highlight_revision_smoke.mjs
+++ b/tests/frontend_prompt_studio_highlight_revision_smoke.mjs
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../web/js/prompt_studio/highlight_revision.js", import.meta.url),
+  "utf8",
+);
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+const {
+  highlightRequestOwnsText,
+  highlightTokensForText,
+} = await import(moduleUrl);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const tokensA = [{ token: "text A", section: "general" }];
+assert(
+  highlightTokensForText("text A", "text A", tokensA) === tokensA,
+  "Matching text must keep its classification token identity",
+);
+assert(
+  highlightTokensForText("text B", "text A", tokensA).length === 0,
+  "Pasted text must not render the previous text token cache",
+);
+assert(
+  highlightTokensForText("text A", "text A", null).length === 0,
+  "Malformed token caches must fail closed",
+);
+
+const requestA = { sequence: 1, text: "text A" };
+assert(
+  highlightRequestOwnsText(requestA, 1, "text A"),
+  "Matching sequence and text must own the highlight result",
+);
+assert(
+  !highlightRequestOwnsText(requestA, 1, "text B"),
+  "A response must become stale as soon as paste changes the text",
+);
+assert(
+  !highlightRequestOwnsText(requestA, 2, "text A"),
+  "A superseded request sequence must not publish",
+);
+assert(
+  !highlightRequestOwnsText(requestA, 1, "text A", false),
+  "A disconnected textarea must not receive a result",
+);
+
+const requestB = { sequence: 2, text: "text B" };
+const requestC = { sequence: 3, text: "text C" };
+assert(
+  !highlightRequestOwnsText(requestA, 3, "text C")
+    && !highlightRequestOwnsText(requestB, 3, "text C")
+    && highlightRequestOwnsText(requestC, 3, "text C"),
+  "Rapid A to B to C input must leave only C as the publishing owner",
+);
+
+console.log("Prompt Studio highlight revision smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -125,6 +125,12 @@ PROMPT_STUDIO_HIGHLIGHT_CORE_JS = PROMPT_STUDIO_MODULES / "highlight_core.js"
 PROMPT_STUDIO_HIGHLIGHT_OVERLAY_CORE_JS = (
     PROMPT_STUDIO_MODULES / "highlight_overlay_core.js"
 )
+PROMPT_STUDIO_HIGHLIGHT_REVISION_JS = (
+    PROMPT_STUDIO_MODULES / "highlight_revision.js"
+)
+PROMPT_STUDIO_HIGHLIGHT_REVISION_SMOKE = (
+    ROOT / "tests" / "frontend_prompt_studio_highlight_revision_smoke.mjs"
+)
 PROMPT_STUDIO_REGIONAL_JS = WEB_JS / "easyuse_anima_prompt_studio_regional.js"
 PROMPT_STUDIO_REGIONAL_MODULES = PROMPT_STUDIO_MODULES / "regional"
 PROMPT_STUDIO_REGIONAL_PURE_DATA_SMOKE = (
@@ -2584,6 +2590,37 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(export=name):
                 self.assertIn(f"  {name},", core_source)
 
+    def test_prompt_highlight_revisions_are_text_owned_across_studio_surfaces(self):
+        revision_source = PROMPT_STUDIO_HIGHLIGHT_REVISION_JS.read_text(
+            encoding="utf-8"
+        )
+        classic_overlay_source = (
+            PROMPT_STUDIO_MODULES / "highlight_ui.js"
+        ).read_text(encoding="utf-8")
+        classic_request_source = (
+            PROMPT_STUDIO_MODULES / "studio_node_ui.js"
+        ).read_text(encoding="utf-8")
+        advanced_source = (
+            PROMPT_STUDIO_MODULES / "advanced_highlights.js"
+        ).read_text(encoding="utf-8")
+        regional_source = PROMPT_STUDIO_REGIONAL_ADAPTER_JS.read_text(
+            encoding="utf-8"
+        )
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(PROMPT_STUDIO_HIGHLIGHT_REVISION_SMOKE.is_file())
+        self.assertIn("function highlightTokensForText", revision_source)
+        self.assertIn("function highlightRequestOwnsText", revision_source)
+        self.assertIn("highlightTokensForText(", classic_overlay_source)
+        self.assertIn("highlightRequestOwnsText(", classic_request_source)
+        for source in (advanced_source, regional_source):
+            self.assertIn("highlightTokensForText(", source)
+            self.assertIn("highlightRequestOwnsText(", source)
+        self.assertIn(
+            r'node "tests\frontend_prompt_studio_highlight_revision_smoke.mjs"',
+            frontend_check_source,
+        )
+
     def test_regional_pure_data_modules_own_dom_free_rules(self):
         entry_source = PROMPT_STUDIO_REGIONAL_JS.read_text(encoding="utf-8")
         adapter_source = PROMPT_STUDIO_REGIONAL_ADAPTER_JS.read_text(
@@ -3760,6 +3797,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "fields.js",
             "highlight_core.js",
             "highlight_overlay_core.js",
+            "highlight_revision.js",
             "highlight_ui.js",
             "legend.js",
             "naia_projection.js",

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -49,6 +49,7 @@ from easyuse_anima.prompt import artist_mix as prompt_artist_mix
 from easyuse_anima.prompt import conditioning as prompt_conditioning
 from easyuse_anima.prompt import contracts as prompt_contracts
 from easyuse_anima.prompt import correction as prompt_correction
+from easyuse_anima.prompt.anima import inspect_prompt
 from easyuse_anima.prompt import data as prompt_data_service
 from easyuse_anima.prompt.advanced import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,
@@ -144,6 +145,47 @@ class PromptCorrectorTests(unittest.TestCase):
         self.assertEqual(corrected, "1girl, long hair")
         data = json.loads(report)
         self.assertEqual(data["duplicate_tags"], ["long hair"])
+
+    def test_unvalidated_explicit_artist_is_known_and_not_reported_unknown(self):
+        corrected, report = EasyUseAnimaPromptCorrector().correct(
+            "general_subject, (@unregistered_artist:0.5), descriptive phrase",
+            "",
+            "",
+        )
+
+        self.assertEqual(
+            corrected,
+            "(@unregistered artist:0.5), general subject, descriptive phrase",
+        )
+        data = json.loads(report)
+        self.assertEqual(data["sections"], ["artist", "unknown", "unknown"])
+        self.assertEqual(
+            data["unknown_tags"],
+            ["general subject", "descriptive phrase"],
+        )
+        self.assertNotIn("@unregistered artist", " ".join(data["warnings"]))
+
+        unvalidated = inspect_prompt(
+            "@unregistered_artist",
+            validate_artist_tags=False,
+        )
+        validated = inspect_prompt(
+            "@unregistered_artist",
+            validate_artist_tags=True,
+        )
+        excluded = inspect_prompt(
+            "@unregistered_artist",
+            validate_artist_tags=False,
+            artist_exclusions=("unregistered_artist",),
+        )
+        self.assertTrue(unvalidated.tokens[0].known)
+        self.assertEqual(unvalidated.tokens[0].section.value, "artist")
+        self.assertEqual(unvalidated.unknown_tags, ())
+        self.assertFalse(validated.tokens[0].known)
+        self.assertEqual(validated.tokens[0].section.value, "unknown")
+        self.assertEqual(validated.unknown_tags, ("@unregistered artist",))
+        self.assertFalse(excluded.tokens[0].known)
+        self.assertEqual(excluded.tokens[0].section.value, "unknown")
 
     def test_prompt_translation_marker_translates_only_wrapped_text(self):
         def fake_translate(text, source="auto", target="en"):

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -219,6 +219,11 @@ try {
         throw "Frontend Prompt Studio paste autosize smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_highlight_revision_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio highlight revision smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_wildcard_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend standalone Wildcard populated-text smoke failed with exit code $LASTEXITCODE."

--- a/web/js/prompt_studio/advanced_highlights.js
+++ b/web/js/prompt_studio/advanced_highlights.js
@@ -16,6 +16,10 @@ import {
   applyPromptStudioTextStyle,
 } from "./settings.js";
 import {
+  highlightRequestOwnsText,
+  highlightTokensForText,
+} from "./highlight_revision.js";
+import {
   getAdvancedEditorElement,
   getAdvancedFields,
 } from "./state.js";
@@ -68,7 +72,12 @@ function updateAdvancedFieldHighlight(node, field, textarea, tokens = null, forc
     copyInputTextMetrics(textarea, overlay);
   }
   syncOverlayBounds(textarea, overlay);
-  overlay.innerHTML = highlightOverlayHtml(value, tokens || state.tokens || [], textarea.placeholder || "", textarea);
+  const currentTokens = highlightTokensForText(
+    value,
+    state.lastText,
+    tokens || state.tokens || [],
+  );
+  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, textarea.placeholder || "", textarea);
 }
 
 function scheduleAdvancedFieldHighlight(node, field, textarea) {
@@ -92,10 +101,16 @@ function scheduleAdvancedFieldHighlight(node, field, textarea) {
 
   const seq = ++state.seq;
   state.pendingText = text;
+  const request = { sequence: seq, text };
   updateAdvancedFieldHighlight(node, field, textarea, state.tokens);
   classifyPrompt(text)
     .then((tokens) => {
-      if (seq !== state.seq || !textarea.isConnected) {
+      if (!highlightRequestOwnsText(
+        request,
+        state.seq,
+        textarea.value,
+        textarea.isConnected,
+      )) {
         return;
       }
       state.lastText = text;
@@ -103,7 +118,12 @@ function scheduleAdvancedFieldHighlight(node, field, textarea) {
       updateAdvancedFieldHighlight(node, field, textarea, tokens);
     })
     .catch(() => {
-      if (seq !== state.seq || !textarea.isConnected) {
+      if (!highlightRequestOwnsText(
+        request,
+        state.seq,
+        textarea.value,
+        textarea.isConnected,
+      )) {
         return;
       }
       state.tokens = [];
@@ -161,7 +181,12 @@ function refreshAdvancedHighlights(node, { classify = true, forceCopyMetrics = f
 
     const state = advancedHighlightState(node, field);
     const value = String(textarea.value || "");
-    const htmlContent = highlightOverlayHtml(value, state.tokens || [], textarea.placeholder || "", textarea);
+    const htmlContent = highlightOverlayHtml(
+      value,
+      highlightTokensForText(value, state.lastText, state.tokens),
+      textarea.placeholder || "",
+      textarea,
+    );
 
     updates.push({
       overlay,

--- a/web/js/prompt_studio/highlight_revision.js
+++ b/web/js/prompt_studio/highlight_revision.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+/**
+ * Return classification tokens only when they belong to the current text.
+ *
+ * @param {unknown} currentText
+ * @param {unknown} classifiedText
+ * @param {unknown} tokens
+ * @returns {any[]}
+ */
+function highlightTokensForText(currentText, classifiedText, tokens) {
+  if (String(currentText ?? "") !== String(classifiedText ?? "")) {
+    return [];
+  }
+  return Array.isArray(tokens) ? tokens : [];
+}
+
+/**
+ * Check both request sequence and text revision before publishing a result.
+ *
+ * @param {Object} request
+ * @param {number} request.sequence
+ * @param {unknown} request.text
+ * @param {number} currentSequence
+ * @param {unknown} currentText
+ * @param {boolean} [connected]
+ */
+function highlightRequestOwnsText(
+  request,
+  currentSequence,
+  currentText,
+  connected = true,
+) {
+  return connected
+    && request.sequence === currentSequence
+    && String(request.text ?? "") === String(currentText ?? "");
+}
+
+export {
+  highlightRequestOwnsText,
+  highlightTokensForText,
+};

--- a/web/js/prompt_studio/highlight_ui.js
+++ b/web/js/prompt_studio/highlight_ui.js
@@ -10,6 +10,9 @@ import {
   applyPromptStudioTextStyle,
 } from "./settings.js";
 import {
+  highlightTokensForText,
+} from "./highlight_revision.js";
+import {
   findInputEl,
   isWidgetInputLinked,
 } from "./widgets.js";
@@ -47,7 +50,12 @@ function updateHighlight(node, widget, tokens = widget.__easyuseAnimaTokens || [
   }
   syncOverlayBounds(input, overlay);
   const value = displayText(node, widget);
-  overlay.innerHTML = highlightOverlayHtml(value, tokens, input.placeholder || "", input);
+  const currentTokens = highlightTokensForText(
+    value,
+    widget.__easyuseAnimaLastClassifiedText,
+    tokens,
+  );
+  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, input.placeholder || "", input);
 }
 
 export {

--- a/web/js/prompt_studio/regional/editor_adapter.js
+++ b/web/js/prompt_studio/regional/editor_adapter.js
@@ -8,6 +8,10 @@ import {
   createHighlightOverlayRenderer,
   syncOverlayBounds,
 } from "../highlight_overlay_core.js";
+import {
+  highlightRequestOwnsText,
+  highlightTokensForText,
+} from "../highlight_revision.js";
 import { PROMPT_STUDIO_VARIANT_FIELD_LABELS } from "./constants.js";
 import { registerExternalAutocompleteInput } from "../../autocomplete/entry_lifecycle.js";
 
@@ -1297,7 +1301,12 @@ export function updatePromptStudioFieldHighlight(node, field, textarea, tokens =
     copyInputTextMetrics(textarea, overlay);
   }
   syncOverlayBounds(textarea, overlay);
-  overlay.innerHTML = highlightOverlayHtml(value, tokens || state.tokens || [], textarea.placeholder || "", textarea);
+  const currentTokens = highlightTokensForText(
+    value,
+    state.lastText,
+    tokens || state.tokens || [],
+  );
+  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, textarea.placeholder || "", textarea);
 }
 
 export function schedulePromptStudioFieldHighlight(node, field, textarea, { namespace = "variant" } = {}) {
@@ -1321,10 +1330,16 @@ export function schedulePromptStudioFieldHighlight(node, field, textarea, { name
 
   const seq = ++state.seq;
   state.pendingText = text;
+  const request = { sequence: seq, text };
   updatePromptStudioFieldHighlight(node, field, textarea, state.tokens, false, namespace);
   classifyPrompt(text)
     .then((tokens) => {
-      if (seq !== state.seq || !textarea.isConnected) {
+      if (!highlightRequestOwnsText(
+        request,
+        state.seq,
+        textarea.value,
+        textarea.isConnected,
+      )) {
         return;
       }
       state.lastText = text;
@@ -1332,7 +1347,12 @@ export function schedulePromptStudioFieldHighlight(node, field, textarea, { name
       updatePromptStudioFieldHighlight(node, field, textarea, tokens, false, namespace);
     })
     .catch(() => {
-      if (seq !== state.seq || !textarea.isConnected) {
+      if (!highlightRequestOwnsText(
+        request,
+        state.seq,
+        textarea.value,
+        textarea.isConnected,
+      )) {
         return;
       }
       state.tokens = [];

--- a/web/js/prompt_studio/studio_node_ui.js
+++ b/web/js/prompt_studio/studio_node_ui.js
@@ -7,6 +7,9 @@ import {
   displayText,
 } from "./highlight_ui.js";
 import {
+  highlightRequestOwnsText,
+} from "./highlight_revision.js";
+import {
   psText,
 } from "./text.js";
 import {
@@ -67,15 +70,27 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
 
       const seq = ++classifySeq;
       widget.__easyuseAnimaPendingClassifyText = text;
+      const request = { sequence: seq, text };
       try {
         const tokens = await classifyPrompt(text);
-        if (seq !== classifySeq) {
+        if (!highlightRequestOwnsText(
+          request,
+          classifySeq,
+          displayText(node, widget),
+        )) {
           return;
         }
         widget.__easyuseAnimaLastClassifiedText = text;
         widget.__easyuseAnimaTokens = tokens;
         updateHighlight(node, widget, tokens);
       } catch {
+        if (!highlightRequestOwnsText(
+          request,
+          classifySeq,
+          displayText(node, widget),
+        )) {
+          return;
+        }
         widget.__easyuseAnimaTokens = [];
         updateHighlight(node, widget);
       } finally {


### PR DESCRIPTION
## 목적과 변경 경계

Prompt Corrector가 명시적 `@artist`를 artist 섹션으로 정렬하면서 동시에 unknown으로 보고하던 모순을 제거합니다. Prompt Studio는 붙여넣기·빠른 교체 직후 이전 텍스트의 분류 토큰을 현재 입력에 표시하지 않도록 분류 결과의 텍스트 revision 소유권을 확인합니다.

Base → Head: `dev` → `codex/fix-prompt-corrector-highlight-sync`

## 주요 변경

- validation이 비활성화된 명시적 `@artist`를 known artist로 취급하고, validation/exclusion 동작은 유지
- Classic, Advanced/Advanced v2, Regional 하이라이트가 request sequence와 현재 textarea 원문을 함께 확인
- 현재 입력과 분류 원문이 다르면 이전 token cache 대신 무색 텍스트를 표시
- 공용 revision helper, Node smoke, Python 구조/교정기 regression test 추가
- analyzer/support-ownership fixture를 실제 변경분에 맞게 갱신

## 보존 계약

- 기존 섹션 정렬, manual artist override/exclusion, weight 구문과 자연어 unknown 정책 유지
- overlay 치수/스크롤, paste autosize, autocomplete, workflow serialization 로직 변경 없음
- 일반 태그·자연어 문장을 autocomplete DB로 새로 분류하지 않음

## 검증

- Prompt Corrector focused unittest: 16 passed
- 신규 revision smoke 및 Prompt Studio import/no-side-effect focused tests: passed
- Repository full (`0b43ba6`): 1,473 Python tests, 121 JavaScript/TypeScript frontend checks, paste autosize/overlay/revision smoke passed
- ComfyUI Codex test instance: source/install/served module 일치, 교정기 등록 확인
- 실제 queue: 명시적 `@artist`가 artist로 유지되고 unknown 목록에서 제외됨; history success/completed, running=0, pending=0
- Legacy canvas: 이전 분류 후 새 문자열 붙여넣기 직후 stale span 0, 응답 후 현재 문자열 span만 표시; EasyUse Anima console error 없음
- Node 2.0: modern-node switch on; Vue native textarea에서 붙여넣은 값 유지, EasyUse Anima console error 없음 (이 표면은 extension highlight overlay를 생성하지 않음)
- 시작 canvas 설정(Legacy) 복원 및 임시 workflow 정리 완료
- User v0.27.0 manual check: not run
- Package validation: not triggered (package/release 경계 변경 없음)

## 위험과 rollback

분류 적용 조건과 하이라이트 publication guard만 변경합니다. 회귀 시 이 PR의 단일 squash commit으로 되돌릴 수 있으며 저장 데이터 migration은 없습니다.

## Next

검토/CI 후 dev에 squash merge하고, main에는 이 변경만 최소 hotfix로 백포트한 뒤 별도 1.0.2 release metadata PR을 진행합니다.

Relates to #635
Relates to #636