### PR TITLE
fix(prompt): align pasted text and highlight overlay

### DIFF
--- a/tests/frontend_prompt_studio_classic_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_classic_values_smoke.mjs
@@ -36,7 +36,7 @@ const settingsUrl = inlineModule(`
 `);
 const highlightWidgetsUrl = inlineModule(`
   export function findInputEl(widget) {
-    return widget?.inputEl || null;
+    return widget?.__easyuseAnimaStudioInput || widget?.inputEl || null;
   }
   export function isWidgetInputLinked(node, name) {
     return node?.inputs?.some((input) => input?.name === name && input?.link != null) || false;
@@ -119,6 +119,26 @@ assert.equal(
   displayText(classicNode, classicPrompt),
   "current classic edit",
   "stale Classic result replaced linked-input presentation",
+);
+
+// Node 2.0 keeps the live native textarea on the shared Prompt Studio seam,
+// not on the legacy inputEl property. Paste rendering must follow that live
+// control even before the host widget value catches up, and retired execution
+// presentation state must never override the current editor text.
+const node2Input = { value: "first pasted line\nsecond pasted line" };
+const node2Prompt = {
+  name: "prompt",
+  value: "stale widget value",
+  __easyuseAnimaStudioInput: node2Input,
+  __easyuseAnimaExecutedText: "retired execution value",
+};
+const node2Node = {
+  inputs: [{ name: "prompt", link: 23 }],
+};
+assert.equal(
+  displayText(node2Node, node2Prompt),
+  node2Input.value,
+  "Node 2.0 pasted text must own the visible highlight overlay",
 );
 
 // QSTATE-04A Extend preservation fixture: submitted slot text, visibility, and

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3440,6 +3440,18 @@ class FrontendModuleStructureTests(unittest.TestCase):
         highlight_ui_source = (
             PROMPT_STUDIO_MODULES / "highlight_ui.js"
         ).read_text(encoding="utf-8")
+        highlight_source = (
+            PROMPT_STUDIO_MODULES / "highlight.js"
+        ).read_text(encoding="utf-8")
+        settings_source = (
+            PROMPT_STUDIO_MODULES / "settings.js"
+        ).read_text(encoding="utf-8")
+        studio_node_ui_source = (
+            PROMPT_STUDIO_MODULES / "studio_node_ui.js"
+        ).read_text(encoding="utf-8")
+        regional_source = PROMPT_STUDIO_REGIONAL_ADAPTER_JS.read_text(
+            encoding="utf-8"
+        )
         runner_source = (
             ROOT / "tools" / "check_frontend.ps1"
         ).read_text(encoding="utf-8")
@@ -3467,6 +3479,30 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("findHighlightInput(widget)", highlight_ui_source)
         self.assertNotIn("widget?.inputEl?.value", highlight_ui_source)
         self.assertNotIn("__easyuseAnimaExecutedText", highlight_ui_source)
+        self.assertIn("PROMPT_STUDIO_SETTINGS.commentEmphasis", highlight_source)
+        self.assertIn("commentEmphasis: true", settings_source)
+        metric_css_rules = (
+            "font:",
+            "font-family:",
+            "font-size:",
+            "font-style:",
+            "font-weight:",
+            "letter-spacing:",
+            "line-height:",
+            "word-spacing:",
+        )
+        for source in (highlight_source, regional_source):
+            token_style_source = source.split("function tokenStyle", 1)[1].split(
+                "function tokenTitle", 1
+            )[0]
+            for css_rule in metric_css_rules:
+                with self.subTest(surface="token-style", css_rule=css_rule):
+                    self.assertNotIn(css_rule, token_style_source)
+        self.assertNotIn("italic: true", regional_source)
+
+        self.assertIn("const STUDIO_INPUT_RETRY_LIMIT = 50", studio_node_ui_source)
+        self.assertIn("const STUDIO_INPUT_RETRY_DELAY_MS = 80", studio_node_ui_source)
+        self.assertNotIn("attempt < 12", studio_node_ui_source)
 
         resolver_source = (
             PROMPT_STUDIO_MODULES / "studio_input_resolver.js"

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3437,6 +3437,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         widgets_source = (
             PROMPT_STUDIO_MODULES / "widgets.js"
         ).read_text(encoding="utf-8")
+        highlight_ui_source = (
+            PROMPT_STUDIO_MODULES / "highlight_ui.js"
+        ).read_text(encoding="utf-8")
         runner_source = (
             ROOT / "tools" / "check_frontend.ps1"
         ).read_text(encoding="utf-8")
@@ -3461,6 +3464,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("widget?.element", widgets_source)
         self.assertIn('candidate?.querySelector?.("textarea, input")', widgets_source)
         self.assertIn("input.isConnected !== false", widgets_source)
+        self.assertIn("findHighlightInput(widget)", highlight_ui_source)
+        self.assertNotIn("widget?.inputEl?.value", highlight_ui_source)
+        self.assertNotIn("__easyuseAnimaExecutedText", highlight_ui_source)
 
         resolver_source = (
             PROMPT_STUDIO_MODULES / "studio_input_resolver.js"

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -161,7 +161,9 @@ const TEXT = {
     underlineWeightSyntax: "Underline weight syntax",
     underlineWeightSyntaxTip:
       "Underline weighted prompt syntax such as (tag:1.2) and Artist Mix groups like [[artist_a, artist_b:0.7]].",
-    italicizeComments: "Italicize comment lines",
+    italicizeComments: "Emphasize comment lines",
+    italicizeCommentsTip:
+      "Uses color and background only so wrapped comments stay aligned with the native text cursor.",
     useDesktopNaia: "Use NAIA desktop Prompt Engineering settings",
   },
   ko: {
@@ -295,7 +297,9 @@ const TEXT = {
     underlineWeightSyntax: "가중치 문법 밑줄 표시",
     underlineWeightSyntaxTip:
       "(tag:1.2) 같은 프롬프트 가중치와 [[artist_a, artist_b:0.7]] 같은 Artist Mix 그룹 문법에 밑줄을 표시합니다.",
-    italicizeComments: "주석 라인 이탤릭체",
+    italicizeComments: "주석 라인 강조",
+    italicizeCommentsTip:
+      "색상과 배경만 사용하여 줄바꿈된 주석도 실제 입력 커서와 정렬되게 유지합니다.",
     useDesktopNaia: "NAIA 데스크톱 Prompt Engineering 설정 사용",
   },
   ja: {
@@ -429,7 +433,9 @@ const TEXT = {
     underlineWeightSyntax: "重み構文に下線を表示",
     underlineWeightSyntaxTip:
       "(tag:1.2) のようなプロンプト重み構文と [[artist_a, artist_b:0.7]] のような Artist Mix グループ構文に下線を表示します。",
-    italicizeComments: "コメント行を斜体にする",
+    italicizeComments: "コメント行を強調",
+    italicizeCommentsTip:
+      "色と背景だけを使い、折り返したコメントを実際の入力カーソルと揃えます。",
     useDesktopNaia: "NAIA デスクトップ Prompt Engineering 設定を使用",
   },
   zh: {
@@ -563,7 +569,9 @@ const TEXT = {
     underlineWeightSyntax: "为权重语法显示下划线",
     underlineWeightSyntaxTip:
       "为 (tag:1.2) 等提示词权重语法和 [[artist_a, artist_b:0.7]] 等 Artist Mix 分组语法显示下划线。",
-    italicizeComments: "注释行使用斜体",
+    italicizeComments: "强调注释行",
+    italicizeCommentsTip:
+      "仅使用颜色和背景，使换行后的注释与实际输入光标保持对齐。",
     useDesktopNaia: "使用 NAIA 桌面 Prompt Engineering 设置",
   },
 };

--- a/web/js/prompt_studio/constants.js
+++ b/web/js/prompt_studio/constants.js
@@ -677,7 +677,7 @@ const SECTION_STYLES = {
   translation: { label: "번역 구문", color: "#22d3ee", background: "rgba(8, 145, 178, 0.22)", weight: 700 },
   wildcard: { label: "와일드카드", color: "#c084fc", background: "rgba(126, 34, 206, 0.24)", weight: 700 },
   lora: { label: "LoRA 구문", color: "#e879f9", background: "rgba(192, 38, 211, 0.22)", weight: 700 },
-  comment: { label: "주석", color: "#9ca3af", background: "rgba(156, 163, 175, 0.14)", weight: 400, italic: true },
+  comment: { label: "주석", color: "#9ca3af", background: "rgba(156, 163, 175, 0.14)", weight: 400 },
   syntax: { label: "문법 오류", color: "#f87171", background: "transparent", underline: true, weight: 400 },
   unknown: { label: "미확인", color: "#cbd5e1", background: "transparent", underline: true, weight: 400 },
 };

--- a/web/js/prompt_studio/highlight.js
+++ b/web/js/prompt_studio/highlight.js
@@ -40,15 +40,17 @@ async function classifyPrompt(text) {
 function tokenStyle(token) {
   const style = SECTION_STYLES[token?.section] || SECTION_STYLES.unknown;
   const opacity = token?.learned || token?.section === "count" ? 1 : 0.88;
+  // Token spans must stay paint-only. The native textarea owns glyph metrics,
+  // caret positions, and wrapping; per-token font changes make them diverge.
   const rules = [
     `color: ${style.color}`,
     `opacity: ${opacity}`,
   ];
-  if (style.background && style.background !== "transparent") {
+  const showBackground = style.background
+    && style.background !== "transparent"
+    && (token?.section !== "comment" || PROMPT_STUDIO_SETTINGS.commentEmphasis);
+  if (showBackground) {
     rules.push(`background: ${style.background}`, "border-radius: 3px");
-  }
-  if (style.italic && PROMPT_STUDIO_SETTINGS.commentItalic) {
-    rules.push("font-style: italic");
   }
   if (style.underline && PROMPT_STUDIO_SETTINGS.typoIndicator && !token?.weighted) {
     rules.push(

--- a/web/js/prompt_studio/highlight_ui.js
+++ b/web/js/prompt_studio/highlight_ui.js
@@ -14,7 +14,6 @@ import {
 } from "./highlight_revision.js";
 import {
   findInputEl,
-  isWidgetInputLinked,
 } from "./widgets.js";
 
 /** @typedef {import("./types.js").PromptStudioInputElement} PromptStudioInputElement */
@@ -27,11 +26,8 @@ function findHighlightInput(widget) {
   return findInputEl(widget);
 }
 
-function displayText(node, widget) {
-  if (isWidgetInputLinked(node, widget.name) && widget.__easyuseAnimaExecutedText != null) {
-    return String(widget.__easyuseAnimaExecutedText);
-  }
-  return String(widget?.inputEl?.value ?? widget?.value ?? "");
+function displayText(_node, widget, input = findHighlightInput(widget)) {
+  return String(input?.value ?? widget?.value ?? "");
 }
 
 function updateHighlight(node, widget, tokens = widget.__easyuseAnimaTokens || [], forceCopyMetrics = false) {
@@ -49,7 +45,7 @@ function updateHighlight(node, widget, tokens = widget.__easyuseAnimaTokens || [
     copyInputTextMetrics(input, overlay);
   }
   syncOverlayBounds(input, overlay);
-  const value = displayText(node, widget);
+  const value = displayText(node, widget, input);
   const currentTokens = highlightTokensForText(
     value,
     widget.__easyuseAnimaLastClassifiedText,

--- a/web/js/prompt_studio/regional/editor_adapter.js
+++ b/web/js/prompt_studio/regional/editor_adapter.js
@@ -225,7 +225,7 @@ const SECTION_STYLES = {
   natural: { label: "Natural language", color: "#cbd5e1", background: "rgba(71, 85, 105, 0.16)", weight: 400 },
   translation: { label: "Translation marker", color: "#22d3ee", background: "rgba(8, 145, 178, 0.22)", weight: 700 },
   wildcard: { label: "Wildcard", color: "#c084fc", background: "rgba(126, 34, 206, 0.24)", weight: 700 },
-  comment: { label: "Comment", color: "#9ca3af", background: "rgba(156, 163, 175, 0.14)", weight: 400, italic: true },
+  comment: { label: "Comment", color: "#9ca3af", background: "rgba(156, 163, 175, 0.14)", weight: 400 },
   syntax: { label: "Syntax error", color: "#f87171", background: "transparent", underline: true, weight: 400 },
   unknown: { label: "Unknown", color: "#cbd5e1", background: "transparent", underline: true, weight: 400 },
 };
@@ -1048,15 +1048,13 @@ function sectionLabel(section) {
 function tokenStyle(token) {
   const style = SECTION_STYLES[token?.section] || SECTION_STYLES.unknown;
   const opacity = token?.learned || token?.section === "count" ? 1 : 0.88;
+  // Match the native textarea's glyph metrics; token styles are paint-only.
   const rules = [
     `color: ${style.color}`,
     `opacity: ${opacity}`,
   ];
   if (style.background && style.background !== "transparent") {
     rules.push(`background: ${style.background}`, "border-radius: 3px");
-  }
-  if (style.italic) {
-    rules.push("font-style: italic");
   }
   if (style.underline && !token?.weighted) {
     rules.push(

--- a/web/js/prompt_studio/settings.js
+++ b/web/js/prompt_studio/settings.js
@@ -17,7 +17,9 @@ import {
 const PROMPT_STUDIO_SETTINGS = {
   typoIndicator: true,
   weightSyntaxUnderline: false,
-  commentItalic: true,
+  // Keep the legacy setting key, but use it only for paint-only emphasis.
+  // Per-token font changes can wrap differently from the native textarea.
+  commentEmphasis: true,
   fontOverride: false,
   fontFamily: "",
   fontSize: PROMPT_STUDIO_FONT_SIZE_DEFAULT,
@@ -52,7 +54,7 @@ function applyPromptStudioTextStyle(input) {
 function applyPromptStudioSettings(settings, { hideTrainedTagTooltip = null } = {}) {
   PROMPT_STUDIO_SETTINGS.typoIndicator = settings?.["prompt_studio.typo_indicator"] !== "false";
   PROMPT_STUDIO_SETTINGS.weightSyntaxUnderline = settings?.["prompt_studio.weight_syntax_underline"] === "true";
-  PROMPT_STUDIO_SETTINGS.commentItalic = settings?.["prompt_studio.comment_italic"] !== "false";
+  PROMPT_STUDIO_SETTINGS.commentEmphasis = settings?.["prompt_studio.comment_italic"] !== "false";
   PROMPT_STUDIO_SETTINGS.trainedTagTooltip = settings?.["prompt_studio.trained_tag_tooltip"] !== "false";
   if (!PROMPT_STUDIO_SETTINGS.trainedTagTooltip) {
     hideTrainedTagTooltip?.();

--- a/web/js/prompt_studio/studio_node_ui.js
+++ b/web/js/prompt_studio/studio_node_ui.js
@@ -20,6 +20,9 @@ import {
   findWidget,
 } from "./widgets.js";
 
+const STUDIO_INPUT_RETRY_LIMIT = 50;
+const STUDIO_INPUT_RETRY_DELAY_MS = 80;
+
 function hookStudioNode(node, attempt = 0, hooks = {}) {
   const {
     applyExtendSlotVisibility = () => {},
@@ -164,8 +167,11 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
     layoutExtendPromptWidgets(node);
   }
   refreshNodeSize(node);
-  if (pendingInput && attempt < 12) {
-    setTimeout(() => hookStudioNode(node, attempt + 1, hooks), 80);
+  if (pendingInput && attempt < STUDIO_INPUT_RETRY_LIMIT) {
+    setTimeout(
+      () => hookStudioNode(node, attempt + 1, hooks),
+      STUDIO_INPUT_RETRY_DELAY_MS,
+    );
   }
 }
 

--- a/web/js/settings/definitions.js
+++ b/web/js/settings/definitions.js
@@ -283,6 +283,7 @@ export function createEasyUseAnimaSettings(dependencies) {
       section: "PromptStudio",
       group: t("highlightBehavior"),
       name: t("italicizeComments"),
+      tooltip: t("italicizeCommentsTip"),
       type: "boolean",
       defaultValue: true,
     }),


### PR DESCRIPTION
## 요약

Prompt Studio에서 붙여넣은 여러 줄 프롬프트의 하이라이트 오버레이와 실제 입력창이 서로 다른 위치에서 줄바꿈되는 문제를 수정합니다.

## 변경

- 하이라이트는 항상 현재 보이는 입력 요소의 live value를 기준으로 렌더링합니다.
- 주석 강조에서 이탤릭처럼 글자 폭을 바꾸는 서식을 제거하고 배경색 강조만 유지합니다.
- Node 2.0 워크플로 재로드 때 늦게 생성되는 입력 요소에도 오버레이가 연결되도록 재시도 시간을 보강합니다.
- Classic, Advanced, Advanced V2, Regional의 기존 설정 키와 저장 워크플로 계약은 유지합니다.

## 검증

- 정확한 신고 프롬프트 2,269자 / 25줄 / 주석 8줄로 Node 2.0과 Legacy Canvas에서 입력값, 오버레이 텍스트, 경계 및 글꼴 메트릭 일치 확인
- Node 2.0 저장 워크플로 재로드 시 20개 입력/오버레이 연결 확인
- focused unittest와 frontend smoke 통과
- 최종 SHA 12d64ae에서 full 검증 통과: Python 1,528 tests (2 skipped), frontend 121 checks
- ComfyUI 0.34.0, frontend 1.49.6
- git diff --check 통과

## 호환성

기존 노드 식별자, 입력/출력, 저장 워크플로, 프롬프트 문자열, 설정 키는 변경하지 않습니다. 업데이트 후 ComfyUI를 재시작하고 브라우저를 강력 새로고침해야 합니다.