### PR TITLE
feat: add isolated Anima 2.9B model and legacy LoRA support

### DIFF
--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 from typing import Any
 
+from ..anima_29b.lora import _apply_anima_29b_aio_lora_stack
 from ..common.serialization import _stable_change_key
 from ..common.values import _as_bool, _as_float, _as_int
 from ..infrastructure.comfy.invocation import (
@@ -379,6 +380,10 @@ def _apply_aio_lora_stack(model, clip, lora_stack):
     entries = _normalize_aio_lora_stack(lora_stack)
     if not entries:
         return model, clip, []
+
+    model_specific_result = _apply_anima_29b_aio_lora_stack(model, clip, entries)
+    if model_specific_result is not None:
+        return model_specific_result
 
     loader_cls = _find_comfy_node_class("LoraLoader")
     if loader_cls is None:

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..anima_29b.architecture import _load_model_with_anima_29b_support
 from ..common.values import _as_int, _choice
 from ..image.sam3 import _sam3_context
 from ..infrastructure.comfy.invocation import _node_output_tuple
@@ -157,10 +158,15 @@ def _load_diffusion_model_with_comfy(unet_name: str, weight_dtype: str = "defaul
     method = getattr(loader, "load_unet", None)
     if method is None:
         raise RuntimeError("[EasyUseAnima] UNETLoader does not expose load_unet.")
-    values = _node_output_tuple(method(str(unet_name), str(weight_dtype or "default")))
-    if not values:
-        raise RuntimeError("[EasyUseAnima] UNETLoader returned no MODEL.")
-    return values[0]
+    def load_model():
+        values = _node_output_tuple(
+            method(str(unet_name), str(weight_dtype or "default"))
+        )
+        if not values:
+            raise RuntimeError("[EasyUseAnima] UNETLoader returned no MODEL.")
+        return values[0]
+
+    return _load_model_with_anima_29b_support(load_model)
 
 
 def _load_vae_with_comfy(vae_name: str):

--- a/easyuse_anima/anima_29b/__init__.py
+++ b/easyuse_anima/anima_29b/__init__.py
@@ -1,0 +1,3 @@
+"""Isolated Anima 2.9B model-loading and LoRA compatibility feature."""
+
+__all__ = ()

--- a/easyuse_anima/anima_29b/architecture.py
+++ b/easyuse_anima/anima_29b/architecture.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import wraps
-from threading import RLock
+from threading import RLock, get_ident
 
 ANIMA_BASE_BLOCK_COUNT = 28
 ANIMA_29B_BLOCK_COUNT = 40
@@ -74,10 +74,13 @@ def _scoped_anima_29b_model_detection():
         if not callable(previous):
             yield
             return
+        owner_thread = get_ident()
 
         @wraps(previous)
         def detect_unet_config(state_dict, key_prefix, *args, **kwargs):
             config = previous(state_dict, key_prefix, *args, **kwargs)
+            if get_ident() != owner_thread:
+                return config
             return _patch_anima_29b_detected_config(
                 config,
                 state_dict,
@@ -108,9 +111,16 @@ def _is_anima_29b_model(model) -> bool:
     )
 
 
-def _reload_anima_29b_model(factory, factory_args, **kwargs):
+def _reload_anima_29b_model(
+    factory,
+    factory_args,
+    factory_result_index=None,
+    **kwargs,
+):
     with _scoped_anima_29b_model_detection():
         model = factory(*factory_args, **kwargs)
+    if factory_result_index is not None:
+        model = model[factory_result_index]
     return _install_anima_29b_cached_reload(model)
 
 
@@ -120,16 +130,19 @@ def _install_anima_29b_cached_reload(model):
     if not _is_anima_29b_model(model):
         return model
     cached = getattr(model, "cached_patcher_init", None)
-    if not isinstance(cached, tuple) or len(cached) != 2:
+    if not isinstance(cached, tuple) or len(cached) not in {2, 3}:
         return model
-    factory, factory_args = cached
+    factory, factory_args, *selector = cached
     if factory is _reload_anima_29b_model:
         return model
     if not callable(factory) or not isinstance(factory_args, (list, tuple)):
         return model
+    factory_result_index = selector[0] if selector else None
+    if factory_result_index is not None and not isinstance(factory_result_index, int):
+        return model
     model.cached_patcher_init = (
         _reload_anima_29b_model,
-        (factory, tuple(factory_args)),
+        (factory, tuple(factory_args), factory_result_index),
     )
     return model
 

--- a/easyuse_anima/anima_29b/architecture.py
+++ b/easyuse_anima/anima_29b/architecture.py
@@ -1,0 +1,143 @@
+"""Scoped ComfyUI compatibility for the 40-block Anima 2.9B architecture."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from functools import wraps
+from threading import RLock
+
+ANIMA_BASE_BLOCK_COUNT = 28
+ANIMA_29B_BLOCK_COUNT = 40
+# New-index positions recorded by the model's expand_manifest.json.
+ANIMA_29B_INSERTION_POSITIONS = (
+    2,
+    5,
+    8,
+    11,
+    14,
+    17,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+)
+ANIMA_29B_LEGACY_BLOCK_MAP = tuple(
+    block_index
+    for block_index in range(ANIMA_29B_BLOCK_COUNT)
+    if block_index not in ANIMA_29B_INSERTION_POSITIONS
+)
+
+_DETECTION_LOCK = RLock()
+
+
+def _state_dict_anima_block_count(state_dict, key_prefix: str = "") -> int | None:
+    prefix = f"{key_prefix}blocks."
+    indices: set[int] = set()
+    for raw_key in state_dict:
+        key = str(raw_key)
+        if not key.startswith(prefix):
+            continue
+        block_text = key[len(prefix):].partition(".")[0]
+        if block_text.isdigit():
+            indices.add(int(block_text))
+    if indices == set(range(ANIMA_29B_BLOCK_COUNT)):
+        return ANIMA_29B_BLOCK_COUNT
+    return None
+
+
+def _patch_anima_29b_detected_config(config, state_dict, key_prefix: str):
+    if not isinstance(config, dict) or config.get("image_model") != "anima":
+        return config
+    if _state_dict_anima_block_count(state_dict, key_prefix) != ANIMA_29B_BLOCK_COUNT:
+        return config
+    if config.get("num_blocks") == ANIMA_29B_BLOCK_COUNT:
+        return config
+    patched = dict(config)
+    patched["num_blocks"] = ANIMA_29B_BLOCK_COUNT
+    return patched
+
+
+@contextmanager
+def _scoped_anima_29b_model_detection():
+    """Patch model detection only while EasyUse loads an AiO diffusion model."""
+
+    try:
+        from comfy import model_detection  # type: ignore
+    except ImportError:
+        yield
+        return
+
+    with _DETECTION_LOCK:
+        previous = getattr(model_detection, "detect_unet_config", None)
+        if not callable(previous):
+            yield
+            return
+
+        @wraps(previous)
+        def detect_unet_config(state_dict, key_prefix, *args, **kwargs):
+            config = previous(state_dict, key_prefix, *args, **kwargs)
+            return _patch_anima_29b_detected_config(
+                config,
+                state_dict,
+                str(key_prefix or ""),
+            )
+
+        model_detection.detect_unet_config = detect_unet_config
+        try:
+            yield
+        finally:
+            if getattr(model_detection, "detect_unet_config", None) is detect_unet_config:
+                model_detection.detect_unet_config = previous
+
+
+def _anima_unet_config(model):
+    base_model = getattr(model, "model", model)
+    model_config = getattr(base_model, "model_config", None)
+    config = getattr(model_config, "unet_config", None)
+    return config if isinstance(config, dict) else None
+
+
+def _is_anima_29b_model(model) -> bool:
+    config = _anima_unet_config(model)
+    return bool(
+        config
+        and config.get("image_model") == "anima"
+        and config.get("num_blocks") == ANIMA_29B_BLOCK_COUNT
+    )
+
+
+def _reload_anima_29b_model(factory, factory_args, **kwargs):
+    with _scoped_anima_29b_model_detection():
+        model = factory(*factory_args, **kwargs)
+    return _install_anima_29b_cached_reload(model)
+
+
+def _install_anima_29b_cached_reload(model):
+    """Keep 40-block detection active when ComfyUI deep-clones a disk-backed model."""
+
+    if not _is_anima_29b_model(model):
+        return model
+    cached = getattr(model, "cached_patcher_init", None)
+    if not isinstance(cached, tuple) or len(cached) != 2:
+        return model
+    factory, factory_args = cached
+    if factory is _reload_anima_29b_model:
+        return model
+    if not callable(factory) or not isinstance(factory_args, (list, tuple)):
+        return model
+    model.cached_patcher_init = (
+        _reload_anima_29b_model,
+        (factory, tuple(factory_args)),
+    )
+    return model
+
+
+def _load_model_with_anima_29b_support(loader):
+    with _scoped_anima_29b_model_detection():
+        model = loader()
+    return _install_anima_29b_cached_reload(model)
+
+
+__all__ = ()

--- a/easyuse_anima/anima_29b/lora.py
+++ b/easyuse_anima/anima_29b/lora.py
@@ -1,0 +1,212 @@
+"""Legacy 28-block Anima LoRA adaptation for the 40-block Anima 2.9B model."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from ..infrastructure.comfy.invocation import _call_with_supported_kwargs
+from .architecture import (
+    ANIMA_29B_LEGACY_BLOCK_MAP,
+    ANIMA_BASE_BLOCK_COUNT,
+    _is_anima_29b_model,
+)
+
+ANIMA_29B_LORA_LAYOUT_AUTO = "auto"
+ANIMA_29B_LORA_LAYOUT_LEGACY = "legacy_28_block"
+
+_ANIMA_FLAT_BLOCK_KEY = re.compile(
+    r"^(?P<prefix>lora_unet_{1,2}blocks_)(?P<index>\d+)(?P<suffix>_.+)$"
+)
+_ANIMA_DOTTED_BLOCK_KEYS = (
+    re.compile(
+        r"^(?P<prefix>(?:model\.)?diffusion_model\.blocks\.)"
+        r"(?P<index>\d+)(?P<suffix>\..+)$"
+    ),
+    re.compile(r"^(?P<prefix>blocks\.)(?P<index>\d+)(?P<suffix>\..+)$"),
+)
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+
+def _anima_lora_block_match(key: str):
+    match = _ANIMA_FLAT_BLOCK_KEY.match(key)
+    if match is not None:
+        return match
+    for pattern in _ANIMA_DOTTED_BLOCK_KEYS:
+        match = pattern.match(key)
+        if match is not None:
+            return match
+    return None
+
+
+def _anima_lora_block_indices(state_dict: Mapping[str, Any]) -> set[int]:
+    indices: set[int] = set()
+    for raw_key in state_dict:
+        match = _anima_lora_block_match(str(raw_key))
+        if match is not None:
+            indices.add(int(match.group("index")))
+    return indices
+
+
+def _remap_legacy_anima_lora_key(key: str) -> str:
+    match = _anima_lora_block_match(key)
+    if match is None:
+        return key
+    old_index = int(match.group("index"))
+    if old_index < 0 or old_index >= ANIMA_BASE_BLOCK_COUNT:
+        return key
+    new_index = ANIMA_29B_LEGACY_BLOCK_MAP[old_index]
+    prefix = match.group("prefix")
+    suffix = match.group("suffix")
+    if prefix.startswith("lora_unet_"):
+        return f"lora_unet_blocks_{new_index}{suffix}"
+    return f"diffusion_model.blocks.{new_index}{suffix}"
+
+
+def _prepare_anima_29b_lora_state_dict(
+    state_dict: Mapping[str, Any],
+    source_layout: str = ANIMA_29B_LORA_LAYOUT_AUTO,
+) -> tuple[dict[str, Any], int]:
+    if source_layout not in {
+        ANIMA_29B_LORA_LAYOUT_AUTO,
+        ANIMA_29B_LORA_LAYOUT_LEGACY,
+    }:
+        raise ValueError(f"Unsupported Anima 2.9B LoRA source layout: {source_layout}")
+
+    indices = _anima_lora_block_indices(state_dict)
+    if source_layout == ANIMA_29B_LORA_LAYOUT_AUTO and any(
+        index >= ANIMA_BASE_BLOCK_COUNT for index in indices
+    ):
+        return dict(state_dict), 0
+    if (
+        source_layout == ANIMA_29B_LORA_LAYOUT_AUTO
+        and indices
+        and indices != set(range(ANIMA_BASE_BLOCK_COUNT))
+    ):
+        raise RuntimeError(
+            "[EasyUseAnima] This Anima 2.9B LoRA layout is ambiguous: it only "
+            "contains part of blocks 0-27. Use the dedicated Anima 2.9B legacy "
+            "LoRA stack node when the LoRA is known to target original Anima, "
+            "or the regular ComfyUI LoRA loader for a native 2.9B LoRA."
+        )
+    if source_layout == ANIMA_29B_LORA_LAYOUT_LEGACY and any(
+        index >= ANIMA_BASE_BLOCK_COUNT for index in indices
+    ):
+        raise RuntimeError(
+            "[EasyUseAnima] This LoRA already contains Anima 2.9B block indices. "
+            "Apply it with the regular ComfyUI LoRA loader instead."
+        )
+
+    remapped: dict[str, Any] = {}
+    remapped_count = 0
+    for raw_key, value in state_dict.items():
+        key = str(raw_key)
+        new_key = _remap_legacy_anima_lora_key(key)
+        remapped[new_key] = value
+        if new_key != key:
+            remapped_count += 1
+    return remapped, remapped_count
+
+
+def _load_lora_file(lora_name: str):
+    import folder_paths  # type: ignore
+    from comfy import utils as comfy_utils  # type: ignore
+
+    lora_path = folder_paths.get_full_path_or_raise("loras", lora_name)
+    loaded = _call_with_supported_kwargs(
+        comfy_utils.load_torch_file,
+        (lora_path,),
+        {"safe_load": True, "return_metadata": True},
+        "ComfyUI load_torch_file",
+    )
+    if isinstance(loaded, tuple) and len(loaded) == 2:
+        state_dict, metadata = loaded
+    else:
+        state_dict, metadata = loaded, None
+    if not isinstance(state_dict, Mapping):
+        raise RuntimeError(
+            f"[EasyUseAnima] LoRA file did not contain a state dictionary: {lora_name}"
+        )
+    return state_dict, metadata
+
+
+def _apply_anima_29b_lora_stack(
+    model,
+    clip,
+    entries,
+    *,
+    source_layout: str = ANIMA_29B_LORA_LAYOUT_AUTO,
+):
+    if not _is_anima_29b_model(model):
+        raise RuntimeError(
+            "[EasyUseAnima] Anima 2.9B LoRA conversion requires a 40-block "
+            "Anima MODEL."
+        )
+
+    active_entries = [
+        (str(name), float(model_strength), float(clip_strength))
+        for name, model_strength, clip_strength in entries
+        if model_strength != 0 or clip_strength != 0
+    ]
+    if not active_entries:
+        return model, clip, []
+
+    from comfy import sd as comfy_sd  # type: ignore
+
+    patched_model = model
+    patched_clip = clip
+    applied: list[dict[str, Any]] = []
+    for name, model_strength, clip_strength in active_entries:
+        state_dict, metadata = _load_lora_file(name)
+        converted, remapped_count = _prepare_anima_29b_lora_state_dict(
+            state_dict,
+            source_layout,
+        )
+        result = _call_with_supported_kwargs(
+            comfy_sd.load_lora_for_models,
+            (
+                patched_model,
+                patched_clip,
+                converted,
+                model_strength,
+                clip_strength,
+            ),
+            {"lora_metadata": metadata},
+            "ComfyUI load_lora_for_models",
+        )
+        if not isinstance(result, (list, tuple)) or len(result) < 2:
+            raise RuntimeError(
+                "[EasyUseAnima] ComfyUI LoRA loader returned no MODEL/CLIP pair."
+            )
+        patched_model, patched_clip = result[0], result[1]
+        if remapped_count:
+            logger.info(
+                "[EasyUseAnima] Anima 2.9B remapped %d legacy LoRA keys for %s.",
+                remapped_count,
+                name,
+            )
+        applied.append(
+            {
+                "name": name,
+                "strength_model": model_strength,
+                "strength_clip": clip_strength,
+            }
+        )
+    return patched_model, patched_clip, applied
+
+
+def _apply_anima_29b_aio_lora_stack(model, clip, entries):
+    if not _is_anima_29b_model(model):
+        return None
+    return _apply_anima_29b_lora_stack(
+        model,
+        clip,
+        entries,
+        source_layout=ANIMA_29B_LORA_LAYOUT_AUTO,
+    )
+
+
+__all__ = ()

--- a/easyuse_anima/anima_29b/lora.py
+++ b/easyuse_anima/anima_29b/lora.py
@@ -133,6 +133,16 @@ def _load_lora_file(lora_name: str):
     return state_dict, metadata
 
 
+def _model_patch_entry_count(model) -> int | None:
+    patches = getattr(model, "patches", None)
+    if not isinstance(patches, Mapping):
+        return None
+    return sum(
+        len(entries) if isinstance(entries, (list, tuple)) else 1
+        for entries in patches.values()
+    )
+
+
 def _apply_anima_29b_lora_stack(
     model,
     clip,
@@ -161,10 +171,16 @@ def _apply_anima_29b_lora_stack(
     applied: list[dict[str, Any]] = []
     for name, model_strength, clip_strength in active_entries:
         state_dict, metadata = _load_lora_file(name)
+        block_indices = _anima_lora_block_indices(state_dict)
+        legacy_model_layout = bool(block_indices) and (
+            source_layout == ANIMA_29B_LORA_LAYOUT_LEGACY
+            or block_indices == set(range(ANIMA_BASE_BLOCK_COUNT))
+        )
         converted, remapped_count = _prepare_anima_29b_lora_state_dict(
             state_dict,
             source_layout,
         )
+        model_patch_count_before = _model_patch_entry_count(patched_model)
         result = _call_with_supported_kwargs(
             comfy_sd.load_lora_for_models,
             (
@@ -182,6 +198,18 @@ def _apply_anima_29b_lora_stack(
                 "[EasyUseAnima] ComfyUI LoRA loader returned no MODEL/CLIP pair."
             )
         patched_model, patched_clip = result[0], result[1]
+        model_patch_count_after = _model_patch_entry_count(patched_model)
+        if (
+            legacy_model_layout
+            and model_strength != 0
+            and model_patch_count_before is not None
+            and model_patch_count_after is not None
+            and model_patch_count_after <= model_patch_count_before
+        ):
+            raise RuntimeError(
+                "[EasyUseAnima] ComfyUI accepted no legacy Anima 2.9B MODEL "
+                f"patches from LoRA: {name}"
+            )
         if remapped_count:
             logger.info(
                 "[EasyUseAnima] Anima 2.9B remapped %d legacy LoRA keys for %s.",

--- a/easyuse_anima/nodes/anima_29b_nodes.py
+++ b/easyuse_anima/nodes/anima_29b_nodes.py
@@ -1,0 +1,63 @@
+"""ComfyUI adapters for the isolated Anima 2.9B compatibility feature."""
+
+from __future__ import annotations
+
+from ..anima_29b.lora import (
+    ANIMA_29B_LORA_LAYOUT_LEGACY,
+    _apply_anima_29b_lora_stack,
+)
+from ..lora.prompt_syntax import _normalize_lora_stack
+
+
+class EasyUseAnima29BLoraStackLoader:
+    """Apply legacy 28-block Anima LoRAs to an Anima 2.9B model patcher."""
+
+    DESCRIPTION = (
+        "Experimentally remaps a regular 28-block Anima LoRA stack onto the 28 "
+        "inherited block positions of Anima 2.9B. Results can differ from the "
+        "original model; native 2.9B LoRA training is recommended."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Anima 2.9B model with the experimental legacy LoRA remap applied.",
+        "CLIP model with any text-encoder LoRA patches applied.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (
+                    "MODEL",
+                    {
+                        "tooltip": "A 40-block Anima 2.9B diffusion model loaded by Easy Use Anima."
+                    },
+                ),
+                "clip": (
+                    "CLIP",
+                    {"tooltip": "The CLIP model paired with the Anima model."},
+                ),
+                "lora_stack": (
+                    "LORA_STACK",
+                    {
+                        "tooltip": "A regular 28-block Anima LoRA stack to remap experimentally and apply in order."
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL", "CLIP")
+    RETURN_NAMES = ("model", "clip")
+    FUNCTION = "apply"
+    CATEGORY = "EasyUse Anima/LoRA"
+
+    def apply(self, model, clip, lora_stack):
+        patched_model, patched_clip, _applied = _apply_anima_29b_lora_stack(
+            model,
+            clip,
+            _normalize_lora_stack(lora_stack),
+            source_layout=ANIMA_29B_LORA_LAYOUT_LEGACY,
+        )
+        return patched_model, patched_clip
+
+
+__all__ = ("EasyUseAnima29BLoraStackLoader",)

--- a/easyuse_anima/registration.py
+++ b/easyuse_anima/registration.py
@@ -2,6 +2,7 @@
 
 from .nodes.aio_hook_nodes import EasyUseAnimaAIOHookCombine
 from .nodes.aio_nodes import EasyUseAnimaAIOGenerator, EasyUseAnimaInput
+from .nodes.anima_29b_nodes import EasyUseAnima29BLoraStackLoader
 from .nodes.image_nodes import (
     EasyUseAnimaDetailerAlignHook,
     EasyUseAnimaImageScaleByMultiple,
@@ -31,6 +32,7 @@ from .nodes.regional_nodes import (
 from .nodes.wildcard_nodes import EasyUseAnimaWildcard, EasyUseAnimaWildcardLora
 
 NODE_CLASS_MAPPINGS = {
+    "EasyUseAnima29BLoraStackLoader": EasyUseAnima29BLoraStackLoader,
     "EasyUseAnimaAIOGenerator": EasyUseAnimaAIOGenerator,
     "EasyUseAnimaAIOHookCombine": EasyUseAnimaAIOHookCombine,
     "EasyUseAnimaDetailerAlignHook": EasyUseAnimaDetailerAlignHook,
@@ -55,6 +57,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
+    "EasyUseAnima29BLoraStackLoader": "Anima 2.9B LoRA Stack Loader",
     "EasyUseAnimaAIOGenerator": "Anima AiO Generator",
     "EasyUseAnimaAIOHookCombine": "Anima AiO Hook Combine",
     "EasyUseAnimaDetailerAlignHook": "Anima Detailer Align Hook",

--- a/locales/ja/nodeDefs.json
+++ b/locales/ja/nodeDefs.json
@@ -820,6 +820,34 @@
       }
     }
   },
+  "EasyUseAnima29BLoraStackLoader": {
+    "display_name": "Anima 2.9B LoRA スタックローダー",
+    "description": "通常の28ブロック Anima LoRA スタックを、Anima 2.9B の継承ブロック位置へ実験的に再マッピングします。元モデルと結果が異なる可能性があるため、ネイティブ2.9B LoRA の学習を推奨します。",
+    "inputs": {
+      "model": {
+        "name": "モデル",
+        "tooltip": "Easy Use Anima で読み込んだ40ブロック Anima 2.9B 拡散モデルです。"
+      },
+      "clip": {
+        "name": "CLIP",
+        "tooltip": "Anima モデルと組み合わせる CLIP モデルです。"
+      },
+      "lora_stack": {
+        "name": "LoRA スタック",
+        "tooltip": "順番に実験的な再マッピングを行って適用する通常の28ブロック Anima LoRA スタックです。"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "モデル",
+        "tooltip": "レガシー LoRA ブロックを実験的に再マッピングした Anima 2.9B モデルです。"
+      },
+      "1": {
+        "name": "CLIP",
+        "tooltip": "テキストエンコーダーの LoRA パッチを適用した CLIP モデルです。"
+      }
+    }
+  },
   "EasyUseAnimaLoraPreset": {
     "display_name": "Anima LoRA プリセット",
     "description": "複数の ANIMA LoRA プリセットプロファイルを保存し、LoRA スタックとトリガーワードを作成し、プロファイルデータをワークフローに保持します。",

--- a/locales/ko/nodeDefs.json
+++ b/locales/ko/nodeDefs.json
@@ -835,6 +835,34 @@
       }
     }
   },
+  "EasyUseAnima29BLoraStackLoader": {
+    "display_name": "Anima 2.9B LoRA 스택 로더",
+    "description": "일반 28블록 Anima LoRA 스택을 Anima 2.9B의 원본 계승 블록 위치에 실험적으로 재매핑합니다. 원본 모델과 결과가 다를 수 있으며 네이티브 2.9B LoRA 학습을 권장합니다.",
+    "inputs": {
+      "model": {
+        "name": "모델",
+        "tooltip": "Easy Use Anima로 로드한 40블록 Anima 2.9B 확산 모델입니다."
+      },
+      "clip": {
+        "name": "CLIP",
+        "tooltip": "Anima 모델과 함께 사용하는 CLIP 모델입니다."
+      },
+      "lora_stack": {
+        "name": "LoRA 스택",
+        "tooltip": "순서대로 실험적 재매핑 후 적용할 일반 28블록 Anima LoRA 스택입니다."
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "모델",
+        "tooltip": "기존 LoRA 블록이 실험적으로 재매핑된 Anima 2.9B 모델입니다."
+      },
+      "1": {
+        "name": "CLIP",
+        "tooltip": "텍스트 인코더 LoRA 패치가 적용된 CLIP 모델입니다."
+      }
+    }
+  },
   "EasyUseAnimaLoraPreset": {
     "display_name": "Anima LoRA 프리셋",
     "description": "여러 ANIMA LoRA 프리셋 프로필을 저장하고, LoRA 스택과 트리거 워드를 만들며, 프로필 데이터를 워크플로우에 보존합니다.",

--- a/locales/zh-CN/nodeDefs.json
+++ b/locales/zh-CN/nodeDefs.json
@@ -820,6 +820,34 @@
       }
     }
   },
+  "EasyUseAnima29BLoraStackLoader": {
+    "display_name": "Anima 2.9B LoRA 堆栈加载器",
+    "description": "将普通的28层 Anima LoRA 堆栈实验性地重映射到 Anima 2.9B 的继承层位置。结果可能与原模型不同，建议训练原生2.9B LoRA。",
+    "inputs": {
+      "model": {
+        "name": "模型",
+        "tooltip": "由 Easy Use Anima 加载的40层 Anima 2.9B 扩散模型。"
+      },
+      "clip": {
+        "name": "CLIP",
+        "tooltip": "与 Anima 模型配套使用的 CLIP 模型。"
+      },
+      "lora_stack": {
+        "name": "LoRA 堆栈",
+        "tooltip": "按顺序进行实验性重映射并应用的普通28层 Anima LoRA 堆栈。"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "模型",
+        "tooltip": "已实验性重映射旧版 LoRA 层的 Anima 2.9B 模型。"
+      },
+      "1": {
+        "name": "CLIP",
+        "tooltip": "已应用文本编码器 LoRA 补丁的 CLIP 模型。"
+      }
+    }
+  },
   "EasyUseAnimaLoraPreset": {
     "display_name": "Anima LoRA 预设",
     "description": "保存多个 ANIMA LoRA 预设配置，构建 LoRA 堆栈和触发词，并在工作流中保留配置数据。",

--- a/locales/zh/nodeDefs.json
+++ b/locales/zh/nodeDefs.json
@@ -820,6 +820,34 @@
       }
     }
   },
+  "EasyUseAnima29BLoraStackLoader": {
+    "display_name": "Anima 2.9B LoRA 堆栈加载器",
+    "description": "将普通的28层 Anima LoRA 堆栈实验性地重映射到 Anima 2.9B 的继承层位置。结果可能与原模型不同，建议训练原生2.9B LoRA。",
+    "inputs": {
+      "model": {
+        "name": "模型",
+        "tooltip": "由 Easy Use Anima 加载的40层 Anima 2.9B 扩散模型。"
+      },
+      "clip": {
+        "name": "CLIP",
+        "tooltip": "与 Anima 模型配套使用的 CLIP 模型。"
+      },
+      "lora_stack": {
+        "name": "LoRA 堆栈",
+        "tooltip": "按顺序进行实验性重映射并应用的普通28层 Anima LoRA 堆栈。"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "模型",
+        "tooltip": "已实验性重映射旧版 LoRA 层的 Anima 2.9B 模型。"
+      },
+      "1": {
+        "name": "CLIP",
+        "tooltip": "已应用文本编码器 LoRA 补丁的 CLIP 模型。"
+      }
+    }
+  },
   "EasyUseAnimaLoraPreset": {
     "display_name": "Anima LoRA 预设",
     "description": "保存多个 ANIMA LoRA 预设配置，构建 LoRA 堆栈和触发词，并在工作流中保留配置数据。",

--- a/tests/fixtures/node_contracts_0_5_2.json
+++ b/tests/fixtures/node_contracts_0_5_2.json
@@ -140,6 +140,44 @@
   ],
   "nodes": [
     {
+      "category": "EasyUse Anima/LoRA",
+      "class_name": "EasyUseAnima29BLoraStackLoader",
+      "display_name": "Anima 2.9B LoRA Stack Loader",
+      "function": "apply",
+      "id": "EasyUseAnima29BLoraStackLoader",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "model",
+              "type": "MODEL"
+            },
+            {
+              "config": {},
+              "name": "clip",
+              "type": "CLIP"
+            },
+            {
+              "config": {},
+              "name": "lora_stack",
+              "type": "LORA_STACK"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "model",
+        "clip"
+      ],
+      "return_types": [
+        "MODEL",
+        "CLIP"
+      ]
+    },
+    {
       "category": "EasyUse Anima/AiO",
       "class_name": "EasyUseAnimaAIOGenerator",
       "display_name": "Anima AiO Generator",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8453,6 +8453,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_apply_anima_29b_aio_lora_stack",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..anima_29b.lora:_apply_anima_29b_aio_lora_stack",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_apply_anima_29b_aio_lora_stack",
+        "optional": false,
+        "requested": "..anima_29b.lora",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_stable_change_key",
         "branch_context": [],
         "classification": "internal",
@@ -8460,7 +8478,7 @@
         "conditional": false,
         "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "..common.serialization",
@@ -8478,7 +8496,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -8496,7 +8514,7 @@
         "conditional": false,
         "imported": "..common.values:_as_float",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_as_float",
         "optional": false,
         "requested": "..common.values",
@@ -8514,7 +8532,7 @@
         "conditional": false,
         "imported": "..common.values:_as_int",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_as_int",
         "optional": false,
         "requested": "..common.values",
@@ -8532,7 +8550,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -8550,7 +8568,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -8568,7 +8586,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -8586,7 +8604,7 @@
         "conditional": false,
         "imported": "..lora.prompt_syntax:_normalize_lora_stack",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "_normalize_lora_stack",
         "optional": false,
         "requested": "..lora.prompt_syntax",
@@ -8604,7 +8622,7 @@
         "conditional": false,
         "imported": ".generation_lifecycle:StageModelPatchPlan",
         "kind": "static_from",
-        "line": 17,
+        "line": 18,
         "name": "StageModelPatchPlan",
         "optional": false,
         "requested": ".generation_lifecycle",
@@ -8622,7 +8640,7 @@
         "conditional": false,
         "imported": ".generation_migrations:AIO_GENERATION_STAGE_IDS",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "AIO_GENERATION_STAGE_IDS",
         "optional": false,
         "requested": ".generation_migrations",
@@ -8640,7 +8658,7 @@
         "conditional": false,
         "imported": ".generation_migrations:AIO_MODEL_PATCH_ORDER_REVISION",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "AIO_MODEL_PATCH_ORDER_REVISION",
         "optional": false,
         "requested": ".generation_migrations",
@@ -8658,7 +8676,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 474
+            "line": 479
           }
         ],
         "classification": "external",
@@ -8666,7 +8684,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 475,
+        "line": 480,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -9894,6 +9912,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_load_model_with_anima_29b_support",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..anima_29b.architecture:_load_model_with_anima_29b_support",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_load_model_with_anima_29b_support",
+        "optional": false,
+        "requested": "..anima_29b.architecture",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_as_int",
         "branch_context": [],
         "classification": "internal",
@@ -9901,7 +9937,7 @@
         "conditional": false,
         "imported": "..common.values:_as_int",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "_as_int",
         "optional": false,
         "requested": "..common.values",
@@ -9919,7 +9955,7 @@
         "conditional": false,
         "imported": "..common.values:_choice",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "_choice",
         "optional": false,
         "requested": "..common.values",
@@ -9937,7 +9973,7 @@
         "conditional": false,
         "imported": "..image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_sam3_context",
         "optional": false,
         "requested": "..image.sam3",
@@ -9955,7 +9991,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -9973,7 +10009,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -9991,7 +10027,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 13,
+        "line": 14,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -10009,7 +10045,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 16,
+        "line": 17,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -10027,7 +10063,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -10045,7 +10081,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 22,
+        "line": 23,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -10063,7 +10099,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -10081,7 +10117,7 @@
         "conditional": false,
         "imported": ".generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".generation_normalization",
@@ -10099,7 +10135,7 @@
         "conditional": false,
         "imported": ".input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".input_defaults",
@@ -10117,7 +10153,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10135,7 +10171,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10153,7 +10189,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10171,7 +10207,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10189,7 +10225,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10207,7 +10243,7 @@
         "conditional": false,
         "imported": ".input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": ".input_defaults",
@@ -10225,7 +10261,7 @@
         "conditional": false,
         "imported": ".input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": ".input_defaults",
@@ -10243,7 +10279,7 @@
         "conditional": false,
         "imported": ".input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": ".input_defaults",
@@ -10259,7 +10295,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 212,
+            "line": 218,
             "type_checking": false
           },
           {
@@ -10267,7 +10303,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 213
+            "line": 219
           }
         ],
         "classification": "external",
