### PR TITLE
chore(release): prepare EasyUse Anima 1.1.6

### DIFF
--- a/.github/registry/changelogs/1.1.6.txt
+++ b/.github/registry/changelogs/1.1.6.txt
@@ -1,0 +1,11 @@
+EasyUse Anima 1.1.6 hardens request, output-path, and optional model-loading boundaries.
+
+Changes:
+1. State-changing EasyUse Anima routes now accept only same-origin JSON requests.
+2. AiO Image Saver paths are validated after template expansion and must stay inside ComfyUI's output directory.
+3. Wildcard listing no longer creates directories or sample files as a read side effect.
+4. AiO ResShift now stops with a clear safety message before invoking its legacy external checkpoint loader; use USDU in the meantime.
+5. Existing nodes, profiles, workflows, and valid Image Saver templates remain compatible. Saved ResShift settings are preserved.
+
+Action required:
+After updating, restart ComfyUI. Cross-origin or non-JSON integrations that call state-changing EasyUse Anima routes must use same-origin JSON requests.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "deprecated": false,
+      "changelog_file": "changelogs/1.1.6.txt"
+    },
+    {
+      "version": "1.1.5",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.5.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## 1.1.6
+
+### Fixed
+
+- State-changing EasyUse Anima HTTP routes now accept only same-origin JSON
+  requests, reducing exposure to cross-site requests from untrusted pages.
+- AiO Image Saver paths are validated after supported template expansion and
+  must remain inside ComfyUI's active output directory.
+- Wildcard listing is now read-only and no longer creates a directory or
+  sample file as a side effect.
+- The AiO ResShift stage now fails closed before loading an external
+  checkpoint. Use USDU while a safe ResShift loader contract is developed.
+
+### Compatibility
+
+- Existing node identifiers, inputs, outputs, profiles, saved workflows, and
+  valid Image Saver templates remain compatible.
+- Saved ResShift settings are preserved, but selecting ResShift will show an
+  explanatory error instead of running the unsafe legacy loader path.
+- Cross-origin or non-JSON tools that call EasyUse Anima's state-changing HTTP
+  routes must move to a same-origin JSON integration.
+
+### Update
+
+- After updating, restart ComfyUI.
+
 ## 1.1.5
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.5"
+version = "1.1.6"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose

Prepare EasyUse Anima 1.1.6 as the release metadata boundary for the Registry security hardening already merged through #680.

## Base -> Head

`dev` -> `codex/release-1.1.6`

## Changes

- Bump the package version from 1.1.5 to 1.1.6.
- Add installer-facing Registry changelog copy for 1.1.6.
- Add the 1.1.6 GitHub release-note section.
- Mark 1.1.6 as current and 1.1.5 as deprecated in the checked-in Registry metadata plan.

## Compatibility and rollback

- Existing node identifiers, inputs, outputs, profiles, workflows, and valid Image Saver templates remain compatible.
- ResShift settings remain serialized, but the stage fails closed until a safe loader contract is available; USDU remains available.
- This PR changes release metadata only and can be reverted independently from the production security fix.

## Validation

- Release-copy focused tests passed.
- Repository quick and full checks passed on ComfyUI 0.34.0 with frontend 1.49.6.
- Full suite: 1,533 Python tests passed, 2 skipped; all 121 frontend checks passed.
- `comfy node validate` passed, including security checks.
- Registry package contained 338 runtime files, excluded 466 tracked development files, and contained no unsafe paths.
- The packaged 1.1.6 node loaded in the isolated ComfyUI instance; node registration and same-origin request enforcement were exercised.
- Ruff retains 25 pre-existing report-only findings.

## Tracking

- #677 remains open until the live Registry reports 1.1.6 as Active.
- Native Image Saver replacement remains tracked separately in #678.
- Safe ResShift re-enablement remains tracked separately in #679.
