### PR TITLE
fix: isolate node discovery from third-party module errors

### DIFF
--- a/easyuse_anima/image/sam3.py
+++ b/easyuse_anima/image/sam3.py
@@ -36,7 +36,10 @@ def _find_impact_detailer_class():
         return cls
 
     for module in list(sys.modules.values()):
-        mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        try:
+            mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        except Exception:
+            continue
         if isinstance(mappings, dict):
             cls = mappings.get("DetailerForEach")
             if cls is not None:
@@ -86,7 +89,10 @@ def _find_impact_mask_to_segs_class():
         return cls
 
     for module in list(sys.modules.values()):
-        mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        try:
+            mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        except Exception:
+            continue
         if isinstance(mappings, dict):
             cls = mappings.get("MaskToSEGS")
             if cls is not None:

--- a/easyuse_anima/infrastructure/comfy/capabilities.py
+++ b/easyuse_anima/infrastructure/comfy/capabilities.py
@@ -107,7 +107,10 @@ def _find_comfy_node_class(node_id: str, comfy_nodes=None):
         except Exception:
             pass
     for module in list(sys.modules.values()):
-        mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        try:
+            mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        except Exception:
+            continue
         if isinstance(mappings, dict):
             cls = mappings.get(node_id)
             if cls is not None:
@@ -156,7 +159,10 @@ def _find_loaded_node_class(
         return cls
 
     for module in list(sys.modules.values()):
-        mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        try:
+            mappings = getattr(module, "NODE_CLASS_MAPPINGS", None)
+        except Exception:
+            continue
         if isinstance(mappings, dict):
             cls = mappings.get(node_id)
             if cls is not None:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -17573,7 +17573,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 45
+            "line": 48
           }
         ],
         "classification": "external",
@@ -17581,7 +17581,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 46,
+        "line": 49,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -17598,7 +17598,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 51
+            "line": 54
           }
         ],
         "classification": "external",
@@ -17606,7 +17606,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 52,
+        "line": 55,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -17623,7 +17623,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 71
+            "line": 74
           }
         ],
         "classification": "external",
@@ -17631,37 +17631,12 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 72,
+        "line": 75,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
         "role": "optional_dependency",
         "scope": "_find_sam3_detect_class",
-        "source": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "MaskToSEGS",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 95
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "impact.segs_nodes:MaskToSEGS",
-        "kind": "static_from",
-        "line": 96,
-        "name": "MaskToSEGS",
-        "optional": true,
-        "requested": "impact.segs_nodes",
-        "role": "optional_dependency",
-        "scope": "_find_impact_mask_to_segs_class",
         "source": "easyuse_anima/image/sam3.py"
       },
       {
@@ -17679,12 +17654,12 @@
         "classification": "external",
         "column": 8,
         "conditional": true,
-        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 102,
         "name": "MaskToSEGS",
         "optional": true,
-        "requested": "modules.impact.segs_nodes",
+        "requested": "impact.segs_nodes",
         "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "easyuse_anima/image/sam3.py"
@@ -17704,12 +17679,12 @@
         "classification": "external",
         "column": 8,
         "conditional": true,
-        "imported": "impact.impact_pack:MaskToSEGS",
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 108,
         "name": "MaskToSEGS",
         "optional": true,
-        "requested": "impact.impact_pack",
+        "requested": "modules.impact.segs_nodes",
         "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "easyuse_anima/image/sam3.py"
@@ -17729,9 +17704,34 @@
         "classification": "external",
         "column": 8,
         "conditional": true,
-        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 114,
+        "name": "MaskToSEGS",
+        "optional": true,
+        "requested": "impact.impact_pack",
+        "role": "optional_dependency",
+        "scope": "_find_impact_mask_to_segs_class",
+        "source": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MaskToSEGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 119
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 120,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -17748,7 +17748,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 164
           }
         ],
         "classification": "external",
