### PR TITLE
release: promote EasyUse Anima 1.1.6

### DIFF
--- a/.github/registry/changelogs/1.1.6.txt
+++ b/.github/registry/changelogs/1.1.6.txt
@@ -1,0 +1,11 @@
+EasyUse Anima 1.1.6 hardens request, output-path, and optional model-loading boundaries.
+
+Changes:
+1. State-changing EasyUse Anima routes now accept only same-origin JSON requests.
+2. AiO Image Saver paths are validated after template expansion and must stay inside ComfyUI's output directory.
+3. Wildcard listing no longer creates directories or sample files as a read side effect.
+4. AiO ResShift now stops with a clear safety message before invoking its legacy external checkpoint loader; use USDU in the meantime.
+5. Existing nodes, profiles, workflows, and valid Image Saver templates remain compatible. Saved ResShift settings are preserved.
+
+Action required:
+After updating, restart ComfyUI. Cross-origin or non-JSON integrations that call state-changing EasyUse Anima routes must use same-origin JSON requests.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "deprecated": false,
+      "changelog_file": "changelogs/1.1.6.txt"
+    },
+    {
+      "version": "1.1.5",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.5.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## 1.1.6
+
+### Fixed
+
+- State-changing EasyUse Anima HTTP routes now accept only same-origin JSON
+  requests, reducing exposure to cross-site requests from untrusted pages.
+- AiO Image Saver paths are validated after supported template expansion and
+  must remain inside ComfyUI's active output directory.
+- Wildcard listing is now read-only and no longer creates a directory or
+  sample file as a side effect.
+- The AiO ResShift stage now fails closed before loading an external
+  checkpoint. Use USDU while a safe ResShift loader contract is developed.
+
+### Compatibility
+
+- Existing node identifiers, inputs, outputs, profiles, saved workflows, and
+  valid Image Saver templates remain compatible.
+- Saved ResShift settings are preserved, but selecting ResShift will show an
+  explanatory error instead of running the unsafe legacy loader path.
+- Cross-origin or non-JSON tools that call EasyUse Anima's state-changing HTTP
+  routes must move to a same-origin JSON integration.
+
+### Update
+
+- After updating, restart ComfyUI.
+
 ## 1.1.5
 
 ### Fixed

--- a/docs/development/registry-scanner-safety.md
+++ b/docs/development/registry-scanner-safety.md
@@ -17,6 +17,25 @@ updating a release branch that will be scanned by Registry automation.
   execute response text.
 - Remote HTTP endpoints must be disabled by default or guarded by an explicit
   allow setting. Localhost-only defaults are preferred.
+- Do not deserialize model data with direct `torch.load`, pickle, marshal, or
+  another executable object format. Route model resources through ComfyUI's
+  inventoried loaders and their safe-loading contract.
+- Validate a user-controlled output path after every supported template has
+  been expanded. The resolved destination must remain below ComfyUI's active
+  output directory before any saver or optional node is resolved.
+
+## Request Side-Effect Boundary
+
+- Every EasyUse Anima POST route parses its body through
+  `easyuse_anima.api.requests.parse_json_object`.
+- The shared parser requires `application/json`, a same-authority
+  `Origin`/`Host` pair, and rejects a provided `Sec-Fetch-Site` value unless it
+  is `same-origin` before parsing or dispatching work.
+- GET handlers must not create, rename, or delete user-managed data. Startup
+  bootstrap code owns default wildcard-directory creation; wildcard reads only
+  resolve the configured paths.
+- New side-effecting routes must inherit this boundary rather than parsing a
+  request body directly.
 
 ## EasyUse Anima Rules
 
@@ -28,6 +47,15 @@ updating a release branch that will be scanned by Registry automation.
   `Anima SAM3 Context` and `Anima SAM3 Detailer` nodes are not shipped.
 - SAM3 and Impact Pack integrations must use explicit optional imports for known
   classes. Do not dynamically import user-provided module names.
+- AiO output templates are expanded inside EasyUse Anima and checked against
+  the ComfyUI output root before either core `SaveImage` or an optional saver is
+  called. Do not forward an unexpanded path template to a third-party saver.
+- AiO ResShift execution is fail-closed before optional-node lookup. Its saved
+  settings remain readable, but re-enabling the adapter requires the safe
+  loader contract tracked in issue #679.
+- Replacing the Image Saver dependency with a native EasyUse output backend is
+  tracked separately in issue #678 so format, workflow, metadata, and Civitai
+  compatibility can be reviewed independently from the 1.1.6 security fix.
 
 ## Archive Surface
 

--- a/easyuse_anima/aio/legacy_upscale.py
+++ b/easyuse_anima/aio/legacy_upscale.py
@@ -198,57 +198,26 @@ def run_aio_resshift_upscale_stage(
     as_int: Callable[..., int],
     image_tensor_size: Callable[..., tuple[int, int]],
 ) -> tuple[Any, dict[str, Any]]:
-    resshift_settings = upscale_settings.get("resshift", {})
-    if not isinstance(resshift_settings, dict):
-        resshift_settings = {}
-    loader_cls = require_custom_node_class(
-        "ResShiftLoader",
-        "ComfyUI-Distilled-ResShift",
-        "Required for AiO Generator final Upscale > ResShift.",
+    del (
+        image,
+        sampler_settings,
+        upscale_settings,
+        quality_tags,
+        quality_neg,
+        prompt_data,
+        exclude_positive_quality,
+        exclude_negative_quality,
+        require_custom_node_class,
+        node_output_tuple,
+        resolve_runtime_seed,
+        as_int,
+        image_tensor_size,
     )
-    upscale_cls = require_custom_node_class(
-        "ResShiftUpscale",
-        "ComfyUI-Distilled-ResShift",
-        "Required for AiO Generator final Upscale > ResShift.",
+    raise RuntimeError(
+        "[EasyUseAnima] AiO ResShift is disabled because the current optional "
+        "loader does not provide a safe checkpoint-loading boundary. Use USDU "
+        "for final upscale; safe re-enable work is tracked in GitHub issue #679."
     )
-    loader = loader_cls()
-    load = getattr(loader, "load", None)
-    if load is None:
-        raise RuntimeError("[EasyUseAnima] ResShiftLoader does not expose load().")
-    model_values = node_output_tuple(
-        load(
-            str(resshift_settings.get("scale") or "x2"),
-            str(resshift_settings.get("student_name") or "(auto-download)"),
-            str(resshift_settings.get("dtype") or "bf16"),
-        )
-    )
-    if not model_values:
-        raise RuntimeError("[EasyUseAnima] ResShiftLoader returned no RESSHIFT_MODEL.")
-    upscaler = upscale_cls()
-    upscale = getattr(upscaler, "upscale", None)
-    if upscale is None:
-        raise RuntimeError("[EasyUseAnima] ResShiftUpscale does not expose upscale().")
-    values = node_output_tuple(
-        upscale(
-            model_values[0],
-            image,
-            resolve_runtime_seed(sampler_settings.get("seed")),
-            as_int(resshift_settings.get("chop"), 512),
-            as_int(resshift_settings.get("overlap"), 64),
-            as_int(resshift_settings.get("tile_batch"), 4),
-        )
-    )
-    if not values:
-        raise RuntimeError("[EasyUseAnima] ResShiftUpscale returned no IMAGE.")
-    output = values[0]
-    width, height = image_tensor_size(output, 0, 0)
-    return output, {
-        "enabled": True,
-        "backend": "resshift",
-        "width": int(width),
-        "height": int(height),
-        "scale": str(resshift_settings.get("scale") or "x2"),
-    }
 
 
 def run_aio_upscale_stage(

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from ..common.values import _as_bool, _as_float, _as_int, _single_value
@@ -19,6 +23,32 @@ from .output_settings import (
 from .sampling import _resolve_aio_runtime_seed
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+_IMAGE_SAVER_SAFE_TIME_FORMAT = "%Y-%m-%d-%H%M%S"
+_IMAGE_SAVER_CUSTOM_TIME_RE = re.compile(r"%time_format<([^>]*)>")
+_IMAGE_SAVER_CUSTOM_COUNTER_RE = re.compile(r"%counter<([0-9]+)>")
+_OUTPUT_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+@dataclass(frozen=True, slots=True)
+class _ImageSaverRuntime:
+    settings: dict[str, Any]
+    defaults: dict[str, Any]
+    modelname: str
+    steps: int
+    cfg: float
+    sampler_name: str
+    scheduler_name: str
+    seed: int
+    width: int
+    height: int
+    counter: int
+    denoise: float
+    clip_skip: int
+    custom: str
+    path: str
+    filename: str
+    extension: str
 
 
 def _missing_host_helper(name: str):
@@ -45,6 +75,251 @@ def _require_custom_node_class(
         _missing_host_helper,
     )
     return helper(node_id, node_pack, install_hint)
+
+
+def _comfy_output_directory() -> Path:
+    try:
+        import folder_paths  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(
+            "[EasyUseAnima] ComfyUI output directory is unavailable."
+        ) from exc
+
+    get_output_directory = getattr(folder_paths, "get_output_directory", None)
+    value = (
+        get_output_directory()
+        if callable(get_output_directory)
+        else getattr(folder_paths, "output_directory", None)
+    )
+    if not value:
+        raise RuntimeError(
+            "[EasyUseAnima] ComfyUI output directory is unavailable."
+        )
+    return Path(str(value)).resolve(strict=False)
+
+
+def _output_path_parts(value: str, *, field: str, allow_empty: bool) -> list[str]:
+    text = str(value or "").strip()
+    if not text:
+        if allow_empty:
+            return []
+        raise RuntimeError(f"[EasyUseAnima] AiO save {field} must not be empty.")
+    if len(text) > 1024 or _OUTPUT_CONTROL_RE.search(text):
+        raise RuntimeError(f"[EasyUseAnima] AiO save {field} is invalid.")
+
+    posix_path = PurePosixPath(text)
+    windows_path = PureWindowsPath(text)
+    if posix_path.is_absolute() or windows_path.drive or windows_path.root:
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO save {field} must be relative to the ComfyUI output directory."
+        )
+
+    parts = [part for part in re.split(r"[\\/]", text) if part]
+    if (
+        not parts
+        or any(part in {".", ".."} for part in parts)
+        or any(":" in part for part in parts)
+    ):
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO save {field} must stay within the ComfyUI output directory."
+        )
+    return parts
+
+
+def _validated_output_subpath(
+    value: str,
+    *,
+    field: str,
+    allow_empty: bool = False,
+    filename: bool = False,
+) -> str:
+    parts = _output_path_parts(value, field=field, allow_empty=allow_empty)
+    if not parts:
+        return ""
+    if filename and (len(parts) != 1 or len(parts[0]) > 255):
+        raise RuntimeError(
+            "[EasyUseAnima] AiO save filename must be a single filename component."
+        )
+
+    output_root = _comfy_output_directory()
+    candidate = output_root.joinpath(*parts).resolve(strict=False)
+    try:
+        candidate.relative_to(output_root)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO save {field} must stay within the ComfyUI output directory."
+        ) from exc
+    return "/".join(parts)
+
+
+def _image_saver_model_names(modelname: str) -> tuple[str, str]:
+    filename = str(modelname or "").replace("\\", "/").rsplit("/", 1)[-1]
+    root, extension = os.path.splitext(filename)
+    try:
+        import folder_paths  # type: ignore
+
+        supported = set(getattr(folder_paths, "supported_pt_extensions", ()))
+    except Exception:
+        supported = {".safetensors", ".pt", ".ckpt", ".bin", ".pth"}
+    basename = root if extension.casefold() in supported | {".gguf"} else filename
+    return filename, basename
+
+
+def _image_saver_timestamp(now: datetime, time_format: str) -> str:
+    try:
+        return now.strftime(time_format)
+    except (OSError, ValueError):
+        return now.strftime(_IMAGE_SAVER_SAFE_TIME_FORMAT)
+
+
+def _render_image_saver_template(
+    pattern: str,
+    *,
+    now: datetime,
+    width: int,
+    height: int,
+    seed: int,
+    modelname: str,
+    counter: int,
+    time_format: str,
+    sampler_name: str,
+    steps: int,
+    cfg: float,
+    scheduler_name: str,
+    denoise: float,
+    clip_skip: int,
+    custom: str,
+) -> str:
+    value = str(pattern or "")
+    if len(value) > 1024 or len(str(time_format or "")) > 256:
+        raise RuntimeError("[EasyUseAnima] AiO save template is too long.")
+
+    def replace_time(match: re.Match[str]) -> str:
+        return _image_saver_timestamp(now, match.group(1))
+
+    def replace_counter(match: re.Match[str]) -> str:
+        padding = int(match.group(1))
+        if padding > 32:
+            raise RuntimeError(
+                "[EasyUseAnima] AiO save counter padding must be 32 or less."
+            )
+        return f"{counter:0{padding}d}"
+
+    model_filename, base_model_name = _image_saver_model_names(modelname)
+    value = _IMAGE_SAVER_CUSTOM_TIME_RE.sub(replace_time, value)
+    value = _IMAGE_SAVER_CUSTOM_COUNTER_RE.sub(replace_counter, value)
+    replacements = (
+        ("%date", _image_saver_timestamp(now, "%Y-%m-%d")),
+        ("%time", _image_saver_timestamp(now, time_format)),
+        ("%model", model_filename),
+        ("%width", str(width)),
+        ("%height", str(height)),
+        ("%seed", str(seed)),
+        ("%counter", str(counter)),
+        ("%sampler_name", sampler_name),
+        ("%steps", str(steps)),
+        ("%cfg", str(cfg)),
+        ("%scheduler_name", scheduler_name),
+        ("%basemodelname", base_model_name),
+        ("%denoise", str(denoise)),
+        ("%clip_skip", str(clip_skip)),
+        ("%custom", custom),
+    )
+    for token, replacement in replacements:
+        value = value.replace(token, replacement)
+    if "%" in value:
+        raise RuntimeError(
+            "[EasyUseAnima] AiO save template contains an unsupported placeholder."
+        )
+    if len(value) > 1024:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    return value
+
+
+def _resolve_image_saver_runtime(
+    save_settings: dict[str, Any],
+    *,
+    width: int,
+    height: int,
+    sampler_settings: dict[str, Any],
+    resource_info: dict[str, Any] | None,
+) -> _ImageSaverRuntime:
+    image_saver = save_settings.get("image_saver", {})
+    if not isinstance(image_saver, dict):
+        image_saver = {}
+    defaults = AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"]
+    modelname = str((resource_info or {}).get("unet_name") or "")
+    steps = _as_int(sampler_settings.get("steps"), 28)
+    cfg = _as_float(sampler_settings.get("cfg"), 5.0)
+    sampler_name = str(sampler_settings.get("sampler_name") or "")
+    scheduler_name = str(sampler_settings.get("scheduler") or "normal")
+    seed = _resolve_aio_runtime_seed(sampler_settings.get("seed"))
+    safe_width = _as_int(width, 512)
+    safe_height = _as_int(height, 512)
+    counter = max(0, _as_int(image_saver.get("counter"), defaults["counter"]))
+    denoise = _as_float(sampler_settings.get("denoise"), 1.0)
+    clip_skip = _as_int(image_saver.get("clip_skip"), defaults["clip_skip"])
+    time_format = str(image_saver.get("time_format") or defaults["time_format"])
+    custom = str(image_saver.get("custom") or "")
+    now = datetime.now()
+    template_values = {
+        "now": now,
+        "width": safe_width,
+        "height": safe_height,
+        "seed": seed,
+        "modelname": modelname,
+        "counter": counter,
+        "time_format": time_format,
+        "sampler_name": sampler_name,
+        "steps": steps,
+        "cfg": cfg,
+        "scheduler_name": scheduler_name,
+        "denoise": denoise,
+        "clip_skip": clip_skip,
+        "custom": custom,
+    }
+    rendered_path = _render_image_saver_template(
+        str(image_saver.get("path") or defaults["path"]),
+        **template_values,
+    )
+    rendered_filename = _render_image_saver_template(
+        str(image_saver.get("filename") or defaults["filename"]),
+        **template_values,
+    )
+    if not rendered_filename:
+        rendered_filename = _image_saver_timestamp(now, time_format)
+    safe_path = _validated_output_subpath(
+        rendered_path,
+        field="path",
+        allow_empty=True,
+    )
+    safe_filename = _validated_output_subpath(
+        rendered_filename,
+        field="filename",
+        filename=True,
+    )
+    extension = str(image_saver.get("extension") or defaults["extension"]).casefold()
+    if extension not in {"png", "jpeg", "jpg", "webp"}:
+        raise RuntimeError("[EasyUseAnima] AiO save extension is invalid.")
+    return _ImageSaverRuntime(
+        settings=image_saver,
+        defaults=defaults,
+        modelname=modelname,
+        steps=steps,
+        cfg=cfg,
+        sampler_name=sampler_name,
+        scheduler_name=scheduler_name,
+        seed=seed,
+        width=safe_width,
+        height=safe_height,
+        counter=counter,
+        denoise=denoise,
+        clip_skip=clip_skip,
+        custom=custom,
+        path=safe_path,
+        filename=safe_filename,
+        extension=extension,
+    )
 
 
 def _aio_image_saver_civitai_hash_fetcher_entries(
@@ -169,6 +444,10 @@ def _save_image_with_comfy(
     workflow_prompt=None,
     extra_pnginfo=None,
 ):
+    safe_prefix = _validated_output_subpath(
+        str(filename_prefix or "EasyUseAnima/AiO"),
+        field="filename prefix",
+    )
     save_cls = _find_comfy_node_class("SaveImage")
     if save_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI SaveImage.")
@@ -178,7 +457,7 @@ def _save_image_with_comfy(
         raise RuntimeError("[EasyUseAnima] SaveImage does not expose save_images().")
     return save_images(
         images,
-        str(filename_prefix or "EasyUseAnima/AiO"),
+        safe_prefix,
         prompt=workflow_prompt,
         extra_pnginfo=extra_pnginfo,
     )
@@ -209,6 +488,14 @@ def _save_image_with_image_saver(
     workflow_prompt=None,
     extra_pnginfo=None,
 ):
+    runtime = _resolve_image_saver_runtime(
+        save_settings,
+        width=width,
+        height=height,
+        sampler_settings=sampler_settings,
+        resource_info=resource_info,
+    )
+
     image_saver_cls = _require_custom_node_class(
         "Image Saver",
         "ComfyUI-Image-Saver",
@@ -219,14 +506,9 @@ def _save_image_with_image_saver(
     if save_files is None:
         raise RuntimeError("[EasyUseAnima] Image Saver node does not expose save_files().")
 
-    image_saver = save_settings.get("image_saver", {})
-    if not isinstance(image_saver, dict):
-        image_saver = {}
-    defaults = AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"]
-    modelname = str((resource_info or {}).get("unet_name") or "")
     save_prompt_metadata = _as_bool(
-        image_saver.get("save_prompt_metadata"),
-        defaults["save_prompt_metadata"],
+        runtime.settings.get("save_prompt_metadata"),
+        runtime.defaults["save_prompt_metadata"],
     )
     metadata_positive = (
         _aio_prompt_with_lora_metadata(
@@ -238,63 +520,57 @@ def _save_image_with_image_saver(
     metadata_negative = str(negative_prompt or "unknown") if save_prompt_metadata else ""
     return save_files(
         images=images,
-        filename=str(image_saver.get("filename") or defaults["filename"]),
-        path=str(image_saver.get("path") or defaults["path"]),
-        extension=str(image_saver.get("extension") or defaults["extension"]),
-        steps=_as_int(sampler_settings.get("steps"), 28),
-        cfg=_as_float(sampler_settings.get("cfg"), 5.0),
-        modelname=modelname,
-        sampler_name=str(sampler_settings.get("sampler_name") or ""),
-        scheduler_name=str(sampler_settings.get("scheduler") or "normal"),
+        filename=runtime.filename,
+        path=runtime.path,
+        extension=runtime.extension,
+        steps=runtime.steps,
+        cfg=runtime.cfg,
+        modelname=runtime.modelname,
+        sampler_name=runtime.sampler_name,
+        scheduler_name=runtime.scheduler_name,
         positive=metadata_positive,
         negative=metadata_negative,
-        seed_value=_resolve_aio_runtime_seed(sampler_settings.get("seed")),
-        width=_as_int(width, 512),
-        height=_as_int(height, 512),
+        seed_value=runtime.seed,
+        width=runtime.width,
+        height=runtime.height,
         lossless_webp=_as_bool(
-            image_saver.get("lossless_webp"), defaults["lossless_webp"]
+            runtime.settings.get("lossless_webp"), runtime.defaults["lossless_webp"]
         ),
         quality_jpeg_or_webp=max(
             1,
             min(
                 100,
                 _as_int(
-                    image_saver.get("quality_jpeg_or_webp"),
-                    defaults["quality_jpeg_or_webp"],
+                    runtime.settings.get("quality_jpeg_or_webp"),
+                    runtime.defaults["quality_jpeg_or_webp"],
                 ),
             ),
         ),
         optimize_png=_as_bool(
-            image_saver.get("optimize_png"), defaults["optimize_png"]
+            runtime.settings.get("optimize_png"), runtime.defaults["optimize_png"]
         ),
-        counter=max(
-            0,
-            _as_int(
-                image_saver.get("counter"), defaults["counter"]
-            ),
-        ),
-        denoise=_as_float(sampler_settings.get("denoise"), 1.0),
-        clip_skip=_as_int(
-            image_saver.get("clip_skip"), defaults["clip_skip"]
-        ),
-        time_format=str(image_saver.get("time_format") or defaults["time_format"]),
+        counter=runtime.counter,
+        denoise=runtime.denoise,
+        clip_skip=runtime.clip_skip,
+        time_format=_IMAGE_SAVER_SAFE_TIME_FORMAT,
         save_workflow_as_json=_as_bool(
-            image_saver.get("save_workflow_as_json"),
-            defaults["save_workflow_as_json"],
+            runtime.settings.get("save_workflow_as_json"),
+            runtime.defaults["save_workflow_as_json"],
         ),
         embed_workflow=_as_bool(
-            image_saver.get("embed_workflow"), defaults["embed_workflow"]
+            runtime.settings.get("embed_workflow"),
+            runtime.defaults["embed_workflow"],
         ),
-        additional_hashes=_aio_image_saver_additional_hashes(image_saver),
+        additional_hashes=_aio_image_saver_additional_hashes(runtime.settings),
         download_civitai_data=_as_bool(
-            image_saver.get("download_civitai_data"),
-            defaults["download_civitai_data"],
+            runtime.settings.get("download_civitai_data"),
+            runtime.defaults["download_civitai_data"],
         ),
         easy_remix=_as_bool(
-            image_saver.get("easy_remix"), defaults["easy_remix"]
+            runtime.settings.get("easy_remix"), runtime.defaults["easy_remix"]
         ),
         show_preview=False,
-        custom=str(image_saver.get("custom") or ""),
+        custom=runtime.custom,
         prompt=workflow_prompt,
         extra_pnginfo=extra_pnginfo,
     )

--- a/easyuse_anima/api/requests.py
+++ b/easyuse_anima/api/requests.py
@@ -2,12 +2,107 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
 
 from .errors import ApiContractError, _field_error
 
+_JSON_CONTENT_TYPE = "application/json"
+
+
+def _request_header(request, name: str) -> str:
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return ""
+    try:
+        value = headers.get(name, "")
+    except (AttributeError, TypeError):
+        return ""
+    return str(value or "").strip()
+
+
+def _origin_authority(value: str) -> tuple[str, int | None] | None:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if (
+        parsed.scheme.casefold() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    if port is None:
+        port = 443 if parsed.scheme.casefold() == "https" else 80
+    return parsed.hostname.rstrip(".").casefold(), port
+
+
+def _host_authority(value: str, origin: str) -> tuple[str, int | None] | None:
+    try:
+        parsed = urlsplit(f"//{value}")
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if (
+        not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    if port is None:
+        try:
+            origin_scheme = urlsplit(origin).scheme.casefold()
+        except (TypeError, ValueError):
+            return None
+        port = 443 if origin_scheme == "https" else 80
+    return parsed.hostname.rstrip(".").casefold(), port
+
+
+def validate_same_origin_json_request(request) -> None:
+    """Reject browser-reachable POSTs before parsing or side effects."""
+
+    fetch_site = _request_header(request, "Sec-Fetch-Site").casefold()
+    if fetch_site and fetch_site != "same-origin":
+        raise ApiContractError(
+            403,
+            "cross_origin_request",
+            "Request must come from the current ComfyUI origin.",
+        )
+
+    origin = _request_header(request, "Origin")
+    host = _request_header(request, "Host")
+    if (
+        not origin
+        or not host
+        or _origin_authority(origin) != _host_authority(host, origin)
+    ):
+        raise ApiContractError(
+            403,
+            "cross_origin_request",
+            "Request must come from the current ComfyUI origin.",
+        )
+
+    content_type = _request_header(request, "Content-Type")
+    media_type = content_type.partition(";")[0].strip().casefold()
+    if media_type != _JSON_CONTENT_TYPE:
+        raise ApiContractError(
+            415,
+            "json_content_type_required",
+            "Request Content-Type must be application/json.",
+        )
+
 
 async def parse_json_object(request) -> dict[str, Any]:
+    validate_same_origin_json_request(request)
     try:
         data = await request.json()
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:

--- a/easyuse_anima/wildcard/sources.py
+++ b/easyuse_anima/wildcard/sources.py
@@ -130,10 +130,7 @@ def resolve_wildcard_roots(extra_paths: str | None = None) -> list[Path]:
             seen.add(key)
             roots.append(root)
 
-    try:
-        default_root = ensure_default_wildcard_root().resolve()
-    except OSError:
-        default_root = default_wildcard_root().resolve()
+    default_root = default_wildcard_root().resolve()
     default_key = os.path.normcase(str(default_root))
     if default_key not in seen:
         roots.append(default_root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.5"
+version = "1.1.6"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9169,6 +9169,108 @@
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "datetime",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "datetime:datetime",
+        "kind": "static_from",
+        "line": 9,
+        "name": "datetime",
+        "optional": false,
+        "requested": "datetime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PurePosixPath",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:PurePosixPath",
+        "kind": "static_from",
+        "line": 10,
+        "name": "PurePosixPath",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PureWindowsPath",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:PureWindowsPath",
+        "kind": "static_from",
+        "line": 10,
+        "name": "PureWindowsPath",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -9176,7 +9278,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 7,
+        "line": 11,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -9193,7 +9295,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -9211,7 +9313,7 @@
         "conditional": false,
         "imported": "..common.values:_as_float",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "_as_float",
         "optional": false,
         "requested": "..common.values",
@@ -9229,7 +9331,7 @@
         "conditional": false,
         "imported": "..common.values:_as_int",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "_as_int",
         "optional": false,
         "requested": "..common.values",
@@ -9247,7 +9349,7 @@
         "conditional": false,
         "imported": "..common.values:_single_value",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "_single_value",
         "optional": false,
         "requested": "..common.values",
@@ -9265,7 +9367,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 10,
+        "line": 14,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "..infrastructure.comfy.wiring",
@@ -9283,7 +9385,7 @@
         "conditional": false,
         "imported": "..lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 11,
+        "line": 15,
         "name": "_format_strength",
         "optional": false,
         "requested": "..lora.preset",
@@ -9301,7 +9403,7 @@
         "conditional": false,
         "imported": ".generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 12,
+        "line": 16,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".generation_defaults",
@@ -9319,7 +9421,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 13,
+        "line": 17,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".output_settings",
@@ -9337,7 +9439,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 16,
+        "line": 20,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -9355,7 +9457,7 @@
         "conditional": false,
         "imported": ".sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 19,
+        "line": 23,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".sampling",
@@ -9373,7 +9475,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 81
           }
         ],
         "classification": "external",
@@ -9381,7 +9483,57 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 137,
+        "line": 82,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_comfy_output_directory",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 158
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 159,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_image_saver_model_names",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 411
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 412,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -13327,6 +13479,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -13334,7 +13503,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -13344,17 +13513,17 @@
       },
       {
         "alias": null,
-        "bound_name": "Mapping",
+        "bound_name": "urlsplit",
         "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
-        "imported": "typing:Mapping",
+        "imported": "urllib.parse:urlsplit",
         "kind": "static_from",
-        "line": 5,
-        "name": "Mapping",
+        "line": 7,
+        "name": "urlsplit",
         "optional": false,
-        "requested": "typing",
+        "requested": "urllib.parse",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/requests.py"
@@ -13368,7 +13537,7 @@
         "conditional": false,
         "imported": ".errors:ApiContractError",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "ApiContractError",
         "optional": false,
         "requested": ".errors",
@@ -13386,7 +13555,7 @@
         "conditional": false,
         "imported": ".errors:_field_error",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "_field_error",
         "optional": false,
         "requested": ".errors",
@@ -47532,25 +47701,25 @@
           },
           {
             "async": false,
-            "end_line": 251,
+            "end_line": 220,
             "kind": "function",
             "line": 185,
-            "loc": 67,
+            "loc": 36,
             "qualified_name": "run_aio_resshift_upscale_stage"
           },
           {
             "async": false,
-            "end_line": 309,
+            "end_line": 278,
             "kind": "function",
-            "line": 254,
+            "line": 223,
             "loc": 56,
             "qualified_name": "run_aio_upscale_stage"
           }
         ],
         "is_package": false,
-        "loc": 312,
+        "loc": 281,
         "module": "easyuse_anima.aio.legacy_upscale",
-        "normalized_git_blob_sha1": "0cd18ac029c50eab60a3a1f50329667ca418641c",
+        "normalized_git_blob_sha1": "e1c57bbb96541c9a42e516395ab4bf252fba141c",
         "path": "easyuse_anima/aio/legacy_upscale.py",
         "top_level": {
           "class_count": 0,
@@ -47982,94 +48151,166 @@
         "functions": [
           {
             "async": false,
-            "end_line": 27,
+            "end_line": 57,
             "kind": "function",
-            "line": 24,
+            "line": 54,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 35,
+            "end_line": 65,
             "kind": "function",
-            "line": 30,
+            "line": 60,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 47,
+            "end_line": 77,
             "kind": "function",
-            "line": 38,
+            "line": 68,
             "loc": 10,
             "qualified_name": "_require_custom_node_class"
           },
           {
             "async": false,
-            "end_line": 114,
+            "end_line": 98,
             "kind": "function",
-            "line": 50,
+            "line": 80,
+            "loc": 19,
+            "qualified_name": "_comfy_output_directory"
+          },
+          {
+            "async": false,
+            "end_line": 126,
+            "kind": "function",
+            "line": 101,
+            "loc": 26,
+            "qualified_name": "_output_path_parts"
+          },
+          {
+            "async": false,
+            "end_line": 152,
+            "kind": "function",
+            "line": 129,
+            "loc": 24,
+            "qualified_name": "_validated_output_subpath"
+          },
+          {
+            "async": false,
+            "end_line": 165,
+            "kind": "function",
+            "line": 155,
+            "loc": 11,
+            "qualified_name": "_image_saver_model_names"
+          },
+          {
+            "async": false,
+            "end_line": 172,
+            "kind": "function",
+            "line": 168,
+            "loc": 5,
+            "qualified_name": "_image_saver_timestamp"
+          },
+          {
+            "async": false,
+            "end_line": 236,
+            "kind": "function",
+            "line": 175,
+            "loc": 62,
+            "qualified_name": "_render_image_saver_template"
+          },
+          {
+            "async": false,
+            "end_line": 198,
+            "kind": "function",
+            "line": 197,
+            "loc": 2,
+            "qualified_name": "_render_image_saver_template.replace_time"
+          },
+          {
+            "async": false,
+            "end_line": 206,
+            "kind": "function",
+            "line": 200,
+            "loc": 7,
+            "qualified_name": "_render_image_saver_template.replace_counter"
+          },
+          {
+            "async": false,
+            "end_line": 322,
+            "kind": "function",
+            "line": 239,
+            "loc": 84,
+            "qualified_name": "_resolve_image_saver_runtime"
+          },
+          {
+            "async": false,
+            "end_line": 389,
+            "kind": "function",
+            "line": 325,
             "loc": 65,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 128,
+            "end_line": 403,
             "kind": "function",
-            "line": 117,
+            "line": 392,
             "loc": 12,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 144,
+            "end_line": 419,
             "kind": "function",
-            "line": 131,
+            "line": 406,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 163,
+            "end_line": 438,
             "kind": "function",
-            "line": 147,
+            "line": 422,
             "loc": 17,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 184,
+            "end_line": 463,
             "kind": "function",
-            "line": 166,
-            "loc": 19,
+            "line": 441,
+            "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 196,
+            "end_line": 475,
             "kind": "function",
-            "line": 187,
+            "line": 466,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 300,
+            "end_line": 576,
             "kind": "function",
-            "line": 199,
-            "loc": 102,
+            "line": 478,
+            "loc": 99,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 303,
+        "loc": 579,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "a75a29177f2610c7d825303caad1e1e3cd229413",
+        "normalized_git_blob_sha1": "285fd526ab6ba1e4d9c0c52a8d5c15dfc4759f9e",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
-          "class_count": 0,
-          "function_count": 10,
-          "global_count": 2
+          "class_count": 1,
+          "function_count": 17,
+          "global_count": 6
         }
       },
       {
@@ -49329,63 +49570,95 @@
       {
         "functions": [
           {
-            "async": true,
-            "end_line": 25,
+            "async": false,
+            "end_line": 22,
             "kind": "function",
-            "line": 10,
-            "loc": 16,
+            "line": 14,
+            "loc": 9,
+            "qualified_name": "_request_header"
+          },
+          {
+            "async": false,
+            "end_line": 43,
+            "kind": "function",
+            "line": 25,
+            "loc": 19,
+            "qualified_name": "_origin_authority"
+          },
+          {
+            "async": false,
+            "end_line": 67,
+            "kind": "function",
+            "line": 46,
+            "loc": 22,
+            "qualified_name": "_host_authority"
+          },
+          {
+            "async": false,
+            "end_line": 101,
+            "kind": "function",
+            "line": 70,
+            "loc": 32,
+            "qualified_name": "validate_same_origin_json_request"
+          },
+          {
+            "async": true,
+            "end_line": 120,
+            "kind": "function",
+            "line": 104,
+            "loc": 17,
             "qualified_name": "parse_json_object"
           },
           {
             "async": false,
-            "end_line": 42,
+            "end_line": 137,
             "kind": "function",
-            "line": 28,
+            "line": 123,
             "loc": 15,
             "qualified_name": "json_object"
           },
           {
             "async": false,
-            "end_line": 62,
+            "end_line": 157,
             "kind": "function",
-            "line": 45,
+            "line": 140,
             "loc": 18,
             "qualified_name": "json_string"
           },
           {
             "async": false,
-            "end_line": 76,
+            "end_line": 171,
             "kind": "function",
-            "line": 65,
+            "line": 160,
             "loc": 12,
             "qualified_name": "json_boolean"
           },
           {
             "async": false,
-            "end_line": 96,
+            "end_line": 191,
             "kind": "function",
-            "line": 79,
+            "line": 174,
             "loc": 18,
             "qualified_name": "json_integer"
           },
           {
             "async": false,
-            "end_line": 116,
+            "end_line": 211,
             "kind": "function",
-            "line": 99,
+            "line": 194,
             "loc": 18,
             "qualified_name": "json_uuid_string"
           }
         ],
         "is_package": false,
-        "loc": 126,
+        "loc": 221,
         "module": "easyuse_anima.api.requests",
-        "normalized_git_blob_sha1": "771ec7c194950e5d07d594059a55cee514f163d4",
+        "normalized_git_blob_sha1": "8ed4b07094f18fde0711c0eff73719d3d1d9332a",
         "path": "easyuse_anima/api/requests.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
-          "global_count": 1
+          "function_count": 10,
+          "global_count": 2
         }
       },
       {
@@ -58774,105 +59047,105 @@
           },
           {
             "async": false,
-            "end_line": 140,
+            "end_line": 137,
             "kind": "function",
             "line": 114,
-            "loc": 27,
+            "loc": 24,
             "qualified_name": "resolve_wildcard_roots"
           },
           {
             "async": false,
-            "end_line": 152,
+            "end_line": 149,
             "kind": "function",
-            "line": 143,
+            "line": 140,
             "loc": 10,
             "qualified_name": "_normalize_wildcard_key"
           },
           {
             "async": false,
-            "end_line": 159,
+            "end_line": 156,
             "kind": "function",
-            "line": 155,
+            "line": 152,
             "loc": 5,
             "qualified_name": "_read_text_file"
           },
           {
             "async": false,
-            "end_line": 173,
+            "end_line": 170,
             "kind": "function",
-            "line": 162,
+            "line": 159,
             "loc": 12,
             "qualified_name": "_parse_option"
           },
           {
             "async": false,
-            "end_line": 185,
+            "end_line": 182,
             "kind": "function",
-            "line": 176,
+            "line": 173,
             "loc": 10,
             "qualified_name": "_options_from_lines"
           },
           {
             "async": false,
-            "end_line": 191,
+            "end_line": 188,
             "kind": "function",
-            "line": 188,
+            "line": 185,
             "loc": 4,
             "qualified_name": "_stringify_yaml_scalar"
           },
           {
             "async": false,
-            "end_line": 231,
+            "end_line": 228,
             "kind": "function",
-            "line": 194,
+            "line": 191,
             "loc": 38,
             "qualified_name": "_yaml_entries"
           },
           {
             "async": false,
-            "end_line": 228,
+            "end_line": 225,
             "kind": "function",
-            "line": 197,
+            "line": 194,
             "loc": 32,
             "qualified_name": "_yaml_entries.collect"
           },
           {
             "async": false,
-            "end_line": 242,
+            "end_line": 239,
             "kind": "function",
-            "line": 234,
+            "line": 231,
             "loc": 9,
             "qualified_name": "_load_yaml_entries"
           },
           {
             "async": false,
-            "end_line": 261,
+            "end_line": 258,
             "kind": "function",
-            "line": 245,
+            "line": 242,
             "loc": 17,
             "qualified_name": "_load_wildcard_file"
           },
           {
             "async": false,
-            "end_line": 268,
+            "end_line": 265,
             "kind": "function",
-            "line": 264,
+            "line": 261,
             "loc": 5,
             "qualified_name": "_wildcard_root_identity"
           },
           {
             "async": false,
-            "end_line": 307,
+            "end_line": 304,
             "kind": "function",
-            "line": 271,
+            "line": 268,
             "loc": 37,
             "qualified_name": "_scan_wildcard_sources"
           }
         ],
         "is_package": false,
-        "loc": 307,
+        "loc": 304,
         "module": "easyuse_anima.wildcard.sources",
-        "normalized_git_blob_sha1": "30c9336418c0985563b53e153b678d8be9374428",
+        "normalized_git_blob_sha1": "e0ef3c0646c34000e75d0c1bb043c7d6302032f0",
         "path": "easyuse_anima/wildcard/sources.py",
         "top_level": {
           "class_count": 2,
@@ -60692,9 +60965,75 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "datetime:datetime",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:PurePosixPath",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:PureWindowsPath",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 7,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/output.py"
@@ -60706,14 +61045,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 137,
+        "line": 82,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 158
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 159,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 411
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 412,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -61724,7 +62101,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "collections.abc:Mapping",
         "kind": "static_from",
         "line": 5,
         "optional": false,
@@ -61735,9 +62112,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Mapping",
+        "imported": "typing:Any",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "urllib.parse:urlsplit",
+        "kind": "static_from",
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/requests.py"
@@ -67391,14 +67779,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 137,
+        "line": 82,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 158
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 159,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 411
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 412,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -69737,7 +70163,43 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 21,
+        "line": 25,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 30,
+        "context": "assign:_IMAGE_SAVER_CUSTOM_TIME_RE",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 33,
+        "context": "assign:_IMAGE_SAVER_CUSTOM_COUNTER_RE",
+        "kind": "import_time_call",
+        "line": 29,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 21,
+        "context": "assign:_OUTPUT_CONTROL_RE",
+        "kind": "import_time_call",
+        "line": 30,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_ImageSaverRuntime",
+        "kind": "import_time_call",
+        "line": 33,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -8,9 +8,13 @@ import unittest
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from easyuse_anima.aio import generation_normalization, legacy_generation, legacy_upscale
+from easyuse_anima.aio import (
+    generation_normalization,
+    legacy_generation,
+    legacy_upscale,
+)
 from easyuse_anima.aio.generation_lifecycle import StageModelPatchPlan
 from easyuse_anima.extensions.aio import AioHookExecutionError
 from easyuse_anima.nodes import aio_nodes
@@ -1454,262 +1458,41 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             legacy_upscale._usdu_flash_attention_error(RuntimeError("upscale failed"))
         )
 
-    def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
-        trace = []
-        image = _Token("image")
-        output = _Token("output")
-        model = _Token("resshift_model")
-        sampler_settings = {"seed": "seed-input"}
-        upscale_settings = {
-            "resshift": {
-                "scale": "x4",
-                "student_name": "student.ckpt",
-                "dtype": "fp32",
-                "chop": "1024",
-                "overlap": "96",
-                "tile_batch": "2",
-            }
-        }
-
-        class Loader:
-            def __init__(self):
-                trace.append("construct:loader")
-
-            def load(self, *args):
-                trace.append(("call", "load", args))
-                return "loader-result"
-
-        class Upscaler:
-            def __init__(self):
-                trace.append("construct:upscaler")
-
-            def upscale(self, *args):
-                trace.append(("call", "upscale", args))
-                return "upscale-result"
-
-        def require(node_id, node_pack, install_hint):
-            trace.append(("call", "_require_custom_node_class", node_id))
-            self.assertEqual(node_pack, "ComfyUI-Distilled-ResShift")
-            self.assertEqual(
-                install_hint,
-                "Required for AiO Generator final Upscale > ResShift.",
-            )
-            return Loader if node_id == "ResShiftLoader" else Upscaler
-
-        tuple_results = iter(((model,), (output,)))
-
-        def node_output_tuple(value):
-            trace.append(("call", "_node_output_tuple", value))
-            return next(tuple_results)
-
-        def resolve_seed(value):
-            trace.append(("call", "_resolve_aio_runtime_seed", value))
-            return 321
-
-        def as_int(value, default):
-            trace.append(("call", "_as_int", value, default))
-            return int(value)
-
-        def image_size(value, fallback_width, fallback_height):
-            trace.append(("call", "_image_tensor_size"))
-            self.assertIs(value, output)
-            self.assertEqual((fallback_width, fallback_height), (0, 0))
-            return 2048, 3072
-
+    def test_resshift_stage_fails_closed_before_optional_loader_resolution(self):
         helpers = {
-            "_require_custom_node_class": require,
-            "_node_output_tuple": node_output_tuple,
-            "_resolve_aio_runtime_seed": resolve_seed,
-            "_as_int": as_int,
-            "_image_tensor_size": image_size,
+            "_require_custom_node_class": Mock(
+                side_effect=AssertionError("must not resolve ResShift nodes")
+            ),
+            "_node_output_tuple": Mock(
+                side_effect=AssertionError("must not inspect node output")
+            ),
+            "_resolve_aio_runtime_seed": Mock(
+                side_effect=AssertionError("must not resolve seed")
+            ),
+            "_as_int": Mock(side_effect=AssertionError("must not parse settings")),
+            "_image_tensor_size": Mock(
+                side_effect=AssertionError("must not inspect image")
+            ),
         }
 
         with patch.multiple(legacy_generation, **helpers):
-            result = legacy_generation._run_aio_resshift_upscale_stage(
-                image,
-                sampler_settings,
-                upscale_settings,
-                "unused-quality",
-                "unused-negative",
-                {"unused": True},
-                True,
-                True,
-            )
-
-        self.assertIs(result[0], output)
-        self.assertEqual(
-            result[1],
-            {
-                "enabled": True,
-                "backend": "resshift",
-                "width": 2048,
-                "height": 3072,
-                "scale": "x4",
-            },
-        )
-        self.assertEqual(
-            list(result[1]),
-            ["enabled", "backend", "width", "height", "scale"],
-        )
-        self.assertEqual(
-            trace,
-            [
-                ("call", "_require_custom_node_class", "ResShiftLoader"),
-                ("call", "_require_custom_node_class", "ResShiftUpscale"),
-                "construct:loader",
-                (
-                    "call",
-                    "load",
-                    ("x4", "student.ckpt", "fp32"),
-                ),
-                ("call", "_node_output_tuple", "loader-result"),
-                "construct:upscaler",
-                ("call", "_resolve_aio_runtime_seed", "seed-input"),
-                ("call", "_as_int", "1024", 512),
-                ("call", "_as_int", "96", 64),
-                ("call", "_as_int", "2", 4),
-                (
-                    "call",
-                    "upscale",
-                    (model, image, 321, 1024, 96, 2),
-                ),
-                ("call", "_node_output_tuple", "upscale-result"),
-                ("call", "_image_tensor_size"),
-            ],
-        )
-
-    def test_resshift_stage_preserves_failure_boundaries(self):
-        image = _Token("image")
-
-        def execute(helpers, trace):
-            with patch.multiple(legacy_generation, **helpers):
-                return legacy_generation._run_aio_resshift_upscale_stage(
-                    image,
-                    {"seed": 7},
-                    {"resshift": {}},
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"AiO ResShift is disabled.*issue #679",
+            ):
+                legacy_generation._run_aio_resshift_upscale_stage(
+                    _Token("image"),
+                    {"seed": "attacker-controlled"},
+                    {
+                        "resshift": {
+                            "student_name": "untrusted.ckpt",
+                            "scale": "x4",
+                        }
+                    },
                 )
 
-        first_provider_trace = []
-
-        def fail_first_provider(*args):
-            first_provider_trace.append("require:loader")
-            raise LookupError("provider failed")
-
-        with self.assertRaisesRegex(LookupError, "provider failed"):
-            execute(
-                {"_require_custom_node_class": fail_first_provider},
-                first_provider_trace,
-            )
-        self.assertEqual(
-            first_provider_trace,
-            ["require:loader"],
-        )
-
-        missing_load_trace = []
-
-        class MissingLoad:
-            def __init__(self):
-                missing_load_trace.append("construct:loader")
-
-        class UnusedUpscaler:
-            def __init__(self):
-                missing_load_trace.append("construct:upscaler")
-
-        def missing_load_provider(node_id, *args):
-            missing_load_trace.append(f"require:{node_id}")
-            return MissingLoad if node_id == "ResShiftLoader" else UnusedUpscaler
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r"^\[EasyUseAnima\] ResShiftLoader does not expose load\(\)\.$",
-        ):
-            execute(
-                {"_require_custom_node_class": missing_load_provider},
-                missing_load_trace,
-            )
-        self.assertEqual(
-            missing_load_trace,
-            [
-                "require:ResShiftLoader",
-                "require:ResShiftUpscale",
-                "construct:loader",
-            ],
-        )
-
-        empty_model_trace = []
-
-        class EmptyLoader:
-            def load(self, *args):
-                empty_model_trace.append("load")
-                return "loader-result"
-
-        class NeverConstructedUpscaler:
-            def __init__(self):
-                empty_model_trace.append("construct:upscaler")
-
-        def empty_model_provider(node_id, *args):
-            return EmptyLoader if node_id == "ResShiftLoader" else NeverConstructedUpscaler
-
-        def empty_tuple(value):
-            empty_model_trace.append(f"tuple:{value}")
-            return ()
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r"^\[EasyUseAnima\] ResShiftLoader returned no RESSHIFT_MODEL\.$",
-        ):
-            execute(
-                {
-                    "_require_custom_node_class": empty_model_provider,
-                    "_node_output_tuple": empty_tuple,
-                },
-                empty_model_trace,
-            )
-        self.assertNotIn("construct:upscaler", empty_model_trace)
-
-        seed_failure_trace = []
-
-        class Loader:
-            def load(self, *args):
-                seed_failure_trace.append("load")
-                return "loader-result"
-
-        class Upscaler:
-            def __init__(self):
-                seed_failure_trace.append("construct:upscaler")
-
-            def upscale(self, *args):
-                seed_failure_trace.append("upscale")
-                return "upscale-result"
-
-        def provider(node_id, *args):
-            return Loader if node_id == "ResShiftLoader" else Upscaler
-
-        tuple_results = iter(((object(),), (object(),)))
-
-        def tuple_helper(value):
-            seed_failure_trace.append(f"tuple:{value}")
-            return next(tuple_results)
-
-        def fail_seed(value):
-            seed_failure_trace.append("seed")
-            raise ValueError("seed failed")
-
-        with self.assertRaisesRegex(ValueError, "seed failed"):
-            execute(
-                {
-                    "_require_custom_node_class": provider,
-                    "_node_output_tuple": tuple_helper,
-                    "_resolve_aio_runtime_seed": fail_seed,
-                },
-                seed_failure_trace,
-            )
-        self.assertIn("construct:upscaler", seed_failure_trace)
-        self.assertEqual(
-            seed_failure_trace[-1:],
-            ["seed"],
-        )
-        self.assertNotIn("upscale", seed_failure_trace)
+        for helper in helpers.values():
+            helper.assert_not_called()
 
     def test_upscale_dispatcher_preserves_lazy_branch_and_exception_contract(self):
         model = _Token("model")

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from easyuse_anima.aio import (
@@ -10,8 +11,8 @@ from easyuse_anima.aio import (
     first_pass_cache,
     generation_defaults,
     generation_normalization,
-    input_defaults,
     input_context,
+    input_defaults,
     legacy_generation,
     model_preparation,
     output,
@@ -20,7 +21,6 @@ from easyuse_anima.aio import (
     sampling,
     usdu,
 )
-from easyuse_anima.nodes import aio_nodes
 from easyuse_anima.extensions.aio import (
     AioHookDescriptor,
     AioHookPatch,
@@ -29,6 +29,7 @@ from easyuse_anima.extensions.aio import (
     AioStage,
     AioStagePhase,
 )
+from easyuse_anima.nodes import aio_nodes
 from easyuse_anima.prompt.data import PROMPT_DATA_TYPE
 from easyuse_anima.wildcard.seed import SEED_CONTROL_FIXED
 from tests.comfy_host_fakes import (
@@ -986,6 +987,15 @@ class AIOSettingsStorageTests(unittest.TestCase):
 
 
 class AIOImageSaverDependencyTests(unittest.TestCase):
+    def setUp(self):
+        output_directory_patch = patch.object(
+            output,
+            "_comfy_output_directory",
+            return_value=Path.cwd() / ".test-output",
+        )
+        output_directory_patch.start()
+        self.addCleanup(output_directory_patch.stop)
+
     def test_missing_image_saver_dependency_names_required_node_pack(self):
         with patch_comfy_helper(aio_nodes, "_find_comfy_node_class", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "ComfyUI-Image-Saver"):
@@ -2401,7 +2411,7 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
         self.assertIn("USDU sampler: steps=20", log_text)
         cleanup.assert_called_once_with("stage_model", "model")
 
-    def test_upscale_stage_runs_only_resshift_when_selected(self):
+    def test_upscale_stage_rejects_resshift_before_optional_node_lookup(self):
         settings = generation_normalization._normalize_aio_generation_settings(json.dumps({
             "sampler": {
                 "seed": 321,
@@ -2419,56 +2429,35 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
                 },
             },
         }))
-        calls = {}
-
-        class FakeLoader:
-            def load(self, scale, student_name, dtype):
-                calls["loader"] = (scale, student_name, dtype)
-                return ("resshift_model",)
-
-        class FakeUpscale:
-            def upscale(self, *args):
-                calls["upscale"] = args
-                return (AIOFinalUpscaleStageTests._Image(2048, 3072),)
-
-        def fake_require(node_id, *_args):
-            if node_id == "ResShiftLoader":
-                return FakeLoader
-            if node_id == "ResShiftUpscale":
-                return FakeUpscale
-            raise AssertionError(f"unexpected node lookup: {node_id}")
 
         input_image = self._Image(512, 768)
         with (
             patch_comfy_helper(
                 aio_nodes,
                 "_require_custom_node_class",
-                side_effect=fake_require,
+                side_effect=AssertionError("must not resolve ResShift nodes"),
             ) as require,
             patch.object(legacy_generation, "_load_upscale_model_with_comfy") as load_upscale,
             patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as patch_stage,
         ):
-            image, metadata = legacy_generation._run_aio_upscale_stage(
-                "model",
-                "clip",
-                "vae",
-                "positive",
-                "negative",
-                input_image,
-                settings["sampler"],
-                settings["upscale"],
-            )
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"AiO ResShift is disabled.*issue #679",
+            ):
+                legacy_generation._run_aio_upscale_stage(
+                    "model",
+                    "clip",
+                    "vae",
+                    "positive",
+                    "negative",
+                    input_image,
+                    settings["sampler"],
+                    settings["upscale"],
+                )
 
-        self.assertIsInstance(image, self._Image)
-        self.assertEqual(require.call_count, 2)
+        require.assert_not_called()
         load_upscale.assert_not_called()
         patch_stage.assert_not_called()
-        self.assertEqual(calls["loader"], ("x4", "student.ckpt", "fp32"))
-        self.assertEqual(calls["upscale"][0], "resshift_model")
-        self.assertIs(calls["upscale"][1], input_image)
-        self.assertEqual(calls["upscale"][2:], (321, 1024, 96, 2))
-        self.assertEqual(metadata["backend"], "resshift")
-        self.assertEqual(metadata["scale"], "x4")
 
 
 class AIOGeneratorRuntimeTests(unittest.TestCase):

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import types
 import unittest
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from easyuse_anima.aio import output, output_settings
 from easyuse_anima.aio.generation_defaults import AIO_GENERATION_DEFAULT_SETTINGS
 from tests.comfy_host_fakes import patch_comfy_helper
+
+
+def fake_folder_paths(output_root: str) -> types.ModuleType:
+    module = types.ModuleType("folder_paths")
+    module.output_directory = output_root
+    module.get_output_directory = Mock(return_value=output_root)
+    module.supported_pt_extensions = {
+        ".safetensors",
+        ".pt",
+        ".ckpt",
+        ".bin",
+        ".pth",
+    }
+    return module
 
 
 class AIOOutputMoveTests(unittest.TestCase):
@@ -174,14 +190,18 @@ class AIOOutputMoveTests(unittest.TestCase):
                 calls.append((args, kwargs))
                 return {"ui": {"images": ["saved"]}}
 
-        with patch_comfy_helper(
-            output,
-            "_find_comfy_node_class",
-            return_value=SaveImage,
-        ) as find:
-            result = output._save_image_with_comfy(
-                "images", "", workflow_prompt="prompt", extra_pnginfo={"workflow": True}
-            )
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch_comfy_helper(
+                    output,
+                    "_find_comfy_node_class",
+                    return_value=SaveImage,
+                ) as find,
+            ):
+                result = output._save_image_with_comfy(
+                    "images", "", workflow_prompt="prompt", extra_pnginfo={"workflow": True}
+                )
 
         find.assert_called_once_with("SaveImage")
         self.assertEqual(
@@ -189,6 +209,20 @@ class AIOOutputMoveTests(unittest.TestCase):
             [(('images', "EasyUseAnima/AiO"), {"prompt": "prompt", "extra_pnginfo": {"workflow": True}})],
         )
         self.assertEqual(result, {"ui": {"images": ["saved"]}})
+
+    def test_comfy_save_rejects_output_traversal_before_node_lookup(self):
+        find = Mock(side_effect=AssertionError("must reject before node lookup"))
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch_comfy_helper(output, "_find_comfy_node_class", find),
+            ):
+                for prefix in ("../outside", "..\\outside", "C:\\outside", "/outside"):
+                    with self.subTest(prefix=prefix):
+                        with self.assertRaisesRegex(RuntimeError, "output directory"):
+                            output._save_image_with_comfy("images", prefix)
+
+        find.assert_not_called()
 
     def test_filename_prefix_uses_call_time_defaults_without_path_drift(self):
         defaults = {"save": {"image_saver": {"path": "Default/Path", "filename": "default_name"}}}
@@ -220,44 +254,46 @@ class AIOOutputMoveTests(unittest.TestCase):
             }
         }
         seed = Mock(return_value=987654321)
-        with (
-            patch_comfy_helper(
-                output,
-                "_require_custom_node_class",
-                return_value=ImageSaver,
-            ),
-            patch.object(output, "_resolve_aio_runtime_seed", seed),
-            patch.object(
-                output,
-                "_aio_prompt_with_lora_metadata",
-                return_value="positive <lora:x:1>",
-            ),
-            patch.object(
-                output,
-                "_aio_image_saver_additional_hashes",
-                return_value="Base:A,Model:B",
-            ),
-        ):
-            result = output._save_image_with_image_saver(
-                images="images",
-                save_settings=save_settings,
-                positive_prompt="positive",
-                negative_prompt="negative",
-                width=768,
-                height=1024,
-                sampler_settings={
-                    "steps": 30,
-                    "cfg": 6.5,
-                    "sampler_name": "euler",
-                    "scheduler": "normal",
-                    "seed": -1,
-                    "denoise": 0.8,
-                },
-                applied_loras=[{"name": "x", "strength_model": 1}],
-                resource_info={"unet_name": "anima.safetensors"},
-                workflow_prompt={"1": {}},
-                extra_pnginfo={"workflow": {}},
-            )
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch_comfy_helper(
+                    output,
+                    "_require_custom_node_class",
+                    return_value=ImageSaver,
+                ),
+                patch.object(output, "_resolve_aio_runtime_seed", seed),
+                patch.object(
+                    output,
+                    "_aio_prompt_with_lora_metadata",
+                    return_value="positive <lora:x:1>",
+                ),
+                patch.object(
+                    output,
+                    "_aio_image_saver_additional_hashes",
+                    return_value="Base:A,Model:B",
+                ),
+            ):
+                result = output._save_image_with_image_saver(
+                    images="images",
+                    save_settings=save_settings,
+                    positive_prompt="positive",
+                    negative_prompt="negative",
+                    width=768,
+                    height=1024,
+                    sampler_settings={
+                        "steps": 30,
+                        "cfg": 6.5,
+                        "sampler_name": "euler",
+                        "scheduler": "normal",
+                        "seed": -1,
+                        "denoise": 0.8,
+                    },
+                    applied_loras=[{"name": "x", "strength_model": 1}],
+                    resource_info={"unet_name": "anima.safetensors"},
+                    workflow_prompt={"1": {}},
+                    extra_pnginfo={"workflow": {}},
+                )
 
         self.assertEqual(result, "saved")
         seed.assert_called_once_with(-1)
@@ -296,6 +332,96 @@ class AIOOutputMoveTests(unittest.TestCase):
                 "extra_pnginfo": {"workflow": {}},
             },
         )
+
+    def test_image_saver_renders_templates_before_forwarding_safe_values(self):
+        calls = []
+
+        class ImageSaver:
+            def save_files(self, **kwargs):
+                calls.append(kwargs)
+                return "saved"
+
+        settings = {
+            "image_saver": {
+                **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                "path": "renders/%time_format<%Y/%m>",
+                "filename": "%custom_%counter<03>_%basemodelname",
+                "custom": "safe",
+                "counter": 7,
+            }
+        }
+        fixed_now = datetime(2026, 9, 4, 12, 34, 56)
+
+        class FixedDateTime:
+            @staticmethod
+            def now():
+                return fixed_now
+
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch_comfy_helper(
+                    output,
+                    "_require_custom_node_class",
+                    return_value=ImageSaver,
+                ),
+                patch.object(output, "datetime", FixedDateTime),
+                patch.object(output, "_resolve_aio_runtime_seed", return_value=11),
+            ):
+                result = output._save_image_with_image_saver(
+                    images="images",
+                    save_settings=settings,
+                    positive_prompt="positive",
+                    negative_prompt="negative",
+                    width=768,
+                    height=1024,
+                    sampler_settings={"seed": 11},
+                    resource_info={"unet_name": "models/anima.safetensors"},
+                )
+
+        self.assertEqual(result, "saved")
+        self.assertEqual(calls[0]["path"], "renders/2026/09")
+        self.assertEqual(calls[0]["filename"], "safe_007_anima")
+        self.assertEqual(calls[0]["time_format"], "%Y-%m-%d-%H%M%S")
+
+    def test_image_saver_rejects_expanded_output_escape_before_dependency_lookup(self):
+        cases = (
+            {"path": "../../outside"},
+            {"path": "..\\..\\outside"},
+            {"path": "C:\\outside"},
+            {"path": "/outside"},
+            {"path": "%custom", "custom": "../../outside"},
+            {"path": "%time", "time_format": "../outside"},
+            {"filename": "%custom", "custom": "../outside"},
+        )
+        require = Mock(side_effect=AssertionError("must reject before dependency lookup"))
+        with tempfile.TemporaryDirectory() as temp:
+            for override in cases:
+                settings = {
+                    "image_saver": {
+                        **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                        **override,
+                    }
+                }
+                with self.subTest(override=override):
+                    with (
+                        patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                        patch_comfy_helper(output, "_require_custom_node_class", require),
+                        patch.object(output, "_resolve_aio_runtime_seed", return_value=11),
+                    ):
+                        with self.assertRaisesRegex(RuntimeError, "output directory|single filename"):
+                            output._save_image_with_image_saver(
+                                images="images",
+                                save_settings=settings,
+                                positive_prompt="positive",
+                                negative_prompt="negative",
+                                width=768,
+                                height=1024,
+                                sampler_settings={"seed": 11},
+                                resource_info={"unet_name": "anima.safetensors"},
+                            )
+
+        require.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -43,6 +43,12 @@ def load_api_module():
 class JsonRequest:
     def __init__(self, payload):
         self.payload = payload
