### PR TITLE
chore(release): prepare EasyUse Anima 1.1.3

### DIFF
--- a/.github/registry/changelogs/1.1.3.txt
+++ b/.github/registry/changelogs/1.1.3.txt
@@ -1,0 +1,9 @@
+EasyUse Anima 1.1.3 improves autocomplete boundaries and AiO manual numeric input.
+
+Changes:
+1. Autocomplete no longer opens after the caret has moved beyond a completed weighted prompt group such as (tag:1.2).
+2. Anima AiO Generator keeps compact slider ranges for convenient adjustment while accepting manually entered values across the larger ranges supported by generation, Highres, Detailer, Upscale, and USDU settings.
+3. Existing slider behavior, saved workflows, generation settings, profiles, public node identifiers, and socket order remain compatible.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "deprecated": false,
+      "changelog_file": "changelogs/1.1.3.txt"
+    },
+    {
+      "version": "1.1.2",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.2.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,24 @@
 # Release Notes
 
+## 1.1.3
+
+### Fixed
+
+- Autocomplete no longer opens after the caret has moved beyond a completed
+  weighted prompt group such as `(tag:1.2)`.
+- Anima AiO Generator numeric controls keep their compact slider ranges while
+  accepting and preserving manually entered values across the larger ranges
+  supported by generation, Highres, Detailer, Upscale, and USDU settings.
+
+### Compatibility
+
+- Existing slider behavior, saved workflows, generation settings, profiles,
+  public node identifiers, and socket order remain compatible.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+
 ## 1.1.2
 
 ### Fixed

--- a/docs/example_workflows/Anima_AiO_v6.0_release_en.json
+++ b/docs/example_workflows/Anima_AiO_v6.0_release_en.json
@@ -27518,7 +27518,7 @@
       "language": "en",
       "kind": "release-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "Anima_AiO_v6.0_release_en.json",
       "release_suffix": "_release_en",

--- a/docs/example_workflows/Anima_AiO_v6.0_release_ja.json
+++ b/docs/example_workflows/Anima_AiO_v6.0_release_ja.json
@@ -27518,7 +27518,7 @@
       "language": "ja",
       "kind": "release-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "Anima_AiO_v6.0_release_ja.json",
       "release_suffix": "_release_ja",

--- a/docs/example_workflows/Anima_AiO_v6.0_release_zh.json
+++ b/docs/example_workflows/Anima_AiO_v6.0_release_zh.json
@@ -27518,7 +27518,7 @@
       "language": "zh",
       "kind": "release-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "Anima_AiO_v6.0_release_zh.json",
       "release_suffix": "_release_zh",

--- a/docs/example_workflows/EasyUse_Anima_artist_mix_release_ko.json
+++ b/docs/example_workflows/EasyUse_Anima_artist_mix_release_ko.json
@@ -1524,7 +1524,7 @@
       "title": "EasyUse Anima Artist Mix",
       "language": "ko",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "release_filename": "EasyUse_Anima_artist_mix_release_ko.json",
       "source": "user/default/workflows/EasyUseAnima_Artist-Mix.json",
       "required_node_packs": [

--- a/docs/example_workflows/EasyUse_Anima_feature_test_release_en.json
+++ b/docs/example_workflows/EasyUse_Anima_feature_test_release_en.json
@@ -850,7 +850,7 @@
       "language": "en",
       "kind": "feature-test-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "EasyUse_Anima_feature_test_release_en.json",
       "release_suffix": "_release_en",

--- a/docs/example_workflows/EasyUse_Anima_feature_test_release_ko.json
+++ b/docs/example_workflows/EasyUse_Anima_feature_test_release_ko.json
@@ -849,7 +849,7 @@
       "language": "ko",
       "kind": "feature-test-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "EasyUse_Anima_feature_test_release_ko.json",
       "release_suffix": "_release_ko",

--- a/docs/example_workflows/EasyUse_Anima_regional_prompt_release_ko.json
+++ b/docs/example_workflows/EasyUse_Anima_regional_prompt_release_ko.json
@@ -686,7 +686,7 @@
       "language": "ko",
       "kind": "regional-prompt-example-workflow",
       "package": "comfyui-easyuse-anima",
-      "package_version": "1.1.2",
+      "package_version": "1.1.3",
       "registry_folder": "docs/example_workflows",
       "release_filename": "EasyUse_Anima_regional_prompt_release_ko.json",
       "release_suffix": "_release_ko",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.2"
+version = "1.1.3"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose and boundary

Prepare EasyUse Anima 1.1.3 as a patch release for the two fixes already merged after 1.1.2. This PR changes release metadata and maintained workflow package-version markers only.

Base -> Head: `dev` (`1551848`) -> `codex/release-1.1.3` (`876f364`)

## User-visible changes

- Autocomplete stops after a completed weighted prompt group.
- AiO numeric controls retain compact slider ranges while valid manual entries can use the larger generation ranges.
- Existing workflows, profiles, slider behavior, public node identifiers, and socket order remain compatible.

## Release files

- Bumps `pyproject.toml` to 1.1.3.
- Adds the user-facing GitHub and Registry release copy.
- Marks 1.1.3 current and 1.1.2 deprecated in the maintained Registry metadata.
- Updates maintained release-workflow package metadata to 1.1.3 without changing workflow topology.

## Validation

- Registry release-copy focused tests: 3 passed.
- Release-workflow focused tests: 9 passed.
- Registry scanner-safety focused tests: 8 passed.
- `comfy node validate`: passed.
- Full repository validation: 1,526 Python tests passed (2 skipped); 121 frontend JavaScript checks passed.
- Registry-equivalent package: 338 runtime files; 463 tracked development files excluded; source worktree clean.
- The AiO manual-input behavior was validated on ComfyUI 0.27.0 in both Legacy Canvas and Node 2.0 before this release-only commit.

## Risk and rollback

The release-only changes do not alter runtime behavior. Before publishing, rollback is reverting this PR. After an immutable public release, fixes require a newer patch version.

## Next

After merge, promote the verified `dev` tree to `main`, create the immutable v1.1.3 tag and GitHub Release/manual-install ZIP, then publish and read back the Registry version.