@@ -10275,7 +10311,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 214,
+        "line": 220,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -10913,6 +10949,307 @@
         "scope": "<module>",
         "source": "easyuse_anima/aio/usdu.py",
         "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 5,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wraps",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "functools:wraps",
+        "kind": "static_from",
+        "line": 6,
+        "name": "wraps",
+        "optional": false,
+        "requested": "functools",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "RLock",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading:RLock",
+        "kind": "static_from",
+        "line": 7,
+        "name": "RLock",
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "model_detection",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 66
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy:model_detection",
+        "kind": "static_from",
+        "line": 67,
+        "name": "model_detection",
+        "optional": true,
+        "requested": "comfy",
+        "role": "optional_dependency",
+        "scope": "_scoped_anima_29b_model_detection",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_call_with_supported_kwargs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_call_with_supported_kwargs",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_call_with_supported_kwargs",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_29B_LEGACY_BLOCK_MAP",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".architecture:ANIMA_29B_LEGACY_BLOCK_MAP",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ANIMA_29B_LEGACY_BLOCK_MAP",
+        "optional": false,
+        "requested": ".architecture",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py",
+        "target": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_BASE_BLOCK_COUNT",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".architecture:ANIMA_BASE_BLOCK_COUNT",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ANIMA_BASE_BLOCK_COUNT",
+        "optional": false,
+        "requested": ".architecture",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py",
+        "target": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_is_anima_29b_model",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".architecture:_is_anima_29b_model",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_is_anima_29b_model",
+        "optional": false,
+        "requested": ".architecture",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/lora.py",
+        "target": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [],
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 115,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "role": "ordinary",
+        "scope": "_load_lora_file",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": "comfy_utils",
+        "bound_name": "comfy_utils",
+        "branch_context": [],
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "comfy:utils",
+        "kind": "static_from",
+        "line": 116,
+        "name": "utils",
+        "optional": false,
+        "requested": "comfy",
+        "role": "ordinary",
+        "scope": "_load_lora_file",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": "comfy_sd",
+        "bound_name": "comfy_sd",
+        "branch_context": [],
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "comfy:sd",
+        "kind": "static_from",
+        "line": 157,
+        "name": "sd",
+        "optional": false,
+        "requested": "comfy",
+        "role": "ordinary",
+        "scope": "_apply_anima_29b_lora_stack",
+        "source": "easyuse_anima/anima_29b/lora.py"
       },
       {
         "alias": null,
@@ -20377,6 +20714,77 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/aio_nodes.py",
         "target": "easyuse_anima/nodes/seed_adapters.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/anima_29b_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_29B_LORA_LAYOUT_LEGACY",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..anima_29b.lora:ANIMA_29B_LORA_LAYOUT_LEGACY",
+        "kind": "static_from",
+        "line": 5,
+        "name": "ANIMA_29B_LORA_LAYOUT_LEGACY",
+        "optional": false,
+        "requested": "..anima_29b.lora",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "target": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_anima_29b_lora_stack",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..anima_29b.lora:_apply_anima_29b_lora_stack",
+        "kind": "static_from",
+        "line": 5,
+        "name": "_apply_anima_29b_lora_stack",
+        "optional": false,
+        "requested": "..anima_29b.lora",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "target": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_lora_stack",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..lora.prompt_syntax:_normalize_lora_stack",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_normalize_lora_stack",
+        "optional": false,
+        "requested": "..lora.prompt_syntax",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "target": "easyuse_anima/lora/prompt_syntax.py"
       },
       {
         "alias": null,
@@ -35727,6 +36135,24 @@
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnima29BLoraStackLoader",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes.anima_29b_nodes:EasyUseAnima29BLoraStackLoader",
+        "kind": "static_from",
+        "line": 5,
+        "name": "EasyUseAnima29BLoraStackLoader",
+        "optional": false,
+        "requested": ".nodes.anima_29b_nodes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/registration.py",
+        "target": "easyuse_anima/nodes/anima_29b_nodes.py"
+      },
+      {
+        "alias": null,
         "bound_name": "EasyUseAnimaDetailerAlignHook",
         "branch_context": [],
         "classification": "internal",
@@ -35734,7 +36160,7 @@
         "conditional": false,
         "imported": ".nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".nodes.image_nodes",
@@ -35752,7 +36178,7 @@
         "conditional": false,
         "imported": ".nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".nodes.image_nodes",
@@ -35770,7 +36196,7 @@
         "conditional": false,
         "imported": ".nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".nodes.lora_nodes",
@@ -35788,7 +36214,7 @@
         "conditional": false,
         "imported": ".nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".nodes.naia_nodes",
@@ -35806,7 +36232,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".nodes.prompt_advanced_nodes",
@@ -35824,7 +36250,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".nodes.prompt_advanced_nodes",
@@ -35842,7 +36268,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".nodes.prompt_data_nodes",
@@ -35860,7 +36286,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".nodes.prompt_data_nodes",
@@ -35878,7 +36304,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".nodes.prompt_data_nodes",
@@ -35896,7 +36322,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_lora_nodes:EasyUseAnimaPromptStudioAdvancedLora",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "EasyUseAnimaPromptStudioAdvancedLora",
         "optional": false,
         "requested": ".nodes.prompt_lora_nodes",
@@ -35914,7 +36340,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".nodes.prompt_nodes",
@@ -35932,7 +36358,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".nodes.prompt_nodes",
@@ -35950,7 +36376,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".nodes.prompt_nodes",
@@ -35968,7 +36394,7 @@
         "conditional": false,
         "imported": ".nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 21,
+        "line": 22,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".nodes.prompt_nodes",
@@ -35986,7 +36412,7 @@
         "conditional": false,
         "imported": ".nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".nodes.regional_nodes",
@@ -36004,7 +36430,7 @@
         "conditional": false,
         "imported": ".nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".nodes.regional_nodes",
@@ -36022,7 +36448,7 @@
         "conditional": false,
         "imported": ".nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".nodes.wildcard_nodes",
@@ -36040,7 +36466,7 @@
         "conditional": false,
         "imported": ".nodes.wildcard_nodes:EasyUseAnimaWildcardLora",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "EasyUseAnimaWildcardLora",
         "optional": false,
         "requested": ".nodes.wildcard_nodes",
@@ -41447,6 +41873,10 @@
       },
       {
         "from": "easyuse_anima/aio/model_preparation.py",
+        "to": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "from": "easyuse_anima/aio/model_preparation.py",
         "to": "easyuse_anima/common/serialization.py"
       },
       {
@@ -41555,6 +41985,10 @@
       },
       {
         "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
         "to": "easyuse_anima/common/values.py"
       },
       {
@@ -41616,6 +42050,14 @@
       {
         "from": "easyuse_anima/aio/usdu.py",
         "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/anima_29b/lora.py",
+        "to": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "from": "easyuse_anima/anima_29b/lora.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
         "from": "easyuse_anima/api/application.py",
@@ -42128,6 +42570,14 @@
       {
         "from": "easyuse_anima/nodes/aio_nodes.py",
         "to": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "to": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "to": "easyuse_anima/lora/prompt_syntax.py"
       },
       {
         "from": "easyuse_anima/nodes/artist_mix_conditioning_adapter.py",
@@ -42967,6 +43417,10 @@
       },
       {
         "from": "easyuse_anima/registration.py",
+        "to": "easyuse_anima/nodes/anima_29b_nodes.py"
+      },
+      {
+        "from": "easyuse_anima/registration.py",
         "to": "easyuse_anima/nodes/image_nodes.py"
       },
       {
@@ -43526,6 +43980,24 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/anima_29b/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/anima_29b/architecture.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/anima_29b/lora.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/__init__.py"
         ]
       },
@@ -43917,6 +44389,12 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/nodes/aio_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/nodes/anima_29b_nodes.py"
         ]
       },
       {
@@ -44384,7 +44862,7 @@
     ]
   },
   "inventory": {
-    "module_count": 191,
+    "module_count": 195,
     "modules": [
       {
         "functions": [
@@ -46879,201 +47357,201 @@
         "functions": [
           {
             "async": false,
-            "end_line": 50,
+            "end_line": 51,
             "kind": "function",
-            "line": 37,
+            "line": 38,
             "loc": 14,
             "qualified_name": "_aio_safe_pag_in_stage"
           },
           {
             "async": false,
-            "end_line": 60,
+            "end_line": 61,
             "kind": "function",
-            "line": 53,
+            "line": 54,
             "loc": 8,
             "qualified_name": "_aio_sage_attention_mode"
           },
           {
             "async": false,
-            "end_line": 75,
+            "end_line": 76,
             "kind": "function",
-            "line": 63,
+            "line": 64,
             "loc": 13,
             "qualified_name": "_aio_sage_attention_in_stage"
           },
           {
             "async": false,
-            "end_line": 90,
+            "end_line": 91,
             "kind": "function",
-            "line": 78,
+            "line": 79,
             "loc": 13,
             "qualified_name": "_aio_stage_kj_settings"
           },
           {
             "async": false,
-            "end_line": 96,
+            "end_line": 97,
             "kind": "function",
-            "line": 93,
+            "line": 94,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 104,
+            "end_line": 105,
             "kind": "function",
-            "line": 99,
+            "line": 100,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 116,
+            "end_line": 117,
             "kind": "function",
-            "line": 107,
+            "line": 108,
             "loc": 10,
             "qualified_name": "_require_custom_node_class"
           },
           {
             "async": false,
-            "end_line": 128,
+            "end_line": 129,
             "kind": "function",
-            "line": 119,
+            "line": 120,
             "loc": 10,
             "qualified_name": "_require_any_custom_node_class"
           },
           {
             "async": false,
-            "end_line": 164,
+            "end_line": 165,
             "kind": "function",
-            "line": 131,
+            "line": 132,
             "loc": 34,
             "qualified_name": "_require_aio_sage_attention_class"
           },
           {
             "async": false,
-            "end_line": 185,
+            "end_line": 186,
             "kind": "function",
-            "line": 167,
+            "line": 168,
             "loc": 19,
             "qualified_name": "_patch_model_sampling_aura_flow"
           },
           {
             "async": false,
-            "end_line": 219,
+            "end_line": 220,
             "kind": "function",
-            "line": 188,
+            "line": 189,
             "loc": 32,
             "qualified_name": "_apply_aio_kj_non_compile_patches"
           },
           {
             "async": false,
-            "end_line": 248,
+            "end_line": 249,
             "kind": "function",
-            "line": 222,
+            "line": 223,
             "loc": 27,
             "qualified_name": "_apply_aio_kj_torch_compile_patch"
           },
           {
             "async": false,
-            "end_line": 253,
+            "end_line": 254,
             "kind": "function",
-            "line": 251,
+            "line": 252,
             "loc": 3,
             "qualified_name": "_apply_aio_kj_model_patches"
           },
           {
             "async": false,
-            "end_line": 322,
+            "end_line": 323,
             "kind": "function",
-            "line": 256,
+            "line": 257,
             "loc": 67,
             "qualified_name": "_aio_stage_model_patch_plan"
           },
           {
             "async": false,
-            "end_line": 357,
+            "end_line": 358,
             "kind": "function",
-            "line": 325,
+            "line": 326,
             "loc": 33,
             "qualified_name": "_apply_aio_stage_model_patch_plan"
           },
           {
             "async": false,
-            "end_line": 362,
+            "end_line": 363,
             "kind": "function",
-            "line": 360,
+            "line": 361,
             "loc": 3,
             "qualified_name": "_apply_aio_model_patches"
           },
           {
             "async": false,
-            "end_line": 375,
+            "end_line": 376,
             "kind": "function",
-            "line": 365,
+            "line": 366,
             "loc": 11,
             "qualified_name": "_aio_lora_stack_signature"
           },
           {
             "async": false,
-            "end_line": 410,
+            "end_line": 415,
             "kind": "function",
-            "line": 378,
-            "loc": 33,
+            "line": 379,
+            "loc": 37,
             "qualified_name": "_apply_aio_lora_stack"
           },
           {
             "async": false,
-            "end_line": 434,
+            "end_line": 439,
             "kind": "function",
-            "line": 413,
+            "line": 418,
             "loc": 22,
             "qualified_name": "_apply_aio_anima_dave_patch"
           },
           {
             "async": false,
-            "end_line": 459,
+            "end_line": 464,
             "kind": "function",
-            "line": 437,
+            "line": 442,
             "loc": 23,
             "qualified_name": "_apply_aio_safe_pag_patch"
           },
           {
             "async": false,
-            "end_line": 484,
+            "end_line": 489,
             "kind": "function",
-            "line": 462,
+            "line": 467,
             "loc": 23,
             "qualified_name": "_cleanup_aio_ephemeral_model"
           },
           {
             "async": false,
-            "end_line": 545,
+            "end_line": 550,
             "kind": "function",
-            "line": 487,
+            "line": 492,
             "loc": 59,
             "qualified_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler"
           },
           {
             "async": false,
-            "end_line": 592,
+            "end_line": 597,
             "kind": "function",
-            "line": 548,
+            "line": 553,
             "loc": 45,
             "qualified_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler"
           },
           {
             "async": false,
-            "end_line": 610,
+            "end_line": 615,
             "kind": "function",
-            "line": 595,
+            "line": 600,
             "loc": 16,
             "qualified_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler"
           }
         ],
         "is_package": false,
-        "loc": 613,
+        "loc": 618,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "1e8374f3e9bc816edfa1d60c1369bd88fc8fc129",
+        "normalized_git_blob_sha1": "bf7c225f4b9d586102816c633d0f531ffb2e6001",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
@@ -47591,145 +48069,153 @@
         "functions": [
           {
             "async": false,
-            "end_line": 41,
+            "end_line": 42,
             "kind": "function",
-            "line": 38,
+            "line": 39,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 49,
+            "end_line": 50,
             "kind": "function",
-            "line": 44,
+            "line": 45,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 82,
+            "end_line": 83,
             "kind": "function",
-            "line": 52,
+            "line": 53,
             "loc": 31,
             "qualified_name": "_normalize_aio_input_settings"
           },
           {
             "async": false,
-            "end_line": 89,
+            "end_line": 90,
             "kind": "function",
-            "line": 85,
+            "line": 86,
             "loc": 5,
             "qualified_name": "_comfy_diffusion_model_names"
           },
           {
             "async": false,
-            "end_line": 96,
+            "end_line": 97,
             "kind": "function",
-            "line": 92,
+            "line": 93,
             "loc": 5,
             "qualified_name": "_comfy_text_encoder_names"
           },
           {
             "async": false,
-            "end_line": 104,
+            "end_line": 105,
             "kind": "function",
-            "line": 99,
+            "line": 100,
             "loc": 6,
             "qualified_name": "_comfy_vae_names"
           },
           {
             "async": false,
-            "end_line": 111,
+            "end_line": 112,
             "kind": "function",
-            "line": 107,
+            "line": 108,
             "loc": 5,
             "qualified_name": "_comfy_clip_loader_types"
           },
           {
             "async": false,
-            "end_line": 128,
+            "end_line": 129,
             "kind": "function",
-            "line": 114,
+            "line": 115,
             "loc": 15,
             "qualified_name": "_preferred_name_default"
           },
           {
             "async": false,
-            "end_line": 132,
+            "end_line": 133,
             "kind": "function",
-            "line": 131,
+            "line": 132,
             "loc": 2,
             "qualified_name": "_preferred_checkpoint_default"
           },
           {
             "async": false,
-            "end_line": 138,
+            "end_line": 139,
             "kind": "function",
-            "line": 135,
+            "line": 136,
             "loc": 4,
             "qualified_name": "_preferred_clip_type_default"
           },
           {
             "async": false,
-            "end_line": 149,
+            "end_line": 150,
             "kind": "function",
-            "line": 141,
+            "line": 142,
             "loc": 9,
             "qualified_name": "_load_checkpoint_with_comfy"
           },
           {
             "async": false,
-            "end_line": 163,
+            "end_line": 169,
             "kind": "function",
-            "line": 152,
-            "loc": 12,
+            "line": 153,
+            "loc": 17,
             "qualified_name": "_load_diffusion_model_with_comfy"
           },
           {
             "async": false,
-            "end_line": 177,
+            "end_line": 167,
             "kind": "function",
-            "line": 166,
+            "line": 161,
+            "loc": 7,
+            "qualified_name": "_load_diffusion_model_with_comfy.load_model"
+          },
+          {
+            "async": false,
+            "end_line": 183,
+            "kind": "function",
+            "line": 172,
             "loc": 12,
             "qualified_name": "_load_vae_with_comfy"
           },
           {
             "async": false,
-            "end_line": 201,
+            "end_line": 207,
             "kind": "function",
-            "line": 180,
+            "line": 186,
             "loc": 22,
             "qualified_name": "_load_clip_with_comfy"
           },
           {
             "async": false,
-            "end_line": 230,
+            "end_line": 236,
             "kind": "function",
-            "line": 204,
+            "line": 210,
             "loc": 27,
             "qualified_name": "_load_upscale_model_with_comfy"
           },
           {
             "async": false,
-            "end_line": 239,
+            "end_line": 245,
             "kind": "function",
-            "line": 233,
+            "line": 239,
             "loc": 7,
             "qualified_name": "_load_aio_sam3_context"
           },
           {
             "async": false,
-            "end_line": 288,
+            "end_line": 294,
             "kind": "function",
-            "line": 242,
+            "line": 248,
             "loc": 47,
             "qualified_name": "_load_aio_resources_from_input_context"
           }
         ],
         "is_package": false,
-        "loc": 291,
+        "loc": 297,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "9ff098a3d36070b9ad87a8810b08dc7e5ac002a1",
+        "normalized_git_blob_sha1": "f63385eb8ecb993ed0190e9e13f186a9fccd4588",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
@@ -48055,6 +48541,175 @@
           "class_count": 0,
           "function_count": 2,
           "global_count": 1
+        }
+      },
+      {
+        "functions": [],
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.anima_29b",
+        "normalized_git_blob_sha1": "d79d7b870ba5571fba66fcf29dec107626786ef2",
+        "path": "easyuse_anima/anima_29b/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 47,
+            "kind": "function",
+            "line": 35,
+            "loc": 13,
+            "qualified_name": "_state_dict_anima_block_count"
+          },
+          {
+            "async": false,
+            "end_line": 59,
+            "kind": "function",
+            "line": 50,
+            "loc": 10,
+            "qualified_name": "_patch_anima_29b_detected_config"
+          },
+          {
+            "async": false,
+            "end_line": 92,
+            "kind": "function",
+            "line": 62,
+            "loc": 31,
+            "qualified_name": "_scoped_anima_29b_model_detection"
+          },
+          {
+            "async": false,
+            "end_line": 85,
+            "kind": "function",
+            "line": 78,
+            "loc": 8,
+            "qualified_name": "_scoped_anima_29b_model_detection.detect_unet_config"
+          },
+          {
+            "async": false,
+            "end_line": 99,
+            "kind": "function",
+            "line": 95,
+            "loc": 5,
+            "qualified_name": "_anima_unet_config"
+          },
+          {
+            "async": false,
+            "end_line": 108,
+            "kind": "function",
+            "line": 102,
+            "loc": 7,
+            "qualified_name": "_is_anima_29b_model"
+          },
+          {
+            "async": false,
+            "end_line": 114,
+            "kind": "function",
+            "line": 111,
+            "loc": 4,
+            "qualified_name": "_reload_anima_29b_model"
+          },
+          {
+            "async": false,
+            "end_line": 134,
+            "kind": "function",
+            "line": 117,
+            "loc": 18,
+            "qualified_name": "_install_anima_29b_cached_reload"
+          },
+          {
+            "async": false,
+            "end_line": 140,
+            "kind": "function",
+            "line": 137,
+            "loc": 4,
+            "qualified_name": "_load_model_with_anima_29b_support"
+          }
+        ],
+        "is_package": false,
+        "loc": 143,
+        "module": "easyuse_anima.anima_29b.architecture",
+        "normalized_git_blob_sha1": "0794dd06dc05e5b7985121edc0d2fce93be2f0c1",
+        "path": "easyuse_anima/anima_29b/architecture.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 8,
+          "global_count": 6
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 42,
+            "kind": "function",
+            "line": 34,
+            "loc": 9,
+            "qualified_name": "_anima_lora_block_match"
+          },
+          {
+            "async": false,
+            "end_line": 51,
+            "kind": "function",
+            "line": 45,
+            "loc": 7,
+            "qualified_name": "_anima_lora_block_indices"
+          },
+          {
+            "async": false,
+            "end_line": 66,
+            "kind": "function",
+            "line": 54,
+            "loc": 13,
+            "qualified_name": "_remap_legacy_anima_lora_key"
+          },
+          {
+            "async": false,
+            "end_line": 111,
+            "kind": "function",
+            "line": 69,
+            "loc": 43,
+            "qualified_name": "_prepare_anima_29b_lora_state_dict"
+          },
+          {
+            "async": false,
+            "end_line": 133,
+            "kind": "function",
+            "line": 114,
+            "loc": 20,
+            "qualified_name": "_load_lora_file"
+          },
+          {
+            "async": false,
+            "end_line": 198,
+            "kind": "function",
+            "line": 136,
+            "loc": 63,
+            "qualified_name": "_apply_anima_29b_lora_stack"
+          },
+          {
+            "async": false,
+            "end_line": 209,
+            "kind": "function",
+            "line": 201,
+            "loc": 9,
+            "qualified_name": "_apply_anima_29b_aio_lora_stack"
+          }
+        ],
+        "is_package": false,
+        "loc": 212,
+        "module": "easyuse_anima.anima_29b.lora",
+        "normalized_git_blob_sha1": "042a5a925c2b772610a64a49472cacf0ffa1cc28",
+        "path": "easyuse_anima/anima_29b/lora.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 7,
+          "global_count": 6
         }
       },
       {
@@ -52446,6 +53101,36 @@
         "functions": [
           {
             "async": false,
+            "end_line": 46,
+            "kind": "method",
+            "line": 25,
+            "loc": 22,
+            "qualified_name": "EasyUseAnima29BLoraStackLoader.INPUT_TYPES"
+          },
+          {
+            "async": false,
+            "end_line": 60,
+            "kind": "method",
+            "line": 53,
+            "loc": 8,
+            "qualified_name": "EasyUseAnima29BLoraStackLoader.apply"
+          }
+        ],
+        "is_package": false,
+        "loc": 63,
+        "module": "easyuse_anima.nodes.anima_29b_nodes",
+        "normalized_git_blob_sha1": "c3660e6d3cbe6533bb3981945b0dce299383ae40",
+        "path": "easyuse_anima/nodes/anima_29b_nodes.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
             "end_line": 140,
             "kind": "function",
             "line": 32,
@@ -55702,9 +56387,9 @@
       {
         "functions": [],
         "is_package": false,
-        "loc": 81,
+        "loc": 84,
         "module": "easyuse_anima.registration",
-        "normalized_git_blob_sha1": "906e975290ed0d39c23b925699c0e553b768584e",
+        "normalized_git_blob_sha1": "d961fe016c6b59835fff949744e1260381d03de1",
         "path": "easyuse_anima/registration.py",
         "top_level": {
           "class_count": 0,
@@ -59649,14 +60334,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 474
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 475,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -60110,7 +60795,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 212,
+            "line": 218,
             "type_checking": false
           },
           {
@@ -60118,14 +60803,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 213
+            "line": 219
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 214,
+        "line": 220,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -60316,6 +61001,157 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "functools:wraps",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading:RLock",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 66
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy:model_detection",
+        "kind": "static_from",
+        "line": 67,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 115,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "comfy:utils",
+        "kind": "static_from",
+        "line": 116,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "comfy:sd",
+        "kind": "static_from",
+        "line": 157,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/lora.py"
       },
       {
         "branch_context": [],
@@ -63078,6 +63914,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/anima_29b_nodes.py"
       },
       {
         "branch_context": [],
@@ -66293,14 +67140,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 474
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 475,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -66424,7 +67271,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 212,
+            "line": 218,
             "type_checking": false
           },
           {
@@ -66432,17 +67279,36 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 213
+            "line": 219
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 214,
+        "line": 220,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 66
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy:model_detection",
+        "kind": "static_from",
+        "line": 67,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/anima_29b/architecture.py"
       },
       {
         "branch_context": [
@@ -67291,6 +68157,9 @@
       "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
+      "easyuse_anima/anima_29b/__init__.py",
+      "easyuse_anima/anima_29b/architecture.py",
+      "easyuse_anima/anima_29b/lora.py",
       "easyuse_anima/api/__init__.py",
       "easyuse_anima/api/application.py",
       "easyuse_anima/api/application_compatibility.py",
@@ -67357,6 +68226,7 @@
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/aio_hook_nodes.py",
       "easyuse_anima/nodes/aio_nodes.py",
+      "easyuse_anima/nodes/anima_29b_nodes.py",
       "easyuse_anima/nodes/artist_mix_conditioning_adapter.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/input_types.py",
@@ -67482,6 +68352,9 @@
       "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
+      "easyuse_anima/anima_29b/__init__.py",
+      "easyuse_anima/anima_29b/architecture.py",
+      "easyuse_anima/anima_29b/lora.py",
       "easyuse_anima/api/__init__.py",
       "easyuse_anima/api/application.py",
       "easyuse_anima/api/application_compatibility.py",
@@ -67550,6 +68423,7 @@
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/aio_hook_nodes.py",
       "easyuse_anima/nodes/aio_nodes.py",
+      "easyuse_anima/nodes/anima_29b_nodes.py",
       "easyuse_anima/nodes/artist_mix_conditioning_adapter.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/input_types.py",
@@ -68595,7 +69469,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 23,
+        "line": 24,
         "module": "easyuse_anima/aio/model_preparation.py",
         "scope": "<module>"
       },
@@ -68651,6 +69525,69 @@
         "kind": "import_time_call",
         "line": 28,
         "module": "easyuse_anima/aio/preview.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "tuple",
+        "column": 29,
+        "context": "assign:ANIMA_29B_LEGACY_BLOCK_MAP",
+        "kind": "import_time_call",
+        "line": 26,
+        "module": "easyuse_anima/anima_29b/architecture.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "range",
+        "column": 23,
+        "context": "assign:ANIMA_29B_LEGACY_BLOCK_MAP",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/anima_29b/architecture.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "RLock",
+        "column": 18,
+        "context": "assign:_DETECTION_LOCK",
+        "kind": "import_time_call",
+        "line": 32,
+        "module": "easyuse_anima/anima_29b/architecture.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 24,
+        "context": "assign:_ANIMA_FLAT_BLOCK_KEY",
+        "kind": "import_time_call",
+        "line": 20,
+        "module": "easyuse_anima/anima_29b/lora.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 4,
+        "context": "assign:_ANIMA_DOTTED_BLOCK_KEYS",
+        "kind": "import_time_call",
+        "line": 24,
+        "module": "easyuse_anima/anima_29b/lora.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 4,
+        "context": "assign:_ANIMA_DOTTED_BLOCK_KEYS",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/anima_29b/lora.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 31,
+        "module": "easyuse_anima/anima_29b/lora.py",
         "scope": "<module>"
       },
       {
@@ -70147,19 +71084,19 @@
       },
       {
         "kind": "dict",
-        "line": 33,
+        "line": 34,
         "module": "easyuse_anima/registration.py",
         "name": "NODE_CLASS_MAPPINGS"
       },
       {
         "kind": "dict",
-        "line": 57,
+        "line": 59,
         "module": "easyuse_anima/registration.py",
         "name": "NODE_DISPLAY_NAME_MAPPINGS"
       },
       {
         "kind": "list",
-        "line": 81,
+        "line": 84,
         "module": "easyuse_anima/registration.py",
         "name": "__all__"
       },
@@ -70263,6 +71200,15 @@
         "line": 255,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_DEFAULT_AIO_FIRST_PASS_CACHE"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "RLock",
+        "line": 32,
+        "module": "easyuse_anima/anima_29b/architecture.py",
+        "name": "_DETECTION_LOCK"
       },
       {
         "categories": [

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -11020,6 +11020,23 @@
       },
       {
         "alias": null,
+        "bound_name": "get_ident",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading:get_ident",
+        "kind": "static_from",
+        "line": 7,
+        "name": "get_ident",
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
+        "alias": null,
         "bound_name": "model_detection",
         "branch_context": [
           {
@@ -11243,7 +11260,7 @@
         "conditional": false,
         "imported": "comfy:sd",
         "kind": "static_from",
-        "line": 157,
+        "line": 167,
         "name": "sd",
         "optional": false,
         "requested": "comfy",
@@ -48576,65 +48593,65 @@
           },
           {
             "async": false,
-            "end_line": 92,
+            "end_line": 95,
             "kind": "function",
             "line": 62,
-            "loc": 31,
+            "loc": 34,
             "qualified_name": "_scoped_anima_29b_model_detection"
           },
           {
             "async": false,
-            "end_line": 85,
+            "end_line": 88,
             "kind": "function",
-            "line": 78,
-            "loc": 8,
+            "line": 79,
+            "loc": 10,
             "qualified_name": "_scoped_anima_29b_model_detection.detect_unet_config"
           },
           {
             "async": false,
-            "end_line": 99,
+            "end_line": 102,
             "kind": "function",
-            "line": 95,
+            "line": 98,
             "loc": 5,
             "qualified_name": "_anima_unet_config"
           },
           {
             "async": false,
-            "end_line": 108,
+            "end_line": 111,
             "kind": "function",
-            "line": 102,
+            "line": 105,
             "loc": 7,
             "qualified_name": "_is_anima_29b_model"
           },
           {
             "async": false,
-            "end_line": 114,
+            "end_line": 124,
             "kind": "function",
-            "line": 111,
-            "loc": 4,
+            "line": 114,
+            "loc": 11,
             "qualified_name": "_reload_anima_29b_model"
           },
           {
             "async": false,
-            "end_line": 134,
+            "end_line": 147,
             "kind": "function",
-            "line": 117,
-            "loc": 18,
+            "line": 127,
+            "loc": 21,
             "qualified_name": "_install_anima_29b_cached_reload"
           },
           {
             "async": false,
-            "end_line": 140,
+            "end_line": 153,
             "kind": "function",
-            "line": 137,
+            "line": 150,
             "loc": 4,
             "qualified_name": "_load_model_with_anima_29b_support"
           }
         ],
         "is_package": false,
-        "loc": 143,
+        "loc": 156,
         "module": "easyuse_anima.anima_29b.architecture",
-        "normalized_git_blob_sha1": "0794dd06dc05e5b7985121edc0d2fce93be2f0c1",
+        "normalized_git_blob_sha1": "5d2eaca0343c92a50e6a1c632eb86cdc8b46723c",
         "path": "easyuse_anima/anima_29b/architecture.py",
         "top_level": {
           "class_count": 0,
@@ -48686,29 +48703,37 @@
           },
           {
             "async": false,
-            "end_line": 198,
+            "end_line": 143,
             "kind": "function",
             "line": 136,
-            "loc": 63,
+            "loc": 8,
+            "qualified_name": "_model_patch_entry_count"
+          },
+          {
+            "async": false,
+            "end_line": 226,
+            "kind": "function",
+            "line": 146,
+            "loc": 81,
             "qualified_name": "_apply_anima_29b_lora_stack"
           },
           {
             "async": false,
-            "end_line": 209,
+            "end_line": 237,
             "kind": "function",
-            "line": 201,
+            "line": 229,
             "loc": 9,
             "qualified_name": "_apply_anima_29b_aio_lora_stack"
           }
         ],
         "is_package": false,
-        "loc": 212,
+        "loc": 240,
         "module": "easyuse_anima.anima_29b.lora",
-        "normalized_git_blob_sha1": "042a5a925c2b772610a64a49472cacf0ffa1cc28",
+        "normalized_git_blob_sha1": "1b10331bf23cd73078c80c0bf74af4ec0bc068b4",
         "path": "easyuse_anima/anima_29b/lora.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
+          "function_count": 8,
           "global_count": 6
         }
       },
