### PR TITLE
fix: 가중치 괄호 뒤 자동완성 비활성화

### DIFF
--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -551,8 +551,29 @@ const legacyAtClosing = currentToken(
 );
 assert.equal(strictAtClosing.active, false);
 assert.equal(strictAtClosing.query, "@old_name");
-assert.equal(legacyAtClosing.active, true);
+assert.equal(legacyAtClosing.active, false);
 assert.equal(legacyAtClosing.query, weightedValue);
+
+const multiTagWeightValue = "(blue eyes, long hair:1.2)";
+const multiTagWeightCaret = multiTagWeightValue.indexOf(":");
+for (const previewCompletion of [false, true]) {
+  const insideWeight = currentToken(multiTagWeightValue, multiTagWeightCaret, {
+    detectNaturalSentences: true,
+    previewCompletion,
+  });
+  assert.equal(insideWeight.active, true);
+  assert.equal(autocompleteQuery(insideWeight).query, "long hair");
+  assert.equal(
+    appliedPlan(insideWeight, "short hair").value,
+    "(blue eyes, short hair:1.2)",
+  );
+
+  const afterClosing = currentToken(multiTagWeightValue, multiTagWeightValue.length, {
+    detectNaturalSentences: true,
+    previewCompletion,
+  });
+  assert.equal(afterClosing.active, false);
+}
 
 const escapedLiteral = "\\(blue archive\\)";
 const escapedToken = currentToken(

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -717,6 +717,33 @@ class PromptBuilderTests(unittest.TestCase):
             "1girl, long hair",
         )
 
+    def test_prompt_studio_normalizes_multiline_fields_to_prompt_commas(self):
+        prompt = "1girl\r\nlong hair\n\nblue eyes"
+
+        studio_output = EasyUseAnimaPromptStudio().build(
+            False,
+            False,
+            "",
+            "",
+            "",
+            prompt,
+            "",
+        )
+
+        self.assertEqual(
+            studio_output["result"],
+            (
+                "1girl, long hair, blue eyes",
+                "",
+                False,
+                "1girl, long hair, blue eyes",
+            ),
+        )
+        self.assertEqual(
+            studio_output["ui"]["prompt_studio_inputs"][0]["prompt"],
+            prompt,
+        )
+
     def test_prompt_studio_advanced_defaults_include_negative_output(self):
         result = EasyUseAnimaPromptStudioAdvanced().build(
             False,

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -461,7 +461,7 @@ export function currentToken(value, caret, options = {}) {
   const legacyRaw = text.slice(segmentStart, safeCaret);
   const segment = text.slice(segmentStart, segmentEnd);
   const strictActive = safeCaret >= replaceStart && safeCaret <= replaceEnd && queryEnd > replaceStart;
-  const legacyActive = legacyRaw.trim().length > 0;
+  const legacyActive = strictActive && legacyRaw.trim().length > 0;
   const useStrictToken = options.previewCompletion === true;
   return {
     value: text,


### PR DESCRIPTION
## Summary / 요약

- 가중치 그룹의 닫는 `)` 뒤에서 inline preview OFF일 때도 자동완성이 활성화되던 경계를 수정합니다.
- legacy query 표현은 유지하되, caret이 실제 자동완성 편집 범위 안에 있을 때만 활성화합니다.
- 괄호 내부 다중 태그 편집과 numeric weight/closing suffix 보존을 preview ON/OFF 양쪽에서 회귀 테스트합니다.
- Prompt Studio multiline 원문은 UI에 유지하고 실행/metadata prompt에서는 CRLF/LF/빈 줄을 `, ` 구분으로 정규화하는 기존 동작을 명시적으로 고정합니다.

## Type of change / 변경 유형

- [x] Bug fix / 버그 수정
- [ ] New feature / 새 기능
- [ ] Documentation update / 문서 수정
- [ ] Refactor / 리팩터링
- [x] UI change / UI 변경
- [ ] Other / 기타

## Affected area / 영향 영역

- [x] Prompt tools / 프롬프트 도구
- [ ] NAIA integration / NAIA 연동
- [ ] LoRA tools / LoRA 도구
- [ ] AiO workflow / AiO 워크플로우
- [ ] Detailer or SAM3 helpers / Detailer 또는 SAM3 헬퍼
- [x] UI / frontend
- [ ] Documentation / 문서
- [ ] Other / 기타

## Compatibility / 호환성

- [x] Existing workflows should continue to load.
- [x] Existing saved image workflows should continue to work.
- [ ] This PR changes workflow behavior or saved data format.
- [ ] This PR changes node inputs, outputs, settings, or metadata.
- [ ] Not applicable.

기존 `()`, 중첩 괄호, `[[...]]`, preview on/off query, smart/insert/replace commit 계약은 유지합니다. 설정·workflow·저장 데이터 migration은 없습니다.

## Testing / 검증

- [x] `python -m unittest discover -s tests` (공식 full runner 경유: 1,525 tests, 2 skipped)
- [x] `python -m compileall -q .` (공식 full runner 경유)
- [x] `git diff --check`
- [x] `node --check web/js/autocomplete/text_model.js`
- [ ] ComfyUI starts without import errors.
- [ ] The affected node appears in the node menu.
- [ ] I tested the changed behavior manually.
- [ ] I tested an existing workflow.
- [ ] I could not test this locally.

Focused:

- `node tests/frontend_autocomplete_text_model_smoke.mjs`
- `run_focused_unittest.ps1 -TestTarget tests.test_prompt_corrector.PromptBuilderTests.test_prompt_studio_normalizes_multiline_fields_to_prompt_commas` — 1 passed

Official full:

- `check_custom_node.ps1 -Profile full` — passed at `027ecc2`
- Python unittest 1,525 passed / 2 skipped
- frontend 121 JavaScript files / TypeScript 6.0.3 passed
- Pyright baseline, import boundary, complexity/file ownership, compile, diff gates passed
- Ruff 26 findings are the existing report-only baseline

Legacy Canvas / Node 2.0 live smoke는 실행하지 않았습니다. 변경 경계는 DOM·serialization·canvas lifecycle이 아닌 pure text token model이며 preview ON/OFF 동작을 동일한 semantic smoke에서 직접 검증했습니다.

## Documentation / 문서

- [ ] README or user documentation updated.
- [ ] Node documentation updated.
- [ ] Example workflow updated.
- [x] Not applicable.

## Screenshots or examples / 스크린샷 또는 예시

```text
Before (preview OFF):
(blue eyes, long hair:1.2)| -> active=true, query="long hair:1.2)"

After (preview OFF/ON):
(blue eyes, long hair:1.2)| -> active=false
(blue eyes, long hair|:1.2) -> active=true; completion preserves :1.2)
```

## Related issue / 관련 이슈

Closes #666

Related completed contracts: #64, #98

## Notes for maintainers / 유지보수자 참고 사항

- Base: `0e86a239b8e6210ccb53d66ae91eb0281ec8ad81` (`origin/dev`)
- Head: `027ecc2`
- Rollback: head 단일 커밋 revert
- 저장 형식/API/설정 변경 없음