@@ -17756,7 +17756,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 159,
+        "line": 165,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -51722,89 +51722,89 @@
           },
           {
             "async": false,
-            "end_line": 61,
+            "end_line": 64,
             "kind": "function",
             "line": 33,
-            "loc": 29,
+            "loc": 32,
             "qualified_name": "_find_impact_detailer_class"
           },
           {
             "async": false,
-            "end_line": 80,
+            "end_line": 83,
             "kind": "function",
-            "line": 64,
+            "line": 67,
             "loc": 17,
             "qualified_name": "_find_sam3_detect_class"
           },
           {
             "async": false,
-            "end_line": 123,
+            "end_line": 129,
             "kind": "function",
-            "line": 83,
-            "loc": 41,
+            "line": 86,
+            "loc": 44,
             "qualified_name": "_find_impact_mask_to_segs_class"
           },
           {
             "async": false,
-            "end_line": 139,
+            "end_line": 145,
             "kind": "function",
-            "line": 126,
+            "line": 132,
             "loc": 14,
             "qualified_name": "_format_sam3_detection_prompt"
           },
           {
             "async": false,
-            "end_line": 148,
+            "end_line": 154,
             "kind": "function",
-            "line": 142,
+            "line": 148,
             "loc": 7,
             "qualified_name": "_sam3_context"
           },
           {
             "async": false,
-            "end_line": 154,
+            "end_line": 160,
             "kind": "function",
-            "line": 151,
+            "line": 157,
             "loc": 4,
             "qualified_name": "_context_value"
           },
           {
             "async": false,
-            "end_line": 167,
+            "end_line": 173,
             "kind": "function",
-            "line": 157,
+            "line": 163,
             "loc": 11,
             "qualified_name": "_empty_mask_for_image"
           },
           {
             "async": false,
-            "end_line": 171,
+            "end_line": 177,
             "kind": "function",
-            "line": 170,
+            "line": 176,
             "loc": 2,
             "qualified_name": "_empty_segs_for_image"
           },
           {
             "async": false,
-            "end_line": 178,
+            "end_line": 184,
             "kind": "function",
-            "line": 174,
+            "line": 180,
             "loc": 5,
             "qualified_name": "_segs_has_items"
           },
           {
             "async": false,
-            "end_line": 189,
+            "end_line": 195,
             "kind": "function",
-            "line": 181,
+            "line": 187,
             "loc": 9,
             "qualified_name": "_call_impact_detailer"
           }
         ],
         "is_package": false,
-        "loc": 192,
+        "loc": 198,
         "module": "easyuse_anima.image.sam3",
-        "normalized_git_blob_sha1": "bac169cbcdb61f3b6a30c5dc62515425dce3a3de",
+        "normalized_git_blob_sha1": "72ed87ef0f19e9123519b70d064da33b695e58dd",
         "path": "easyuse_anima/image/sam3.py",
         "top_level": {
           "class_count": 0,
@@ -51996,41 +51996,41 @@
           },
           {
             "async": false,
-            "end_line": 115,
+            "end_line": 118,
             "kind": "function",
             "line": 97,
-            "loc": 19,
+            "loc": 22,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 130,
+            "end_line": 133,
             "kind": "function",
-            "line": 118,
+            "line": 121,
             "loc": 13,
             "qualified_name": "_require_custom_node_class"
           },
           {
             "async": false,
-            "end_line": 147,
+            "end_line": 150,
             "kind": "function",
-            "line": 133,
+            "line": 136,
             "loc": 15,
             "qualified_name": "_require_any_custom_node_class"
           },
           {
             "async": false,
-            "end_line": 164,
+            "end_line": 170,
             "kind": "function",
-            "line": 150,
-            "loc": 15,
+            "line": 153,
+            "loc": 18,
             "qualified_name": "_find_loaded_node_class"
           }
         ],
         "is_package": false,
-        "loc": 167,
+        "loc": 173,
         "module": "easyuse_anima.infrastructure.comfy.capabilities",
-        "normalized_git_blob_sha1": "3dec2d43ac366bb66bc1e8ca89a2698b58fcd7b9",
+        "normalized_git_blob_sha1": "ef9f4594c33367905545c8ac3b8e5a1a6f973ca8",
         "path": "easyuse_anima/infrastructure/comfy/capabilities.py",
         "top_level": {
           "class_count": 0,
@@ -62810,14 +62810,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 45
+            "line": 48
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 46,
+        "line": 49,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -62829,14 +62829,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 51
+            "line": 54
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 52,
+        "line": 55,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -62848,33 +62848,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 71
+            "line": 74
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 72,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 95
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.segs_nodes:MaskToSEGS",
-        "kind": "static_from",
-        "line": 96,
+        "line": 75,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -62891,7 +62872,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 102,
         "optional": true,
@@ -62910,7 +62891,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:MaskToSEGS",
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 108,
         "optional": true,
@@ -62929,7 +62910,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 114,
         "optional": true,
@@ -62943,14 +62924,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 119
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 120,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 164
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 159,
+        "line": 165,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -67625,14 +67625,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 45
+            "line": 48
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 46,
+        "line": 49,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -67644,14 +67644,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 51
+            "line": 54
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 52,
+        "line": 55,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -67663,33 +67663,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 71
+            "line": 74
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 72,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 95
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.segs_nodes:MaskToSEGS",
-        "kind": "static_from",
-        "line": 96,
+        "line": 75,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -67706,7 +67687,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 102,
         "optional": true,
@@ -67725,7 +67706,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:MaskToSEGS",
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 108,
         "optional": true,
@@ -67744,7 +67725,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 114,
         "optional": true,
@@ -67758,14 +67739,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 119
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 120,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 164
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 159,
+        "line": 165,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -125,6 +125,41 @@ class ComfyCapabilityAdapterTests(unittest.TestCase):
                 loaded_class,
             )
 