@@ -61047,6 +61072,17 @@
         "source": "easyuse_anima/anima_29b/architecture.py"
       },
       {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading:get_ident",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/anima_29b/architecture.py"
+      },
+      {
         "branch_context": [
           {
             "branch": "body",
@@ -61148,7 +61184,7 @@
         "conditional": false,
         "imported": "comfy:sd",
         "kind": "static_from",
-        "line": 157,
+        "line": 167,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/anima_29b/lora.py"

--- a/tests/fixtures/python_file_disposition_contract.v1.json
+++ b/tests/fixtures/python_file_disposition_contract.v1.json
@@ -4,7 +4,7 @@
   "inventory_owner": {
     "path": "tests/fixtures/python_backend_baseline.json",
     "expected_baseline_files": 189,
-    "expected_target_files": 191
+    "expected_target_files": 195
   },
   "linked_contracts": {
     "compatibility_registry": "docs/architecture/python-compatibility-shims.md",
@@ -2522,19 +2522,41 @@
       "path": "easyuse_anima/nodes/lora_nodes.py",
       "role": "comfyui-node-adapter",
       "owner_group": "nodes",
-      "disposition": "cohesive_retain",
+      "disposition": "split",
       "status": "complete",
       "targets": [
+        {
+          "path": "easyuse_anima/anima_29b/__init__.py",
+          "role": "anima-29b-package",
+          "owner_group": "anima_29b"
+        },
+        {
+          "path": "easyuse_anima/anima_29b/architecture.py",
+          "role": "anima-29b-architecture",
+          "owner_group": "anima_29b"
+        },
+        {
+          "path": "easyuse_anima/anima_29b/lora.py",
+          "role": "anima-29b-lora-service",
+          "owner_group": "anima_29b"
+        },
+        {
+          "path": "easyuse_anima/nodes/anima_29b_nodes.py",
+          "role": "anima-29b-node-adapter",
+          "owner_group": "nodes"
+        },
         {
           "path": "easyuse_anima/nodes/lora_nodes.py",
           "role": "comfyui-node-adapter",
           "owner_group": "nodes"
         }
       ],
-      "direct_contracts": [],
+      "direct_contracts": [
+        "tests/test_anima_29b.py"
+      ],
       "compatibility_registry_key": null,
-      "task_id": null,
-      "rollback_unit": null,
+      "task_id": "ANIMA-29B",
+      "rollback_unit": "Revert the isolated Anima 2.9B architecture, LoRA service, and node adapter split.",
       "replacement_owner": null,
       "size_exception_verdicts": []
     },

--- a/tests/fixtures/python_import_boundary_contract.v2.json
+++ b/tests/fixtures/python_import_boundary_contract.v2.json
@@ -10,6 +10,10 @@
       "role": "feature-service"
     },
     {
+      "group": "anima_29b",
+      "role": "feature-service"
+    },
+    {
       "group": "api",
       "role": "http-adapter"
     },

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -163,6 +163,18 @@
       "thread_safety": "One RLock protects enabled/generation/cache/order/metrics publication and mutation."
     },
     {
+      "categories": ["lock", "model_detection_patch"],
+      "cleanup": "The scoped context always restores ComfyUI's original detector before releasing the lock; the lock itself remains for process lifetime.",
+      "id": "anima-29b-detection-scope",
+      "lifetime": "Process lifetime from module import; detector replacement is limited to the owning thread and one AiO diffusion-model load scope.",
+      "module": "easyuse_anima/anima_29b/architecture.py",
+      "owner": "easyuse_anima.anima_29b.architecture._DETECTION_LOCK",
+      "symbols": ["_DETECTION_LOCK"],
+      "target_phase": "anima-29b-complete",
+      "test_evidence": ["tests/test_anima_29b.py"],
+      "thread_safety": "One RLock serializes temporary detector replacement, while owner-thread gating sends concurrent external callers directly to the original detector."
+    },
+    {
       "categories": ["async_limiter", "lock", "weak_registry"],
       "cleanup": "Weak loop keys and weak semaphore values self-expire; no explicit process shutdown hook.",
       "id": "api-file-io-limiters",

--- a/tests/fixtures/python_support_ownership_contract.v1.json
+++ b/tests/fixtures/python_support_ownership_contract.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "baseline_commit": "a0b0dc1f599fcf01ec0f25fc75a23f7524f165ab",
   "inventory": {
-    "expected_files": 210,
+    "expected_files": 211,
     "manual_matrix_source": "tests/fixtures/python_test_ownership_contract.v1.json",
     "patterns": [
       "tests/**/*.json",
@@ -1540,6 +1540,17 @@
         "aio"
       ],
       "purpose": "Direct Python unittest contract for test aio wheel."
+    },
+    {
+      "execution_mode": "unittest",
+      "generated": false,
+      "kind": "test",
+      "owner": "tests/test_anima_29b.py",
+      "path": "tests/test_anima_29b.py",
+      "production_groups": [
+        "anima_29b"
+      ],
+      "purpose": "Direct Python unittest contract for Anima 2.9B architecture and LoRA compatibility."
     },
     {
       "execution_mode": "unittest",

--- a/tests/fixtures/python_test_ownership_contract.v1.json
+++ b/tests/fixtures/python_test_ownership_contract.v1.json
@@ -91,6 +91,30 @@
       }
     },
     {
+      "name": "anima_29b",
+      "production_paths": [
+        "easyuse_anima/anima_29b/"
+      ],
+      "owners": {
+        "adapter_api_node_integration": [
+          "tests/test_anima_29b.py"
+        ],
+        "live_host": [
+          "@matrix:dual-canvas-live"
+        ],
+        "migration_compatibility": [
+          "tests/test_anima_29b.py"
+        ],
+        "package_archive": [
+          "@matrix:package-import-closure",
+          "@matrix:registry-archive-closure"
+        ],
+        "pure_service_unit": [
+          "tests/test_anima_29b.py"
+        ]
+      }
+    },
+    {
       "name": "api",
       "production_paths": [
         "easyuse_anima/api/"

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -58,6 +58,33 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
         self.assertIs(result_clip, original_clip)
         self.assertEqual(applied, [])
 
+    def test_anima_29b_lora_hook_claims_stack_before_core_loader(self):
+        hook_result = ("anima-29b-model", "anima-29b-clip", [{"name": "legacy"}])
+        with (
+            patch.object(
+                model_preparation,
+                "_apply_anima_29b_aio_lora_stack",
+                return_value=hook_result,
+            ) as apply_hook,
+            patch_comfy_helper(
+                model_preparation,
+                "_find_comfy_node_class",
+                side_effect=AssertionError("core LoraLoader must not run"),
+            ),
+        ):
+            result = model_preparation._apply_aio_lora_stack(
+                "model",
+                "clip",
+                [("legacy.safetensors", 0.8, 0.6)],
+            )
+
+        self.assertEqual(result, hook_result)
+        apply_hook.assert_called_once_with(
+            "model",
+            "clip",
+            [("legacy.safetensors", 0.8, 0.6)],
+        )
+
     def test_model_patch_aggregate_uses_canonical_subcalls_in_order(self):
         trace: list[tuple[str, object]] = []
         replacement_dave = Mock(

--- a/tests/test_aio_resources.py
+++ b/tests/test_aio_resources.py
@@ -146,6 +146,40 @@ class AIOResourceMoveTests(unittest.TestCase):
             ):
                 aio_resources._load_diffusion_model_with_comfy("unet.safetensors")
 
+    def test_diffusion_loader_runs_inside_anima_29b_support_boundary(self):
+        trace: list[str] = []
+
+        class UNETLoader:
+            def load_unet(self, *_args):
+                trace.append("core-loader")
+                return ("model",)
+
+        def support_boundary(loader):
+            trace.append("boundary-enter")
+            model = loader()
+            trace.append("boundary-exit")
+            return f"wrapped-{model}"
+
+        with (
+            patch_comfy_helper(
+                aio_resources,
+                "_find_comfy_node_class",
+                return_value=UNETLoader,
+            ),
+            patch.object(
+                aio_resources,
+                "_load_model_with_anima_29b_support",
+                side_effect=support_boundary,
+            ) as support,
+        ):
+            result = aio_resources._load_diffusion_model_with_comfy(
+                "anima-2.9b.safetensors"
+            )
+
+        self.assertEqual(result, "wrapped-model")
+        self.assertEqual(trace, ["boundary-enter", "core-loader", "boundary-exit"])
+        support.assert_called_once()
+
     def test_upscale_loader_keeps_blank_validation_and_call_time_lookup(self):
         with self.assertRaisesRegex(
             RuntimeError,

--- a/tests/test_anima_29b.py
+++ b/tests/test_anima_29b.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import types
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock, patch
 
 from easyuse_anima.anima_29b import architecture, lora
@@ -115,6 +116,33 @@ class Anima29BArchitectureTests(unittest.TestCase):
             28,
         )
 
+    def test_detection_patch_does_not_change_concurrent_loader_threads(self):
+        def base_detect(_state_dict, _prefix):
+            return {"image_model": "anima", "num_blocks": 28}
+
+        modules = _fake_comfy_modules(detect_unet_config=base_detect)
+        model_detection = modules["comfy.model_detection"]
+        state_dict = {
+            f"diffusion_model.blocks.{index}.self_attn.qkv_proj.weight": object()
+            for index in range(40)
+        }
+
+        with patch.dict(sys.modules, modules):
+            with architecture._scoped_anima_29b_model_detection():
+                local = model_detection.detect_unet_config(
+                    state_dict,
+                    "diffusion_model.",
+                )
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    concurrent = executor.submit(
+                        model_detection.detect_unet_config,
+                        state_dict,
+                        "diffusion_model.",
+                    ).result()
+
+        self.assertEqual(local["num_blocks"], 40)
+        self.assertEqual(concurrent["num_blocks"], 28)
+
     def test_cached_disk_reload_reenters_scoped_detection(self):
         def base_detect(_state_dict, _prefix, metadata=None):
             return {"image_model": "anima", "num_blocks": 28}
@@ -150,6 +178,34 @@ class Anima29BArchitectureTests(unittest.TestCase):
             architecture._reload_anima_29b_model,
         )
         self.assertIs(model_detection.detect_unet_config, base_detect)
+
+    def test_cached_reload_preserves_factory_result_selector(self):
+        modules = _fake_comfy_modules(
+            detect_unet_config=lambda _state_dict, _prefix: {
+                "image_model": "anima",
+                "num_blocks": 28,
+            }
+        )
+
+        def core_reload(_path, **_kwargs):
+            first = _model_with_blocks(28)
+            second = _model_with_blocks(40)
+            second.cached_patcher_init = (core_reload, ("checkpoint.safetensors",), 1)
+            return first, second
+
+        model = _model_with_blocks(40)
+        model.cached_patcher_init = (core_reload, ("checkpoint.safetensors",), 1)
+
+        with patch.dict(sys.modules, modules):
+            loaded = architecture._install_anima_29b_cached_reload(model)
+            cached_factory, cached_args = loaded.cached_patcher_init
+            fresh = cached_factory(*cached_args, disable_dynamic=True)
+
+        self.assertEqual(fresh.model.model_config.unet_config["num_blocks"], 40)
+        self.assertIs(
+            fresh.cached_patcher_init[0],
+            architecture._reload_anima_29b_model,
+        )
 
 
 class Anima29BLoraTests(unittest.TestCase):
@@ -324,6 +380,45 @@ class Anima29BLoraTests(unittest.TestCase):
                 [("legacy.safetensors", 1.0, 1.0)],
             )
         )
