### PR TITLE
Fix long terminal wildcard expansion

### DIFF
--- a/easyuse_anima/wildcard/expansion.py
+++ b/easyuse_anima/wildcard/expansion.py
@@ -213,6 +213,13 @@ class _Replacement:
             len(self.parts) - 1,
         )
 
+    @property
+    def can_expand(self) -> bool:
+        values = self.parts
+        if len(self.parts) > 1 and self.separator:
+            values = (*values, self.separator)
+        return any(has_wildcard_syntax(value) for value in values)
+
     def materialize(self) -> str:
         if len(self.parts) == 1:
             return self.parts[0]
@@ -284,13 +291,14 @@ class _ExpansionState:
             or projected_bytes > self.budget.max_output_chars
         ):
             return "max_output_chars"
-        growth = self.budget.max_growth_per_pass
-        if (
-            projected_chars > math.floor(max(1, self._pass_base_chars) * growth)
-            or projected_bytes
-            > math.floor(max(1, self._pass_base_bytes) * growth)
-        ):
-            return "max_growth_per_pass"
+        if replacement.can_expand:
+            growth = self.budget.max_growth_per_pass
+            if (
+                projected_chars > math.floor(max(1, self._pass_base_chars) * growth)
+                or projected_bytes
+                > math.floor(max(1, self._pass_base_bytes) * growth)
+            ):
+                return "max_growth_per_pass"
         return None
 
     def replace_matches(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -57988,153 +57988,161 @@
           },
           {
             "async": false,
-            "end_line": 219,
+            "end_line": 221,
             "kind": "method",
             "line": 216,
+            "loc": 6,
+            "qualified_name": "_Replacement.can_expand"
+          },
+          {
+            "async": false,
+            "end_line": 226,
+            "kind": "method",
+            "line": 223,
             "loc": 4,
             "qualified_name": "_Replacement.materialize"
           },
           {
             "async": false,
-            "end_line": 229,
+            "end_line": 236,
             "kind": "method",
-            "line": 223,
+            "line": 230,
             "loc": 7,
             "qualified_name": "_ExpansionState.__init__"
           },
           {
             "async": false,
-            "end_line": 233,
+            "end_line": 240,
             "kind": "method",
-            "line": 231,
+            "line": 238,
             "loc": 3,
             "qualified_name": "_ExpansionState.begin_pass"
           },
           {
             "async": false,
-            "end_line": 237,
+            "end_line": 244,
             "kind": "method",
-            "line": 235,
+            "line": 242,
             "loc": 3,
             "qualified_name": "_ExpansionState.stop"
           },
           {
             "async": false,
-            "end_line": 257,
+            "end_line": 264,
             "kind": "method",
-            "line": 239,
+            "line": 246,
             "loc": 19,
             "qualified_name": "_ExpansionState.candidate"
           },
           {
             "async": false,
-            "end_line": 294,
+            "end_line": 302,
             "kind": "method",
-            "line": 259,
-            "loc": 36,
+            "line": 266,
+            "loc": 37,
             "qualified_name": "_ExpansionState._replacement_limit_reason"
           },
           {
             "async": false,
-            "end_line": 337,
+            "end_line": 345,
             "kind": "method",
-            "line": 296,
+            "line": 304,
             "loc": 42,
             "qualified_name": "_ExpansionState.replace_matches"
           },
           {
             "async": false,
-            "end_line": 353,
+            "end_line": 361,
             "kind": "function",
-            "line": 340,
+            "line": 348,
             "loc": 14,
             "qualified_name": "_expand_multiselect_options"
           },
           {
             "async": false,
-            "end_line": 404,
+            "end_line": 412,
             "kind": "function",
-            "line": 356,
+            "line": 364,
             "loc": 49,
             "qualified_name": "_replace_dynamic"
           },
           {
             "async": false,
-            "end_line": 402,
+            "end_line": 410,
             "kind": "function",
-            "line": 362,
+            "line": 370,
             "loc": 41,
             "qualified_name": "_replace_dynamic.replace"
           },
           {
             "async": false,
-            "end_line": 430,
+            "end_line": 438,
             "kind": "function",
-            "line": 407,
+            "line": 415,
             "loc": 24,
             "qualified_name": "_replace_quantified_wildcards"
           },
           {
             "async": false,
-            "end_line": 428,
+            "end_line": 436,
             "kind": "function",
-            "line": 413,
+            "line": 421,
             "loc": 16,
             "qualified_name": "_replace_quantified_wildcards.replace"
           },
           {
             "async": false,
-            "end_line": 451,
+            "end_line": 459,
             "kind": "function",
-            "line": 433,
+            "line": 441,
             "loc": 19,
             "qualified_name": "_replace_file_wildcards"
           },
           {
             "async": false,
-            "end_line": 449,
+            "end_line": 457,
             "kind": "function",
-            "line": 439,
+            "line": 447,
             "loc": 11,
             "qualified_name": "_replace_file_wildcards.replace"
           },
           {
             "async": false,
-            "end_line": 460,
+            "end_line": 468,
             "kind": "function",
-            "line": 454,
+            "line": 462,
             "loc": 7,
             "qualified_name": "has_wildcard_syntax"
           },
           {
             "async": false,
-            "end_line": 472,
+            "end_line": 480,
             "kind": "function",
-            "line": 463,
+            "line": 471,
             "loc": 10,
             "qualified_name": "_bounded_output_prefix"
           },
           {
             "async": false,
-            "end_line": 480,
+            "end_line": 488,
             "kind": "function",
-            "line": 475,
+            "line": 483,
             "loc": 6,
             "qualified_name": "_expansion_state_signature"
           },
           {
             "async": false,
-            "end_line": 595,
+            "end_line": 603,
             "kind": "function",
-            "line": 491,
+            "line": 499,
             "loc": 105,
             "qualified_name": "_expand_snapshot_texts"
           }
         ],
         "is_package": false,
