### PR TITLE
chore(release): prepare EasyUse Anima 1.1.5

### DIFF
--- a/.github/registry/changelogs/1.1.5.txt
+++ b/.github/registry/changelogs/1.1.5.txt
@@ -1,0 +1,10 @@
+EasyUse Anima 1.1.5 keeps Prompt Studio highlights aligned with pasted multiline text.
+
+Changes:
+1. Prompt Studio highlights now follow the current visible editor text after a long prompt is pasted or replaced.
+2. Comment-line emphasis keeps the same font metrics as the input text, so headings and long translated lines no longer shift the overlay.
+3. Saved Node 2.0 workflows reconnect Prompt Studio highlights when their text inputs finish loading after the node.
+4. Existing prompts, settings, workflows, node identifiers, inputs, and outputs remain compatible.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "deprecated": false,
+      "changelog_file": "changelogs/1.1.5.txt"
+    },
+    {
+      "version": "1.1.4",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.4.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## 1.1.5
+
+### Fixed
+
+- Prompt Studio highlights now stay on the same lines as the editable text
+  after pasting or replacing long multiline prompts.
+- Comment-line emphasis no longer changes glyph width, preventing headings and
+  long translated lines from shifting the remaining highlight overlay.
+- Saved Node 2.0 workflows now reconnect Prompt Studio highlights when their
+  text inputs finish loading after the node itself.
+
+### Compatibility
+
+- Prompt Studio Classic, Advanced, Advanced V2, and Regional keep their
+  existing prompts, settings, saved workflows, node identifiers, inputs, and
+  outputs.
+- The existing comment highlight setting is preserved and now uses
+  layout-neutral background emphasis.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+
 ## 1.1.4
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.4"
+version = "1.1.5"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose and boundary

Prepare EasyUse Anima 1.1.5 as a patch release for the Prompt Studio highlight alignment fix already merged into dev.

## Base -> Head

dev at bc5b71f -> codex/release-1.1.5 at 6ec2110

## Changes

- Bump the package version from 1.1.4 to 1.1.5.
- Add user-facing GitHub and Comfy Registry release notes.
- Mark 1.1.5 as the current Registry metadata entry and retain previous versions as immutable history.

## Preserved contracts

- No additional runtime Python or JavaScript changes are included in this release-preparation PR.
- Existing prompts, settings, workflows, node identifiers, inputs, and outputs remain compatible.
- Existing workflow templates are unchanged because this patch does not change their schema or content.

## Validation

- Registry release copy tests: 3 passed.
- Release workflow tests: 9 passed.
- comfy node validate: passed.
- Official full profile on ComfyUI v0.34.0 and frontend 1.49.6: 1,528 passed, 2 skipped.
- Frontend checks passed for 121 JavaScript files; Python contract gates and git diff check passed.
- Registry package: 338 runtime files, 0 forbidden paths, embedded version 1.1.5.
- Exact reported 2,269-character prompt passed Node 2.0 and Legacy Canvas overlay/text/metric parity checks before the runtime fix was merged.
- The isolated test server was stopped; no user instance was changed.

## Remaining risk and rollback

Comfy Registry versions 1.1.2 through 1.1.4 are currently flagged by the external scanner for informational SQLite and explicit NAIA network patterns. The 1.1.5 publish may enter the same external review state. Reverting this release-preparation commit restores 1.1.4 metadata; a published Registry version remains immutable.

## Next

After merge, promote the byte-identical release tree to main, create and verify annotated tag v1.1.5, publish the GitHub Release with a top-level-folder manual-install ZIP and SHA-256, then publish and read back Comfy Registry 1.1.5.