+
+    def test_legacy_loader_rejects_when_comfy_accepts_no_model_patches(self):
+        state_dict = {
+            "lora_unet_blocks_0_unknown.lora_down.weight": "down",
+        }
+
+        def load_torch_file(_path, safe_load=True, return_metadata=True):
+            return state_dict, None
+
+        def load_lora_for_models(
+            model,
+            clip,
+            _converted,
+            _strength_model,
+            _strength_clip,
+            lora_metadata=None,
+        ):
+            fresh = _model_with_blocks(40)
+            fresh.patches = dict(model.patches)
+            return fresh, clip
+
+        folder_paths = types.ModuleType("folder_paths")
+        folder_paths.get_full_path_or_raise = lambda _kind, name: name
+        modules = _fake_comfy_modules(
+            load_torch_file=load_torch_file,
+            load_lora=load_lora_for_models,
+        )
+        modules["folder_paths"] = folder_paths
+        model = _model_with_blocks(40)
+        model.patches = {}
+
+        with patch.dict(sys.modules, modules):
+            with self.assertRaisesRegex(RuntimeError, "accepted no legacy"):
+                lora._apply_anima_29b_lora_stack(
+                    model,
+                    "clip",
+                    [("unsupported.safetensors", 1.0, 0.0)],
+                    source_layout=lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+                )
 
 
 class Anima29BNodeTests(unittest.TestCase):

