### PR TITLE
fix(aio): clarify external FlashAttention failures in USDU Upscale

### DIFF
--- a/easyuse_anima/aio/legacy_upscale.py
+++ b/easyuse_anima/aio/legacy_upscale.py
@@ -4,6 +4,22 @@ from collections.abc import Callable
 from typing import Any
 
 
+def _usdu_flash_attention_error(error: Exception) -> RuntimeError | None:
+    message = str(error).strip()
+    normalized = message.lower().replace(" ", "").replace("-", "").replace("_", "")
+    if "flashattention" not in normalized:
+        return None
+    original = message or type(error).__name__
+    return RuntimeError(
+        "[EasyUseAnima] AiO Upscale > USDU failed in an active FlashAttention "
+        "backend. EasyUseAnima does not enable FlashAttention by default. Disable "
+        "ComfyUI --use-flash-attention or an external KJNodes Patch Flash Attention "
+        "model patch, or install a flash-attn build compatible with the active "
+        "PyTorch/CUDA/GPU. If AiO SageAttention is enabled for the Upscale stage, "
+        f"disable that stage scope and retry. Original error: {original}"
+    )
+
+
 def run_aio_usdu_upscale_stage(
     model,
     clip,
@@ -129,20 +145,20 @@ def run_aio_usdu_upscale_stage(
             mask_blur=as_int(usdu_settings.get("mask_blur"), 8),
             tile_padding=as_int(usdu_settings.get("tile_padding"), 32),
             seam_fix_mode=str(usdu_settings.get("seam_fix_mode") or "None"),
-            seam_fix_denoise=as_float(
-                usdu_settings.get("seam_fix_denoise"), 1.0
-            ),
-            seam_fix_mask_blur=as_int(
-                usdu_settings.get("seam_fix_mask_blur"), 8
-            ),
+            seam_fix_denoise=as_float(usdu_settings.get("seam_fix_denoise"), 1.0),
+            seam_fix_mask_blur=as_int(usdu_settings.get("seam_fix_mask_blur"), 8),
             seam_fix_width=as_int(usdu_settings.get("seam_fix_width"), 64),
             seam_fix_padding=as_int(usdu_settings.get("seam_fix_padding"), 16),
-            force_uniform_tiles=as_bool(
-                usdu_settings.get("force_uniform_tiles"), True
-            ),
+            force_uniform_tiles=as_bool(usdu_settings.get("force_uniform_tiles"), True),
             tiled_decode=as_bool(usdu_settings.get("tiled_decode"), False),
             batch_size=as_int(usdu_settings.get("batch_size"), 1),
         )
+    except Exception as error:
+        diagnostic = _usdu_flash_attention_error(error)
+        if diagnostic is None:
+            raise
+        # Keep the upstream exception available to ComfyUI's traceback renderer.
+        raise diagnostic from error
     finally:
         cleanup_model(stage_model, model)
     values = node_output_tuple(result)

--- a/easyuse_anima/aio/legacy_upscale.py
+++ b/easyuse_anima/aio/legacy_upscale.py
@@ -7,7 +7,7 @@ from typing import Any
 def _usdu_flash_attention_error(error: Exception) -> RuntimeError | None:
     message = str(error).strip()
     normalized = message.lower().replace(" ", "").replace("-", "").replace("_", "")
-    if "flashattention" not in normalized:
+    if "flashattention" not in normalized and "flashattn" not in normalized:
         return None
     original = message or type(error).__name__
     return RuntimeError(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -46875,7 +46875,7 @@
         "is_package": false,
         "loc": 312,
         "module": "easyuse_anima.aio.legacy_upscale",
-        "normalized_git_blob_sha1": "085cda9f202ca69d4cb767fb8066a153d8b7b16f",
+        "normalized_git_blob_sha1": "0cd18ac029c50eab60a3a1f50329667ca418641c",
         "path": "easyuse_anima/aio/legacy_upscale.py",
         "top_level": {
           "class_count": 0,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -46841,37 +46841,45 @@
         "functions": [
           {
             "async": false,
-            "end_line": 166,
+            "end_line": 20,
             "kind": "function",
             "line": 7,
+            "loc": 14,
+            "qualified_name": "_usdu_flash_attention_error"
+          },
+          {
+            "async": false,
+            "end_line": 182,
+            "kind": "function",
+            "line": 23,
             "loc": 160,
             "qualified_name": "run_aio_usdu_upscale_stage"
           },
           {
             "async": false,
-            "end_line": 235,
+            "end_line": 251,
             "kind": "function",
-            "line": 169,
+            "line": 185,
             "loc": 67,
             "qualified_name": "run_aio_resshift_upscale_stage"
           },
           {
             "async": false,
-            "end_line": 293,
+            "end_line": 309,
             "kind": "function",
-            "line": 238,
+            "line": 254,
             "loc": 56,
             "qualified_name": "run_aio_upscale_stage"
           }
         ],
         "is_package": false,
-        "loc": 296,
+        "loc": 312,
         "module": "easyuse_anima.aio.legacy_upscale",
-        "normalized_git_blob_sha1": "7ff9a3ac88221798428f378b39886d94e0b55d6e",
+        "normalized_git_blob_sha1": "085cda9f202ca69d4cb767fb8066a153d8b7b16f",
         "path": "easyuse_anima/aio/legacy_upscale.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
+          "function_count": 4,
           "global_count": 1
         }
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -1371,6 +1371,75 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertIs(result[0], output)
         self.assertEqual(result[1]["prompt_mode"], "full")
 
+    def test_usdu_stage_reclassifies_flash_attention_errors_after_cleanup(self):
+        trace = []
+        original = ImportError(
+            "Flash attention not found. Install either FA2 ('flash_attn') or FA3."
+        )
+
+        class Logger:
+            def info(self, *args):
+                return None
+
+        class FailingUSDU:
+            def upscale(self, **kwargs):
+                trace.append("upscale")
+                raise original
+
+        helpers = {
+            "_require_custom_node_class": lambda *args: FailingUSDU,
+            "_load_upscale_model_with_comfy": lambda name: object(),
+            "_aio_stage_sampler_settings": lambda *args, **kwargs: {
+                "seed": 1,
+                "steps": 2,
+                "cfg": 3.0,
+                "sampler_name": "euler",
+                "scheduler": "simple",
+                "denoise": 0.4,
+            },
+            "_as_float": lambda value, default: default,
+            "_as_int": lambda value, default: default,
+            "_as_bool": lambda value, default: default,
+            "_aio_usdu_tile_plan": lambda *args: {
+                "auto": False,
+                "tile_width": 512,
+                "tile_height": 512,
+            },
+            "logger": Logger(),
+            "_aio_usdu_conditioning": lambda *args: (object(), object()),
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler": (
+                lambda *args: object()
+            ),
+            "_resolve_aio_runtime_seed": lambda value: 1,
+            "_cleanup_aio_ephemeral_model": (
+                lambda current, base: trace.append("cleanup")
+            ),
+            "AIO_USDU_PROMPT_FULL": "full",
+        }
+
+        with patch.multiple(legacy_generation, **helpers):
+            with self.assertRaises(RuntimeError) as raised:
+                legacy_generation._run_aio_usdu_upscale_stage(
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    {},
+                    {"usdu": {}},
+                )
+
+        self.assertEqual(trace, ["upscale", "cleanup"])
+        self.assertIs(raised.exception.__cause__, original)
+        message = str(raised.exception)
+        self.assertIn("AiO Upscale > USDU", message)
+        self.assertIn("does not enable FlashAttention by default", message)
+        self.assertIn("--use-flash-attention", message)
+        self.assertIn("Patch Flash Attention", message)
+        self.assertIn("SageAttention", message)
+        self.assertIn(str(original), message)
+
     def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
         trace = []
         image = _Token("image")

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from easyuse_anima.aio import generation_normalization, legacy_generation
+from easyuse_anima.aio import generation_normalization, legacy_generation, legacy_upscale
 from easyuse_anima.aio.generation_lifecycle import StageModelPatchPlan
 from easyuse_anima.extensions.aio import AioHookExecutionError
 from easyuse_anima.nodes import aio_nodes
@@ -1439,6 +1439,20 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertIn("Patch Flash Attention", message)
         self.assertIn("SageAttention", message)
         self.assertIn(str(original), message)
+
+    def test_usdu_flash_attention_classifier_accepts_display_and_module_names(self):
+        for message in (
+            "Flash attention does not support attention masks",
+            "No module named 'flash_attn'",
+        ):
+            with self.subTest(message=message):
+                diagnostic = legacy_upscale._usdu_flash_attention_error(
+                    RuntimeError(message)
+                )
+                self.assertIsInstance(diagnostic, RuntimeError)
+        self.assertIsNone(
+            legacy_upscale._usdu_flash_attention_error(RuntimeError("upscale failed"))
+        )
 
     def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
         trace = []


### PR DESCRIPTION
## 목적과 변경 경계

Closes #654

- AiO `Upscale > USDU`에서 외부 attention backend가 던진 FlashAttention 오류를 stage-scoped 진단으로 재분류합니다.
- EasyUseAnima가 FlashAttention을 기본 활성화하지 않는다는 소유 경계와 확인할 설정을 안내합니다.
- `Flash attention` 표시명과 `flash_attn` 모듈명만 대상으로 하며 원래 예외를 `__cause__`로 보존합니다.
- 패키지 자동 설치, attention backend 자동 변경, 오류 삼키기/fallback, ResShift 동작 변경은 포함하지 않습니다.

## Base -> Head

- `dev@35ad48a` -> `codex/fix-upscale-flashattention-diagnostic@181c941`

## 주요 파일과 보존 계약

- `easyuse_anima/aio/legacy_upscale.py`
  - 알려진 FlashAttention 표기만 분류해 ComfyUI 시작 인자, 외부 KJNodes patch, 환경 호환성, AiO SageAttention Upscale scope를 확인하도록 안내합니다.
  - 일반 USDU 예외는 기존 타입/메시지 그대로 다시 던집니다.
  - 성공/실패 시 stage model cleanup 순서를 보존합니다.
- `tests/test_aio_legacy_generation.py`
  - 표시명, 모듈명, 일반 오류 비분류, 원인 예외 체인, cleanup을 고정합니다.
- `tests/fixtures/python_backend_baseline.json`
  - 저장소 analyzer로 새 helper inventory만 결정적으로 갱신했습니다.

## 검증

- focused `tests.test_aio_legacy_generation`: 34 passed
- focused `tests.test_python_backend_analyzer`: 19 passed
- focused `tests.test_python_size_complexity`: 7 passed
- quick profile: passed
- full profile at `181c941`: 1,508 passed, 2 skipped
- frontend: 121 JavaScript files / TypeScript 6.0.3 passed
- `git diff --check`: passed

## 남은 위험과 rollback

- 제보의 전체 traceback은 아직 없으므로 upstream 원인 자체를 고쳤다고 단정하지 않습니다. 이 PR은 EasyUseAnima가 직접 활성화하지 않은 FlashAttention 실패의 소유 경계와 다음 조치를 정확히 안내합니다.
- 문자열에 `Flash attention` 또는 `flash_attn`이 없는 다른 backend 문구는 의도적으로 재분류하지 않습니다.
- GPU/live queue는 실행하지 않았습니다. 샘플링 결과를 바꾸지 않는 예외 진단 경계이며, 외부 FlashAttention 환경을 자동 구성하지 않습니다.
- rollback은 이 브랜치의 두 커밋 revert로 제한됩니다.

## Next

- 제보자의 전체 traceback이 확보되면 실제 활성화 경로가 ComfyUI `--use-flash-attention`, KJNodes patch, 또는 다른 backend인지 이슈 #654에 추가 확인합니다.
- 리뷰 후 Ready 전환 여부를 결정합니다.