+    def test_node_discovery_skips_loaded_modules_with_failing_attribute_access(self):
+        class FailingModule(types.ModuleType):
+            def __getattr__(self, _name):
+                raise ImportError("_C_flashattention unavailable")
+
+        loaded_class = type("LoadedAfterFailure", (), {})
+        failing_module = FailingModule("xformers._C_flashattention")
+        loaded_module = types.ModuleType("easyuse_anima_test_loaded_after_failure")
+        loaded_module.NODE_CLASS_MAPPINGS = {"LoadedAfterFailure": loaded_class}
+
+        with patch.dict(
+            sys.modules,
+            {
+                failing_module.__name__: failing_module,
+                loaded_module.__name__: loaded_module,
+            },
+        ):
+            self.assertIs(
+                capabilities._find_comfy_node_class("LoadedAfterFailure"),
+                loaded_class,
+            )
+            self.assertIs(
+                capabilities._find_loaded_node_class(
+                    "LoadedAfterFailure",
+                    lambda _node_id: None,
+                ),
+                loaded_class,
+            )
+            self.assertIsNone(
+                capabilities._find_loaded_node_class(
+                    "MissingAfterFailure",
+                    lambda _node_id: None,
+                )
+            )
+
     def test_required_node_errors_and_candidate_order_are_preserved(self):
         found_class = type("FoundNode", (), {})
         calls = []

--- a/tests/test_sam3_services.py
+++ b/tests/test_sam3_services.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import sys
 import unittest
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock, patch
 
 from easyuse_anima.image import sam3 as sam3_service
@@ -83,6 +84,48 @@ class SAM3ServiceTests(unittest.TestCase):
         ) as find:
             self.assertIs(sam3_service._find_impact_detailer_class(), sentinel)
         find.assert_called_once_with("DetailerForEach")
+
+    def test_impact_lookup_skips_loaded_modules_with_failing_attribute_access(self):
+        class FailingModule(ModuleType):
+            def __getattr__(self, _name):
+                raise ImportError("_C_flashattention unavailable")
+
+        detailer_class = type("DetailerAfterFailure", (), {})
+        mask_to_segs_class = type("MaskToSEGSAfterFailure", (), {})
+        failing_module = FailingModule("xformers._C_flashattention")
+        loaded_module = ModuleType("easyuse_anima_test_impact_after_failure")
+        loaded_module.NODE_CLASS_MAPPINGS = {
+            "DetailerForEach": detailer_class,
+            "MaskToSEGS": mask_to_segs_class,
+        }
+
+        with (
+            patch_comfy_helper(
+                sam3_service,
+                "_find_comfy_node_mapping_class",
+                return_value=None,
+            ),
+            patch_comfy_helper(
+                sam3_service,
+                "_find_comfy_node_class",
+                return_value=None,
+            ),
+            patch.dict(
+                sys.modules,
+                {
+                    failing_module.__name__: failing_module,
+                    loaded_module.__name__: loaded_module,
+                },
+            ),
+        ):
+            self.assertIs(
+                sam3_service._find_impact_detailer_class(),
+                detailer_class,
+            )
+            self.assertIs(
+                sam3_service._find_impact_mask_to_segs_class(),
+                mask_to_segs_class,
+            )
 
     def test_detailer_missing_host_helper_error_is_preserved(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
## Purpose and boundary

Prevent EasyUseAnima node discovery from failing when an unrelated loaded module raises while NODE_CLASS_MAPPINGS is inspected. The change covers the canonical Comfy host discovery path and the SAM3/Impact fallback scans. Node ids, inputs, outputs, workflows, dependencies, and discovery order remain unchanged.

## Base -> Head

dev -> codex/fix-node-discovery-module-errors

## Changes

- Isolate exceptions to the individual loaded module being inspected, then continue discovery.
- Add regression coverage matching the xformers._C_flashattention ImportError behavior reported with SeedVR2.
- Cover both successful discovery after a failing module and the original missing-node None result.
- Apply the same guard to SAM3 Impact Pack fallback discovery.
- Refresh the deterministic Python backend analyzer fixture.

## Preserved contracts

- Direct ComfyUI mappings and attributes keep priority.
- Loaded-module mappings are searched in the existing order.
- Exceptions from selected node classes and their execution are not swallowed.
- Existing missing dependency errors remain unchanged.

## Validation

- Focused reported regression: 1 passed.
- Comfy adapter owner module: 14 passed.
- SAM3 service owner module: 9 passed.
- Python backend analyzer fixture contract: 1 passed.
- Official full profile on ComfyUI v0.34.0: 1,528 passed, 2 skipped.
- Pyright baseline, import boundaries, size/complexity, file disposition, support ownership, frontend checks for 121 JavaScript files, and git diff check passed.

## Remaining risk and rollback

A live SeedVR2 coexistence server smoke was not run; the regression test reproduces the exact failing ModuleType __getattr__ and ImportError contract without requiring that external node pack. Risk is limited because exception handling is scoped to optional per-module discovery probes. Reverting commit 40d9f18241ee175cb948de377d2b4b763adc03d0 restores the previous behavior.

## Next

After merge and release, installed users must restart ComfyUI so the Python backend change is loaded.