-        "loc": 595,
+        "loc": 603,
         "module": "easyuse_anima.wildcard.expansion",
-        "normalized_git_blob_sha1": "943f80770883575c05b1d09b2c0db66c218678b9",
+        "normalized_git_blob_sha1": "fee70c95714c0047f8b78cce1ab20765fd8cac5b",
         "path": "easyuse_anima/wildcard/expansion.py",
         "top_level": {
           "class_count": 6,

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -644,7 +644,12 @@ class WildcardCanonicalContractTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "unicode.txt").write_text(f"{'가' * 5}\n", encoding="utf-8")
-            (root / "growth.txt").write_text(f"{'x' * 21}\n", encoding="utf-8")
+            (root / "terminal.txt").write_text(f"{'x' * 21}\n", encoding="utf-8")
+            (root / "growth.txt").write_text(
+                f"{'x' * 13}__leaf__\n",
+                encoding="utf-8",
+            )
+            (root / "leaf.txt").write_text("done\n", encoding="utf-8")
 
             output_limited = expand_wildcards(
                 "__unicode__",
@@ -652,7 +657,16 @@ class WildcardCanonicalContractTests(unittest.TestCase):
                 roots=[root],
                 budget=WildcardExpansionBudget(max_output_chars=12),
             )
-            growth_limited = expand_wildcards(
+            terminal = expand_wildcards(
+                "__terminal__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(
+                    max_output_chars=100,
+                    max_growth_per_pass=2.0,
+                ),
+            )
+            recursive_growth_limited = expand_wildcards(
                 "__growth__",
                 seed=0,
                 roots=[root],
@@ -667,9 +681,15 @@ class WildcardCanonicalContractTests(unittest.TestCase):
         self.assertEqual(output_limited.replacement_count, 0)
         self.assertLessEqual(len(output_limited.text), 12)
         self.assertLessEqual(len(output_limited.text.encode("utf-8")), 12)
-        self.assertEqual(growth_limited.text, "__growth__")
-        self.assertEqual(growth_limited.limit_reason, "max_growth_per_pass")
-        self.assertEqual(growth_limited.replacement_count, 0)
+        self.assertEqual(terminal.text, "x" * 21)
+        self.assertIsNone(terminal.limit_reason)
+        self.assertEqual(terminal.replacement_count, 1)
+        self.assertEqual(recursive_growth_limited.text, "__growth__")
+        self.assertEqual(
+            recursive_growth_limited.limit_reason,
+            "max_growth_per_pass",
+        )
+        self.assertEqual(recursive_growth_limited.replacement_count, 0)
 
     def test_random_mode_uses_numpy_pcg64_golden_outputs(self):
         selector = wildcard_selector._Selector(7, sequential=False)
@@ -1427,6 +1447,61 @@ class WildcardNodeTests(unittest.TestCase):
         self.assertIn(first[0]["text"], {"rose", "tulip", "sunflower"})
         self.assertNotEqual(first[0]["text"], "samples/flower")
         self.assertEqual(source_fields[0]["text"], "__samples/flower__")
+
+    def test_prompt_studio_advanced_v2_expands_long_terminal_file_candidate(self):
+        long_prompt = ", ".join(
+            [
+                "newest",
+                "masterpiece",
+                "1girl",
+                "solo",
+                *[f"descriptive tag {index}" for index in range(100)],
+                "An intelligent girl watches the city lights while the rain falls softly.",
+            ]
+        )
+        fields = [{
+            "id": "positive_general",
+            "pane": "positive",
+            "type": "general",
+            "label": "General Tags",
+            "text": "__long_prompt__",
+            "height": 120,
+            "enabled": True,
+        }]
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "long_prompt.txt").write_text(
+                f"{long_prompt}\n",
+                encoding="utf-8",
+            )
+
+            def expand_from_test_root(texts, *, seed, mode):
+                return expand_wildcard_texts(texts, seed=seed, mode=mode, roots=[root])
+
+            with patch.object(
+                prompt_advanced,
+                "expand_wildcard_texts",
+                side_effect=expand_from_test_root,
+            ):
+                output = EasyUseAnimaPromptStudioAdvancedV2().build(
+                    False,
+                    True,
+                    False,
+                    False,
+                    json.dumps(fields),
+                    wildcard_mode="sequential",
+                    wildcard_seed=0,
+                    wildcard_seed_after_generate="fixed",
+                )
+
+        prompt_data = output["result"][0]
+        self.assertGreater(len(long_prompt), len("__long_prompt__") * 8)
+        self.assertEqual(prompt_data["fields"][0]["text"], long_prompt)
+        self.assertNotEqual(prompt_data["positive_prompt"], "long prompt")
+        self.assertIn("descriptive tag 99", prompt_data["positive_prompt"])
+        self.assertIn("An intelligent girl watches", prompt_data["positive_prompt"])
+        self.assertEqual(prompt_data["wildcard"]["used_keys"], ["long_prompt"])
 
     def test_prompt_studio_sequential_seed_selects_and_wraps_in_order(self):
         fields = [{


### PR DESCRIPTION
## Purpose and scope

Promote the validated long terminal wildcard fix from `dev` to stable `main`.

Fixes #660.

Version metadata, tag creation, GitHub Release, and Comfy Registry publication are intentionally separate from this production-change PR.

## Base -> head

- `main@66ae8b6` -> `codex/promote-long-wildcard-main@44c02b3`
- The promotion branch contains only the squash commit from #661.
- Its tree is byte-for-byte identical to validated `dev@8f99291`.

## Behavior and preserved contracts

- Long terminal wildcard candidates with comma-separated tags and natural-language text can exceed the relative per-pass growth ratio.
- Candidates that can recursively expand retain the growth guard.
- The absolute output, depth, replacement-count, and cycle limits remain active.
- Prompt Studio Advanced v2 receives expanded content instead of a normalized wildcard filename.
- Wildcard syntax, sequential/random modes, seeds, workflows, and public node contracts remain compatible.

## Validation reused from the identical tree

- Focused output/growth regression: passed
- Focused Prompt Studio Advanced v2 long wildcard regression: passed
- `WildcardCanonicalContractTests`: 49 passed
- `WildcardNodeTests`: 26 passed
- Official full gate: 1,524 Python tests passed, 2 skipped; frontend checks passed across 121 JavaScript files; all architecture and contract gates passed
- The final 1.1.2 tree containing these identical production files also passed `comfy node validate`, package inspection, and isolated ComfyUI 0.27.0 / frontend 1.45.20 validation
- Ruff remains report-only with the existing 26 findings

## Risk and rollback

The relaxed boundary applies only to terminal content and remains bounded by the absolute output cap. Reverting this promotion commit restores the prior behavior.

## Next

Promote the separately validated 1.1.2 release metadata, then create the immutable tag and publish GitHub and Comfy Registry releases.