--- a/tests/test_anima_29b.py
+++ b/tests/test_anima_29b.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+from easyuse_anima.anima_29b import architecture, lora
+from easyuse_anima.nodes import anima_29b_nodes
+
+
+def _model_with_blocks(block_count: int):
+    model_config = types.SimpleNamespace(
+        unet_config={"image_model": "anima", "num_blocks": block_count}
+    )
+    return types.SimpleNamespace(model=types.SimpleNamespace(model_config=model_config))
+
+
+def _fake_comfy_modules(*, detect_unet_config=None, load_torch_file=None, load_lora=None):
+    comfy = types.ModuleType("comfy")
+    comfy.__path__ = []
+    modules = {"comfy": comfy}
+
+    if detect_unet_config is not None:
+        model_detection = types.ModuleType("comfy.model_detection")
+        model_detection.detect_unet_config = detect_unet_config
+        comfy.model_detection = model_detection
+        modules["comfy.model_detection"] = model_detection
+    if load_torch_file is not None:
+        utils = types.ModuleType("comfy.utils")
+        utils.load_torch_file = load_torch_file
+        comfy.utils = utils
+        modules["comfy.utils"] = utils
+    if load_lora is not None:
+        sd = types.ModuleType("comfy.sd")
+        sd.load_lora_for_models = load_lora
+        comfy.sd = sd
+        modules["comfy.sd"] = sd
+    return modules
+
+
+class Anima29BArchitectureTests(unittest.TestCase):
+    def test_manifest_block_mapping_preserves_original_expanded_positions(self):
+        self.assertEqual(len(architecture.ANIMA_29B_LEGACY_BLOCK_MAP), 28)
+        self.assertEqual(
+            architecture.ANIMA_29B_LEGACY_BLOCK_MAP,
+            (
+                0,
+                1,
+                3,
+                4,
+                6,
+                7,
+                9,
+                10,
+                12,
+                13,
+                15,
+                16,
+                18,
+                19,
+                20,
+                22,
+                23,
+                25,
+                26,
+                28,
+                29,
+                31,
+                32,
+                34,
+                35,
+                37,
+                38,
+                39,
+            ),
+        )
+
+    def test_detection_patch_is_scoped_and_only_changes_complete_40_block_anima(self):
+        base_detect = Mock(
+            side_effect=lambda _state_dict, _prefix, metadata=None: {
+                "image_model": "anima",
+                "num_blocks": 28,
+                "metadata": metadata,
+            }
+        )
+        modules = _fake_comfy_modules(detect_unet_config=base_detect)
+        model_detection = modules["comfy.model_detection"]
+        state_dict = {
+            f"diffusion_model.blocks.{index}.self_attn.qkv_proj.weight": object()
+            for index in range(40)
+        }
+
+        with patch.dict(sys.modules, modules):
+            with architecture._scoped_anima_29b_model_detection():
+                self.assertIsNot(model_detection.detect_unet_config, base_detect)
+                config = model_detection.detect_unet_config(
+                    state_dict,
+                    "diffusion_model.",
+                    metadata={"source": "test"},
+                )
+            self.assertIs(model_detection.detect_unet_config, base_detect)
+
+        self.assertEqual(config["num_blocks"], 40)
+        self.assertEqual(config["metadata"], {"source": "test"})
+
+        incomplete = dict(state_dict)
+        incomplete.pop("diffusion_model.blocks.39.self_attn.qkv_proj.weight")
+        self.assertEqual(
+            architecture._patch_anima_29b_detected_config(
+                {"image_model": "anima", "num_blocks": 28},
+                incomplete,
+                "diffusion_model.",
+            )["num_blocks"],
+            28,
+        )
+
+    def test_cached_disk_reload_reenters_scoped_detection(self):
+        def base_detect(_state_dict, _prefix, metadata=None):
+            return {"image_model": "anima", "num_blocks": 28}
+
+        modules = _fake_comfy_modules(detect_unet_config=base_detect)
+        model_detection = modules["comfy.model_detection"]
+        reload_was_scoped: list[bool] = []
+        reload_kwargs: list[dict[str, object]] = []
+
+        def core_reload(path, options, **kwargs):
+            reload_was_scoped.append(model_detection.detect_unet_config is not base_detect)
+            reload_kwargs.append(kwargs)
+            fresh = _model_with_blocks(40)
+            fresh.cached_patcher_init = (core_reload, (path, options))
+            return fresh
+
+        model = _model_with_blocks(40)
+        model.cached_patcher_init = (
+            core_reload,
+            ("anima-2.9b.safetensors", {"dtype": "bf16"}),
+        )
+
+        with patch.dict(sys.modules, modules):
+            loaded = architecture._load_model_with_anima_29b_support(lambda: model)
+            cached_factory, cached_args = loaded.cached_patcher_init
+            fresh = cached_factory(*cached_args, disable_dynamic=True)
+
+        self.assertIs(cached_factory, architecture._reload_anima_29b_model)
+        self.assertEqual(reload_was_scoped, [True])
+        self.assertEqual(reload_kwargs, [{"disable_dynamic": True}])
+        self.assertIs(
+            fresh.cached_patcher_init[0],
+            architecture._reload_anima_29b_model,
+        )
+        self.assertIs(model_detection.detect_unet_config, base_detect)
+
+
+class Anima29BLoraTests(unittest.TestCase):
+    def test_legacy_keys_are_remapped_and_non_model_keys_are_preserved(self):
+        original = {
+            "lora_unet_blocks_2_self_attn_qkv_proj.lora_down.weight": "down",
+            "lora_unet__blocks_27_cross_attn_k.lora_up.weight": "up",
+            "model.diffusion_model.blocks.5.mlp.layer1.lora_down.weight": "generic",
+            "blocks.6.mlp.layer2.lora_up.weight": "bare",
+            "lora_te_qwen3_blocks_2_attn.lora_down.weight": "clip",
+        }
+
+        converted, count = lora._prepare_anima_29b_lora_state_dict(
+            original,
+            lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+        )
+
+        self.assertEqual(count, 4)
+        self.assertEqual(
+            converted["lora_unet_blocks_3_self_attn_qkv_proj.lora_down.weight"],
+            "down",
+        )
+        self.assertEqual(
+            converted["lora_unet_blocks_39_cross_attn_k.lora_up.weight"],
+            "up",
+        )
+        self.assertEqual(
+            converted["diffusion_model.blocks.7.mlp.layer1.lora_down.weight"],
+            "generic",
+        )
+        self.assertEqual(
+            converted["diffusion_model.blocks.9.mlp.layer2.lora_up.weight"],
+            "bare",
+        )
+        self.assertEqual(
+            converted["lora_te_qwen3_blocks_2_attn.lora_down.weight"],
+            "clip",
+        )
+
+    def test_auto_layout_preserves_native_40_block_lora(self):
+        native = {
+            "lora_unet_blocks_3_self_attn_qkv_proj.lora_down.weight": "base",
+            "lora_unet_blocks_30_self_attn_qkv_proj.lora_down.weight": "expanded",
+        }
+
+        converted, count = lora._prepare_anima_29b_lora_state_dict(native)
+
+        self.assertEqual(converted, native)
+        self.assertEqual(count, 0)
+        with self.assertRaisesRegex(RuntimeError, "already contains Anima 2.9B"):
+            lora._prepare_anima_29b_lora_state_dict(
+                native,
+                lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+            )
+
+    def test_auto_layout_remaps_complete_legacy_28_block_lora(self):
+        legacy = {
+            f"lora_unet_blocks_{index}_self_attn_q_proj.lora_down.weight": index
+            for index in range(28)
+        }
+
+        converted, count = lora._prepare_anima_29b_lora_state_dict(legacy)
+
+        self.assertEqual(count, 26)
+        self.assertEqual(
+            {
+                int(key.partition("lora_unet_blocks_")[2].partition("_")[0])
+                for key in converted
+            },
+            set(architecture.ANIMA_29B_LEGACY_BLOCK_MAP),
+        )
+
+    def test_auto_layout_rejects_sparse_low_block_layout_as_ambiguous(self):
+        sparse = {
+            "lora_unet_blocks_0_self_attn_qkv_proj.lora_down.weight": "down",
+            "lora_unet_blocks_27_self_attn_qkv_proj.lora_up.weight": "up",
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "layout is ambiguous"):
+            lora._prepare_anima_29b_lora_state_dict(sparse)
+
+        converted, count = lora._prepare_anima_29b_lora_state_dict(
+            sparse,
+            lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+        )
+        self.assertEqual(count, 1)
+        self.assertIn(
+            "lora_unet_blocks_39_self_attn_qkv_proj.lora_up.weight",
+            converted,
+        )
+
+    def test_stack_loader_remaps_in_order_and_preserves_metadata_and_strengths(self):
+        load_calls: list[tuple[object, ...]] = []
+        lora_files = {
+            "first.safetensors": {
+                "lora_unet_blocks_2_self_attn_qkv_proj.lora_down.weight": "first"
+            },
+            "second.safetensors": {
+                "lora_unet_blocks_27_mlp_layer2.lora_up.weight": "second"
+            },
+        }
+
+        def load_torch_file(path, safe_load=True, return_metadata=True):
+            name = str(path).rsplit("/", 1)[-1]
+            return lora_files[name], {"name": name}
+
+        def load_lora_for_models(
+            model,
+            clip,
+            state_dict,
+            strength_model,
+            strength_clip,
+            lora_metadata=None,
+        ):
+            load_calls.append(
+                (
+                    model,
+                    clip,
+                    state_dict,
+                    strength_model,
+                    strength_clip,
+                    lora_metadata,
+                )
+            )
+            name = lora_metadata["name"]
+            return f"{model}>{name}", f"{clip}>{name}"
+
+        folder_paths = types.ModuleType("folder_paths")
+        folder_paths.get_full_path_or_raise = lambda _kind, name: f"C:/loras/{name}"
+        modules = _fake_comfy_modules(
+            load_torch_file=load_torch_file,
+            load_lora=load_lora_for_models,
+        )
+        modules["folder_paths"] = folder_paths
+
+        with patch.dict(sys.modules, modules):
+            result = lora._apply_anima_29b_lora_stack(
+                _model_with_blocks(40),
+                "clip",
+                [
+                    ("first.safetensors", 0.8, 0.6),
+                    ("skip.safetensors", 0.0, 0.0),
+                    ("second.safetensors", 1.2, 0.7),
+                ],
+                source_layout=lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+            )
+
+        self.assertEqual(result[0].count(">"), 2)
+        self.assertEqual(result[1], "clip>first.safetensors>second.safetensors")
+        self.assertEqual(
+            list(load_calls[0][2]),
+            ["lora_unet_blocks_3_self_attn_qkv_proj.lora_down.weight"],
+        )
+        self.assertEqual(
+            list(load_calls[1][2]),
+            ["lora_unet_blocks_39_mlp_layer2.lora_up.weight"],
+        )
+        self.assertEqual(
+            load_calls[0][3:6],
+            (0.8, 0.6, {"name": "first.safetensors"}),
+        )
+        self.assertEqual(
+            [item["name"] for item in result[2]],
+            ["first.safetensors", "second.safetensors"],
+        )
+
+    def test_aio_hook_only_claims_40_block_anima_models(self):
+        self.assertIsNone(
+            lora._apply_anima_29b_aio_lora_stack(
+                _model_with_blocks(28),
+                "clip",
+                [("legacy.safetensors", 1.0, 1.0)],
+            )
+        )
+
+
+class Anima29BNodeTests(unittest.TestCase):
+    def test_node_has_fixed_stack_contract_and_forces_legacy_layout(self):
+        input_types = anima_29b_nodes.EasyUseAnima29BLoraStackLoader.INPUT_TYPES()
+        self.assertEqual(
+            list(input_types["required"]),
+            ["model", "clip", "lora_stack"],
+        )
+        self.assertEqual(
+            anima_29b_nodes.EasyUseAnima29BLoraStackLoader.RETURN_TYPES,
+            ("MODEL", "CLIP"),
+        )
+
+        apply_stack = Mock(return_value=("patched-model", "patched-clip", []))
+        with (
+            patch.object(
+                anima_29b_nodes,
+                "_normalize_lora_stack",
+                return_value=[("legacy.safetensors", 0.8, 0.6)],
+            ),
+            patch.object(
+                anima_29b_nodes,
+                "_apply_anima_29b_lora_stack",
+                apply_stack,
+            ),
+        ):
+            result = anima_29b_nodes.EasyUseAnima29BLoraStackLoader().apply(
+                "model",
+                "clip",
+                ["stack"],
+            )
+
+        self.assertEqual(result, ("patched-model", "patched-clip"))
+        apply_stack.assert_called_once_with(
+            "model",
+            "clip",
+            [("legacy.safetensors", 0.8, 0.6)],
+            source_layout=lora.ANIMA_29B_LORA_LAYOUT_LEGACY,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -77,11 +77,11 @@ def load_dynamic():
         self.assertEqual(report["source"], "easyuse_anima/registration.py")
         self.assertEqual(
             report["git_blob_sha1"],
-            "906e975290ed0d39c23b925699c0e553b768584e",
+            "d961fe016c6b59835fff949744e1260381d03de1",
         )
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 81)
+        self.assertEqual(report["line_count"], 84)
         self.assertEqual(
             [item["name"] for item in report["top_level"]["globals"]],
             [
@@ -90,7 +90,7 @@ def load_dynamic():
                 "__all__",
             ],
         )