+        self.headers = {
+            "Content-Type": "application/json",
+            "Host": "127.0.0.1:8188",
+            "Origin": "http://127.0.0.1:8188",
+            "Sec-Fetch-Site": "same-origin",
+        }
 
     async def json(self):
         return self.payload

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -84,10 +84,20 @@ class FakeHTTPException(Exception):
 
 
 class JsonRequest:
-    def __init__(self, payload=None, *, error=None, query=None):
+    DEFAULT_HEADERS = {
+        "Content-Type": "application/json",
+        "Host": "127.0.0.1:8188",
+        "Origin": "http://127.0.0.1:8188",
+        "Sec-Fetch-Site": "same-origin",
+    }
+
+    def __init__(self, payload=None, *, error=None, query=None, headers=None):
         self.payload = payload
         self.error = error
         self.query = query or {}
+        self.headers = dict(
+            self.DEFAULT_HEADERS if headers is None else headers
+        )
 
     async def json(self):
         if self.error is not None:
@@ -3255,6 +3265,74 @@ class ApiRequestContractTests(unittest.TestCase):
         "/easyuse_anima/aio_profiles/rename",
         "/easyuse_anima/lora_profiles/fix",
     )
+
+    def test_all_json_routes_reject_cross_origin_requests_before_submit(self):
+        api, routes = load_api_routes()
+        cases = (
+            {
+                "Content-Type": "application/json",
+                "Host": "127.0.0.1:8188",
+                "Origin": "https://attacker.example",
+                "Sec-Fetch-Site": "cross-site",
+            },
+            {
+                "Content-Type": "application/json",
+                "Host": "127.0.0.1:8188",
+                "Origin": "https://attacker.example",
+            },
+            {
+                "Content-Type": "application/json",
+                "Host": "127.0.0.1:8188",
+            },
+        )
+
+        with (
+            patch.object(asyncio, "to_thread") as submit,
+            patch.object(api.application.translation_executor, "execute") as translate,
+        ):
+            for route in self.POST_ROUTES:
+                for headers in cases:
+                    with self.subTest(route=route, headers=headers):
+                        response = asyncio.run(
+                            routes.handlers[route](
+                                JsonRequest({}, headers=headers)
+                            )
+                        )
+                        self.assertEqual(response["status"], 403)
+                        self.assertEqual(
+                            response["payload"]["code"],
+                            "cross_origin_request",
+                        )
+
+            submit.assert_not_called()
+            translate.assert_not_called()
+
+    def test_all_json_routes_require_application_json_before_submit(self):
+        api, routes = load_api_routes()
+        headers = {
+            "Content-Type": "text/plain",
+            "Host": "127.0.0.1:8188",
+            "Origin": "http://127.0.0.1:8188",
+            "Sec-Fetch-Site": "same-origin",
+        }
+
+        with (
+            patch.object(asyncio, "to_thread") as submit,
+            patch.object(api.application.translation_executor, "execute") as translate,
+        ):
+            for route in self.POST_ROUTES:
+                with self.subTest(route=route):
+                    response = asyncio.run(
+                        routes.handlers[route](JsonRequest({}, headers=headers))
+                    )
+                    self.assertEqual(response["status"], 415)
+                    self.assertEqual(
+                        response["payload"]["code"],
+                        "json_content_type_required",
+                    )
+
+            submit.assert_not_called()
+            translate.assert_not_called()
 
     def test_all_json_routes_reject_malformed_and_non_object_bodies_before_submit(self):
         api, routes = load_api_routes()

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import stat
 import sys
 import tempfile
 import threading
