### PR TITLE
[LoRA] 와일드카드가 반환한 태그의 Prompt Studio → AiO 적용 보장

### DIFF
--- a/docs/nodes/anima-prompt-studio-advanced.en.md
+++ b/docs/nodes/anima-prompt-studio-advanced.en.md
@@ -50,6 +50,9 @@ body only shows the current wildcard mode, seed, and seed control summary.
 - The live workflow keeps original wildcard text and the next seed state.
 - Saved-image workflows store expanded text in `재현` mode.
 - When NAIA fill is also enabled, NAIA text is applied before wildcard expansion.
+- When a wildcard in an Advanced v2 positive field emits a `<lora:...>` tag,
+  the tag becomes structured LoRA data. A connected `Anima AiO Generator`
+  applies it after the existing LoRA stack.
 
 See the [Wildcard Guide](../wildcards.en.md) for syntax.
 

--- a/docs/nodes/anima-prompt-studio-advanced.ko.md
+++ b/docs/nodes/anima-prompt-studio-advanced.ko.md
@@ -51,6 +51,9 @@
 - 저장 이미지 workflow는 확장 결과를 `재현` mode로 저장합니다.
 - NAIA 채우기와 같이 사용할 때는 NAIA 결과를 먼저 받은 뒤 와일드카드를
   확장합니다.
+- Advanced v2의 양성 필드에서 와일드카드가 `<lora:...>` 태그를 반환하면 태그를
+  구조화된 LoRA 정보로 변환합니다. 연결된 `Anima AiO Generator`는 이를 기존 LoRA
+  stack 뒤에 적용합니다.
 
 문법은 [와일드카드 가이드](../wildcards.ko.md)를 참고하세요.
 

--- a/docs/wildcards.en.md
+++ b/docs/wildcards.en.md
@@ -118,8 +118,27 @@ __style/anime__
 selection. Sequential mode counts it as one candidate and strips the `N::`
 prefix.
 
-`<lora:name:weight>` syntax is preserved as text. EasyUse Anima wildcard
-expansion does not apply LoRAs to MODEL or CLIP.
+The wildcard expander preserves `<lora:name:weight>` and
+`<lora:name:model_weight:clip_weight>` as text. How an expanded tag is handled
+depends on the connected node.
+
+- LoRA tags emitted in positive fields of `Anima Prompt Studio Advanced v2`
+  become structured LoRA data in `EASYUSE_ANIMA_PROMPT_DATA`. `Anima AiO
+  Generator` applies them after its existing LoRA stack.
+- `Anima Prompt Studio Advanced LoRA` and `Anima Wildcard LoRA` append expanded
+  tags to their input LoRA stack and return the result.
+- The standard `Anima Wildcard` node returns text only and does not directly
+  apply a LoRA to MODEL or CLIP.
+
+For example, a candidate in `prompt_lora.txt` may contain:
+
+```text
+<lora:styles/my-style:0.7:0.4>
+```
+
+When `__prompt_lora__` is used in a positive Prompt Studio Advanced v2 field,
+the expanded LoRA tag is removed from the final prompt text and carried as
+structured LoRA data.
 
 ## Modes
 

--- a/docs/wildcards.ko.md
+++ b/docs/wildcards.ko.md
@@ -117,8 +117,26 @@ __style/anime__
 `N::candidate`는 가중치 후보입니다. 일반 채우기에서는 가중치 기반 선택에
 사용되고, 순차 모드에서는 후보 1개로 계산한 뒤 `N::` prefix만 제거됩니다.
 
-`<lora:name:weight>` 형식은 텍스트로 보존합니다. EasyUse Anima 와일드카드는
-MODEL/CLIP에 LoRA를 직접 적용하지 않습니다.
+와일드카드 확장기는 `<lora:name:weight>` 또는
+`<lora:name:model_weight:clip_weight>` 형식을 텍스트로 보존합니다. 확장된 태그의
+처리는 연결한 노드에 따라 달라집니다.
+
+- `Anima Prompt Studio Advanced v2`의 양성 필드에서 나온 LoRA 태그는
+  `EASYUSE_ANIMA_PROMPT_DATA`의 구조화된 LoRA 정보로 변환되며, `Anima AiO
+  Generator`가 기존 LoRA stack 뒤에 적용합니다.
+- `Anima Prompt Studio Advanced LoRA`와 `Anima Wildcard LoRA`는 입력 LoRA stack
+  뒤에 확장 결과를 추가해 출력합니다.
+- 일반 `Anima Wildcard` 노드는 문자열만 출력하므로 MODEL/CLIP에 LoRA를 직접
+  적용하지 않습니다.
+
+예를 들어 `prompt_lora.txt`의 한 후보가 다음과 같다면:
+
+```text
+<lora:styles/my-style:0.7:0.4>
+```
+
+Prompt Studio Advanced v2의 양성 필드에서 `__prompt_lora__`를 사용했을 때 확장된
+LoRA 태그는 최종 프롬프트 문자열에서 제거되고 구조화된 LoRA 정보로 전달됩니다.
 
 ## 모드
 

--- a/tests/test_lora_prompt_syntax.py
+++ b/tests/test_lora_prompt_syntax.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -19,6 +20,7 @@ from easyuse_anima.nodes.wildcard_nodes import (
     EasyUseAnimaWildcardLora,
 )
 from easyuse_anima.registration import NODE_CLASS_MAPPINGS
