### PR TITLE
chore(release): prepare EasyUse Anima 1.1.4

### DIFF
--- a/.github/registry/changelogs/1.1.4.txt
+++ b/.github/registry/changelogs/1.1.4.txt
@@ -1,0 +1,9 @@
+EasyUse Anima 1.1.4 improves compatibility with other installed custom nodes during startup.
+
+Changes:
+1. EasyUse Anima no longer stops node discovery when an unrelated loaded module raises an import error while its node mappings are inspected.
+2. SAM3 and Impact Pack fallback discovery skips only the failing third-party module and continues searching available compatible nodes.
+3. Existing node identifiers, inputs, outputs, workflows, dependencies, and discovery order remain unchanged.
+
+Action required:
+After updating, restart ComfyUI.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "deprecated": false,
+      "changelog_file": "changelogs/1.1.4.txt"
+    },
+    {
+      "version": "1.1.3",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.3.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## 1.1.4
+
+### Fixed
+
+- EasyUse Anima no longer stops loading or compatible-node discovery when an
+  unrelated loaded module raises an import error while its node mappings are
+  inspected.
+- SAM3 and Impact Pack fallback discovery now skips only the failing
+  third-party module and continues searching the remaining available modules.
+
+### Compatibility
+
+- This improves coexistence with custom nodes such as SeedVR2 when an optional
+  xformers FlashAttention module is unavailable or fails during inspection.
+- Existing node identifiers, inputs, outputs, workflows, dependencies, and
+  discovery order remain unchanged.
+
+### Update
+
+- After updating, restart ComfyUI.
+
 ## 1.1.3
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.3"
+version = "1.1.4"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose and boundary

Prepare EasyUse Anima 1.1.4 as a patch release for the third-party module discovery compatibility fix already merged into `dev`.

## Base -> Head

`dev` -> `codex/release-1.1.4`

## Changes

- Bump the package version from 1.1.3 to 1.1.4.
- Add user-facing GitHub and Comfy Registry release notes.
- Mark 1.1.4 as the current Registry metadata entry and retain previous versions as immutable history.

## Preserved contracts

- No additional runtime code changes are included in this release-preparation PR.
- Node identifiers, inputs, outputs, workflows, dependencies, and discovery order remain unchanged.
- Existing example workflow files are not rewritten because this patch does not change their schema or content.

## Validation

- Registry release copy tests: 3 passed.
- Release workflow tests: 9 passed.
- `comfy node validate`: passed with comfy-cli 1.11.1.
- Official full profile on ComfyUI v0.34.0: 1,528 passed, 2 skipped.
- Pyright baseline, import boundaries, size/complexity, file disposition, support ownership, frontend checks for 121 JavaScript files, and git diff check passed.
- Registry package: 338 runtime files; installed package reported version 1.1.4.
- Isolated ComfyUI startup/API smoke: 22 EasyUse Anima nodes registered and expected core nodes were available.
- The isolated test server was stopped after validation; no user instance was changed.

## Remaining risk and rollback

The exact reported third-party failure is covered by regression tests rather than a live SeedVR2 installation. Runtime risk remains limited because exceptions are isolated to optional per-module discovery probes. Reverting this release-preparation commit restores the 1.1.3 metadata state; published Registry versions remain immutable.

## Next

After merge, promote the validated `dev` state to `main`, create the immutable v1.1.4 tag and GitHub Release with a manual-install ZIP, then publish and read back Comfy Registry 1.1.4.