@@ -30,6 +29,12 @@ def load_api_module():
 class JsonRequest:
     def __init__(self, payload):
         self.payload = payload
+        self.headers = {
+            "Content-Type": "application/json",
+            "Host": "127.0.0.1:8188",
+            "Origin": "http://127.0.0.1:8188",
+            "Sec-Fetch-Site": "same-origin",
+        }
 
     async def json(self):
         return self.payload

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -15,6 +15,12 @@ ROUTE = "/easyuse_anima/translate_prompt"
 class JsonRequest:
     def __init__(self, payload):
         self.payload = payload
+        self.headers = {
+            "Content-Type": "application/json",
+            "Host": "127.0.0.1:8188",
+            "Origin": "http://127.0.0.1:8188",
+            "Sec-Fetch-Site": "same-origin",
+        }
 
     async def json(self):
         return self.payload

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -5,7 +5,6 @@ import subprocess
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 AUTOCOMPLETE_ENTRY = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
 EXPECTED_AUTOCOMPLETE_MODULES = {
@@ -189,6 +188,8 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "subprocess",
             "pickle.loads",
             "marshal.loads",
+            "torch.load(",
+            "yaml.load(",
             "base64.b64decode",
             "GOOGLE_TRANSLATION_API_KEY",
             "os.environ",
@@ -392,4 +393,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
         self.assertIn("docs/development/registry-scanner-safety.md", entry)
         self.assertIn("comfy node validate", safety)
         self.assertIn("NAIA `requests.post`", safety)
+        self.assertIn("same-authority", safety)
+        self.assertIn("ComfyUI output root", safety)
+        self.assertIn("issue #679", safety)
         self.assertIn('web/js -g "!easyuse_anima_api.js"', safety)

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -384,6 +384,15 @@ class WildcardCanonicalContractTests(unittest.TestCase):
                 self.assertEqual(root, Path(temp) / "wildcards")
                 self.assertTrue((root / DEFAULT_TEST_WILDCARD_FILE).is_file())
 
+    def test_resolving_roots_does_not_create_files(self):
+        with tempfile.TemporaryDirectory() as temp:
+            default_root = Path(temp) / "wildcards"
+            with patch.object(wildcard_sources, "USER_DATA_DIR", Path(temp)):
+                roots = wildcard_sources.resolve_wildcard_roots("")
+
+            self.assertEqual(roots, [default_root.resolve()])
+            self.assertFalse(default_root.exists())
+
     def test_empty_text_batch_returns_before_snapshot_lifecycle(self):
         with patch.object(
             wildcard_service,


### PR DESCRIPTION
## Purpose

Promote the validated EasyUse Anima 1.1.6 tree from `dev` to the stable `main` branch for GitHub and Comfy Registry release.

## Base -> Head

`main` -> `codex/promote-1.1.6-main`

## Promotion contents

- Registry security hardening from #680.
- Version 1.1.6 and installer-facing release metadata from #681.
- The head tree is byte-for-byte identical to the current `origin/dev` tree.

## Preserved contracts

- Existing node identifiers, inputs, outputs, profiles, workflows, and valid Image Saver templates remain compatible.
- ResShift settings remain preserved but execution fails closed until its external loader has a safe contract.

## Reused release evidence

- Full repository validation passed on ComfyUI 0.34.0 with frontend 1.49.6: 1,533 Python tests passed, 2 skipped, and all 121 frontend checks passed.
- `comfy node validate` passed, including security checks.
- Registry package validation produced 338 runtime files with no unsafe paths.
- The packaged node loaded in the isolated ComfyUI instance; node registration and same-origin request enforcement were exercised.

## After merge

- Create immutable tag `v1.1.6` from the merged `main` commit.
- Publish the GitHub Release and manual-install ZIP with SHA-256.
- Dispatch the Registry publish workflow and verify the live API result.
- Keep #677 open until Registry status becomes Active.