-        self.assertEqual(len(report["imports"]), 21)
+        self.assertEqual(len(report["imports"]), 22)
 
     def test_external_source_label_does_not_expose_parent_directories(self):
         label = analyzer._source_label(Path("Z:/private/user/data/example.py"))

--- a/tests/test_python_file_disposition_contract.py
+++ b/tests/test_python_file_disposition_contract.py
@@ -60,9 +60,9 @@ class PythonFileDispositionContractTests(unittest.TestCase):
         self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
         contract = self.validate(self.document)
         self.assertEqual(contract["expected_baseline_files"], 189)
-        self.assertEqual(contract["expected_target_files"], 191)
+        self.assertEqual(contract["expected_target_files"], 195)
         self.assertEqual(len(contract["entries"]), 189)
-        self.assertEqual(len(contract["target_paths"]), 191)
+        self.assertEqual(len(contract["target_paths"]), 195)
 
     def test_inventory_requires_every_source_exactly_once(self):
         missing = copy.deepcopy(self.document)

--- a/tests/test_python_import_boundaries.py
+++ b/tests/test_python_import_boundaries.py
@@ -303,7 +303,7 @@ class CompletedPackageImportBoundaryTests(unittest.TestCase):
         }
         contract_groups = self.contract["groups"]
 
-        self.assertEqual(len(contract_groups), 17)
+        self.assertEqual(len(contract_groups), 18)
         self.assertEqual(
             {
                 group["group"]: list(group["production_paths"])
@@ -317,6 +317,7 @@ class CompletedPackageImportBoundaryTests(unittest.TestCase):
                 for group in contract_groups
             },
             {
+                "anima_29b": "feature-service",
                 "aio": "feature-service",
                 "api": "http-adapter",
                 "autocomplete": "feature-service",


### PR DESCRIPTION
## Goal and change boundary

Add maintainable Anima 2.9B support to EasyUse Anima without requiring `ComfyUI-Anima-2.9B` and without folding model-specific behavior into the generic loaders.

- Adds an isolated `easyuse_anima.anima_29b` package for architecture detection and LoRA adaptation.
- Loads the 40-block checkpoint through a scoped ComfyUI detection wrapper and preserves that scope for disk-backed model reloads.
- Adds an AiO model-specific LoRA hook while preserving the normal core `LoraLoader` path for other models.
- Adds `EasyUseAnima29BLoraStackLoader` for an explicitly legacy 28-block LoRA stack.
- Remaps legacy LoRA deltas only to the 28 inherited block positions recorded by the official expansion manifest; inserted blocks are not patched.

## Preserved contracts

- No runtime dependency on `ComfyUI-Anima-2.9B`.
- No permanent global monkey patch during custom-node startup.
- The temporary detector override is serialized and owner-thread gated; concurrent external model loaders use ComfyUI's original detector.
- Both current cached-patcher factory result shapes are supported, including the optional result selector.
- Non-Anima-2.9B models keep the existing AiO loader and LoRA behavior.
- MODEL/CLIP strengths, stack order, and LoRA metadata continue through ComfyUI's loader.
- Ambiguous sparse low-block LoRAs are rejected by AiO auto-detection instead of being silently remapped; the dedicated node remains the explicit legacy path.
- A legacy model LoRA application must add accepted model patch records when model strength is nonzero, preventing silent no-op success.

## Validation

- Final candidate: `9b5dd1c591a91addfed4d55da51ab33541afa0b3`.
- Focused `tests.test_anima_29b`: 13 passed.
- Focused runtime-state ownership contract: 7 passed.
- Focused backend analyzer contract: 19 passed.
- Official `full` profile passed: Python compile, Pyright baseline ratchet, import boundaries, size/complexity, file disposition, support/runtime ownership, 1,521 Python tests (2 skipped), 121 frontend JavaScript checks, and `git diff --check`.
- The downloaded `Anima-2.9B-preview-v1.safetensors` loaded through the scoped path as Anima with `num_blocks=40`; the instantiated model had 40 blocks and retained the scoped cached reload factory.
- Exhaustive checkpoint comparison confirmed all 560 tensors across the original 28 blocks are byte-value identical at the manifest-derived inherited positions in preview-v1 (560/560 exact, 0 missing, 0 changed).
- Installed-LoRA inventory found 168/168 Anima candidates with a complete original 0..27 block layout; no ambiguous sparse candidate was observed.
- Real model-patch checks succeeded for representative installed legacy formats:
  - regular Anima LoRA: 280 patch records added;
  - Anima LoKr: 280 patch records added;
  - dotted generic LoRA: 448 patch records added.

The repository's 26 existing Ruff findings remain report-only under G-01 and do not include the new Anima 2.9B files.

## Remaining risk and rollback

Legacy LoRA remapping is explicitly experimental. Structural key compatibility does not guarantee visual equivalence after the inserted blocks were trained; native Anima 2.9B LoRA training remains the recommended path. A fixed-prompt visual/latent quality comparison can still be added before promotion if desired.

Rollback is isolated to the Anima 2.9B package, its AiO hook/node registration, and associated contracts.

## Next

- Keep this PR in Draft for maintainer review and any optional inference-quality comparison.
- Merge only after explicit approval.