+from easyuse_anima.settings import repository as settings_repository
 from easyuse_anima.settings import service as settings_service
 from easyuse_anima.settings.schema import (
     COMFY_SETTING_KEYS,
@@ -261,6 +263,72 @@ class LoraPromptNodeIntegrationTests(unittest.TestCase):
         self.assertNotIn(
             "<lora:",
             prompt_data["outputs"]["positive_prompt"].lower(),
+        )
+
+    def test_advanced_v2_applies_lora_emitted_by_file_wildcard_through_aio(self):
+        source = "subject, __prompt_lora__"
+        fields = [_field("positive", source)]
+        input_stack = [("base.safetensors", 0.9, 0.8)]
+
+        with tempfile.TemporaryDirectory() as temp:
+            wildcard_root = Path(temp)
+            (wildcard_root / "prompt_lora.txt").write_text(
+                "<lora:styles/wildcard-style:0.7:0.4>\n",
+                encoding="utf-8",
+            )
+            with (
+                patch.object(
+                    settings_repository,
+                    "get_settings",
+                    return_value={"wildcard.extra_paths": str(wildcard_root)},
+                ),
+                patch.object(
+                    prompt_syntax,
+                    "_lora_combo_values",
+                    return_value=[
+                        "None",
+                        "styles/wildcard-style.safetensors",
+                    ],
+                ),
+            ):
+                output = EasyUseAnimaPromptStudioAdvancedV2().build(
+                    **_advanced_build_kwargs(fields)
+                )
+                prompt_data = output["result"][0]
+                normalized, effective_stack = prompt_lora._prepare_aio_prompt_loras(
+                    prompt_data,
+                    input_stack,
+                    normalize_prompt_data=lambda value: value,
+                )
+
+        self.assertIs(normalized, prompt_data)
+        self.assertEqual(prompt_data["saved_fields"][0]["text"], source)
+        self.assertEqual(prompt_data["wildcard"]["used_keys"], ["prompt_lora"])
+        self.assertEqual(prompt_data["positive_prompt"], "subject")
+        self.assertEqual(prompt_data["fields"][0]["text"], "subject")
+        self.assertEqual(
+            prompt_data["lora"],
+            {
+                "syntax": "a1111",
+                "directives": [
+                    {
+                        "name": "styles/wildcard-style",
+                        "strength_model": 0.7,
+                        "strength_clip": 0.4,
+                    }
+                ],
+            },
+        )
+        self.assertEqual(
+            effective_stack,
+            [
+                *input_stack,
+                (
+                    os.path.join("styles", "wildcard-style.safetensors"),
+                    0.7,
+                    0.4,
+                ),
+            ],
         )
 
     def test_advanced_lora_reuses_advanced_contract_and_appends_stack(self):


### PR DESCRIPTION
## 목적과 변경 경계

Prompt Studio Advanced v2의 실제 파일형 와일드카드(`__name__`)가 `<lora:...>`를 반환할 때, 기존 실행 순서가 Prompt Data 구조화와 AiO LoRA stack 적용까지 유지되는지 회귀 테스트로 고정합니다.

이 PR은 #647에서 병합된 공통 LoRA 파서와 AiO adapter를 그대로 사용합니다. 별도 parser나 production 분기를 추가하지 않으며, 사용자 문서의 노드별 동작만 현재 구현과 맞춥니다.

Related: #645

## Base -> Head

- `dev` -> `codex/prompt-wildcard-lora`
- Base SHA: `955180d08eaf4cc1701f3a3052f5b67f9ba9e273`
- Head SHA: `a6f467b`

## 주요 변경

- 임시 wildcard 파일 `prompt_lora.txt`가 `<lora:styles/wildcard-style:0.7:0.4>`를 반환하는 실제 경로 검증
- 원본 `saved_fields`와 wildcard `used_keys` 보존 검증
- 실행 positive prompt에서 LoRA tag 제거 및 `EASYUSE_ANIMA_PROMPT_DATA.lora` 구조화 검증
- AiO의 기존 `LORA_STACK` 뒤에 wildcard LoRA가 model/clip 강도를 보존해 추가되는지 검증
- 한국어/영어 wildcard 및 Prompt Studio Advanced 문서를 표준 노드와 LoRA 지원 노드별 동작으로 정정

## 보존 계약

- 기존 Advanced v2 / AiO 공개 socket과 Prompt Data schema 변경 없음
- 일반 `Anima Wildcard`는 계속 text-only
- 기존 stack 항목의 순서와 identity 보존
- negative field 및 `<|>` 계열 문법 처리 변경 없음
- 공통 wildcard expansion과 공통 LoRA parser만 사용

## 검증

- Focused:
  - `tests.test_lora_prompt_syntax.LoraPromptNodeIntegrationTests.test_advanced_v2_applies_lora_emitted_by_file_wildcard_through_aio`
  - 1 test passed (non-sandbox; 실제 temporary wildcard file)
- Official full gate at `a6f467b`:
  - Python unittest: 1,495 passed
  - Frontend: 121 JavaScript files passed
  - Pyright baseline, import boundary, size/complexity, disposition, support ownership, git diff: passed
  - Ruff: 기존 report-only 26건

## 위험과 rollback

Production code 변경은 없습니다. 회귀 테스트 또는 설명이 잘못된 경우 이 커밋만 되돌리면 되며 runtime 동작에는 영향이 없습니다.

## Next

리뷰 후 병합되면 `dev`의 v1.1.0 release 후보 범위를 확정하고, release metadata/changelog는 별도 rollback 경계로 준비합니다.