### PR TITLE
feat: complete native image resource metadata

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -41,12 +41,26 @@ denoising strength when applicable, clip skip, custom text, model name, model
 hash, resource hashes, optional Civitai resource identifiers, and
 `Version: ComfyUI`.
 
-The selected diffusion model and applied LoRAs are resolved only through
-ComfyUI's model inventory. SHA-256 values are cached in memory by resolved path,
-size, and modification time; no cache file is written beside a model. The
-first ten hash characters are written in the A1111/Civitai-compatible fields.
-Manual hash and hash-bundle settings remain supported without accepting file
-paths.
+The selected diffusion model, applied LoRAs, and `embedding:name` references in
+the positive or negative prompt are resolved only through ComfyUI's model
+inventory. Embedding subdirectories are supported; an extension may be omitted,
+but an ambiguous basename or path-like value containing traversal components is
+not hashed. ComfyUI's prompt parser supplies embedding attention weights, such
+as `0.8` in `(embedding:styles/example:0.8)`.
+
+SHA-256 values keep a 128-entry process cache and a bounded cross-session cache
+at `easyuse_anima/cache/resource-hashes.v1.json` under ComfyUI's user-data
+directory. Cache keys contain an opaque digest of the resolved path rather than
+the path itself. A hit must match size, modification/change timestamps, device,
+and file identity; uncached reads report byte progress through ComfyUI. Cache
+files are size/schema validated and atomically replaced. Corruption or write
+failure causes a safe recomputation, and no cache file is written beside a
+model, LoRA, or embedding.
+
+Locally calculated SHA-256 values use the first ten characters in the
+A1111/Civitai-compatible fields. Manual hash and hash-bundle settings preserve
+the supplied validated value, do not accept file paths, and cannot claim the
+reserved locally owned `model` key.
 
 Local hashes do not require network access. `Civitai data` is disabled by
 default; explicitly enabling it adds remote resource descriptors, and enabled
@@ -57,8 +71,10 @@ Civitai Hash Fetcher rows resolve an AutoV3 value. Both paths use fixed
 - redirects are disabled and normal TLS verification remains enabled;
 - connect/read timeouts are bounded;
 - response bodies are streamed with a 2 MiB hard limit;
-- one save performs remote enrichment for at most 32 local resources and processes at most 32 enabled hash-fetcher rows;
+- one save performs remote enrichment for at most 32 distinct local or manual resources and processes at most 32 enabled hash-fetcher rows;
 - remote names and identifiers are length/control-character validated;
+- a by-hash response is accepted only when one returned file contains an exact
+  match for the requested full or short hexadecimal hash;
 - successful lookups cache only a small validated hash string or descriptor in memory;
 - transport, HTTP, size, and parse failures are logged as metadata misses and
   never block image saving.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -45,6 +45,9 @@ E-01 drift gate until classified.
 | `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry shared by direct/factory stores | guard plus per-path `RLock`; no clear | E-03b complete |
 | `bootstrap-initialize-state` | bootstrap default runtime, wildcard completion, executor, atexit, and terminal state | shared initialize/shutdown `Lock`; expected-identity detach and once-only cleanup | E-09 complete; E-09c audited |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
+| `native-civitai-lookup-cache` | native image metadata owns two bounded successful-result LRU caches for Civitai lookups | `functools.lru_cache`; transport and parse failures are not cached | native image output complete |
+| `native-image-output-runtime` | native image output owns one process save lock | serializes output-name reservation and publication; no reset | native image output complete |
+| `native-resource-hash-runtime` | native resource hashing owns a bounded process LRU and validated persistent cache under the ComfyUI user directory | persistent-cache `Lock`, atomic JSON replacement, 128-entry and 1 MiB bounds; no reset | native image metadata parity complete |
 | `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior plus once-registered terminal `atexit` shutdown | E-09 complete; E-09c audited |
 | `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d complete |
 | prompt warning-dedupe entries | Conditioning owns the canonical process warning set; the callerless Artist Mix duplicate is removed | canonical set remains process-lifetime with its accepted benign race | E-09 complete; E-09c audited |

--- a/docs/nodes/anima-aio-generator.en.md
+++ b/docs/nodes/anima-aio-generator.en.md
@@ -109,14 +109,21 @@ values supplied to the saver.
 
 Saved metadata uses first-pass sampler values for `Steps`, `CFG`, `Sampler`,
 `Scheduler`, `Seed`, and `Denoise`. `Size` uses the final image resolution after
-Highres and Detailer. EasyUse hashes the locally resolved diffusion model and
-applied `lora_stack` files with SHA-256 in memory, writes their Civitai-compatible
-short hashes, and never creates cache files beside model files. Manual hash
-bundles remain supported. `Civitai data` is disabled by default; explicitly
-enable it to enrich those local hashes through fixed
-`https://civitai.com/api/v1` endpoints. Failures are logged and do not block
-image saving. Civitai Hash Fetcher rows likewise store username, model name,
-and version and add `model_name:AutoV3` entries.
+Highres and Detailer. EasyUse hashes the locally resolved diffusion model,
+applied `lora_stack` files, and `embedding:name` references in either prompt.
+Embedding subdirectories and `(embedding:name:0.8)` attention weights are
+supported; missing, unsafe, or ambiguous inventory names are skipped.
+
+SHA-256 results use an in-memory cache plus a bounded, atomic cache under the
+ComfyUI user-data directory, with progress shown for uncached files. EasyUse
+never creates cache files beside model resources. Locally calculated hashes are
+shortened for A1111 compatibility; validated manual hash values are preserved
+and cannot replace the locally owned `model` hash. `Civitai data` is disabled by
+default; explicitly enable it to enrich local and manual hashes through fixed
+`https://civitai.com/api/v1` endpoints. A short-hash result is accepted only
+when the response contains an exact matching file hash. Failures are logged and
+do not block image saving. Civitai Hash Fetcher rows likewise store username,
+model name, and version and add `model_name:AutoV3` entries.
 
 ## Required Node Packs
 

--- a/docs/nodes/anima-aio-generator.ko.md
+++ b/docs/nodes/anima-aio-generator.ko.md
@@ -106,12 +106,19 @@ quality`로 화질과 파일 크기의 균형을 조절합니다. lossless 모�
 
 저장 메타데이터의 `Steps`, `CFG`, `Sampler`, `Scheduler`, `Seed`, `Denoise`는
 1차 샘플러 값을 사용합니다. `Size`는 Highres와 Detailer 이후의 최종 해상도를
-사용합니다. EasyUse는 로컬에서 확인된 diffusion model과 실제 적용된
-`lora_stack` 파일을 메모리에서 SHA-256으로 계산하여 Civitai 호환 short hash를
-저장하며, 모델 파일 옆에는 hash cache 파일을 만들지 않습니다. 수동 hash
-bundle도 계속 지원합니다. `Civitai data`는 기본적으로 꺼져 있으며, 명시적으로
-켜면 고정된 `https://civitai.com/api/v1` endpoint로 로컬 hash 정보를 보강합니다.
-조회에 실패해도 이미지 저장은 계속됩니다. Civitai Hash Fetcher 항목도 username,
+사용합니다. EasyUse는 로컬에서 확인된 diffusion model, 실제 적용된
+`lora_stack`, 양쪽 prompt의 `embedding:name` 참조를 SHA-256으로 계산합니다.
+embedding 하위 폴더와 `(embedding:name:0.8)` 가중치를 지원하며, 존재하지 않거나
+안전하지 않거나 이름이 모호한 항목은 건너뜁니다.
+
+SHA-256 결과는 메모리 cache와 ComfyUI user-data 폴더 내부의 제한된 원자적
+cache를 사용하고, cache가 없는 파일은 계산 진행률을 표시합니다. 모델, LoRA,
+embedding 파일 옆에는 cache 파일을 만들지 않습니다. 로컬 hash는 A1111 호환
+길이로 줄이지만 검증된 수동 hash 값은 그대로 보존하며, 로컬 `model` hash를
+덮어쓸 수 없습니다. `Civitai data`는 기본적으로 꺼져 있으며, 명시적으로 켜면
+고정된 `https://civitai.com/api/v1` endpoint로 로컬 및 수동 hash 정보를
+보강합니다. 짧은 hash는 응답 파일의 hash와 정확히 일치할 때만 사용합니다.
+조회 실패는 이미지 저장을 막지 않습니다. Civitai Hash Fetcher 항목도 username,
 model name, version을 사용해 `model_name:AutoV3` 항목을 추가합니다.
 
 ## 필요 노드팩

--- a/easyuse_anima/aio/native_civitai.py
+++ b/easyuse_anima/aio/native_civitai.py
@@ -14,8 +14,10 @@ logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 _CIVITAI_API_ROOT = "https://civitai.com/api/v1"
 _CIVITAI_RESPONSE_LIMIT = 2 * 1024 * 1024
+_MAX_REMOTE_FILES = 256
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _SAFE_HASH_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_LOOKUP_HASH_RE = re.compile(r"^[0-9a-f]{8,128}$")
 _SAFE_AIR_RE = re.compile(r"^urn:air:[A-Za-z0-9][A-Za-z0-9._~:@%+\-]{0,503}$")
 
 
@@ -46,6 +48,25 @@ def _positive_int(value: object) -> int | None:
         return None
     result = int(text)
     return result if result > 0 else None
+
+
+def _response_proves_hash(data: Mapping[str, object], normalized_hash: str) -> bool:
+    """Require an exact file-hash match before trusting a by-hash response."""
+
+    files = data.get("files")
+    if not isinstance(files, list):
+        return False
+    for item in files[:_MAX_REMOTE_FILES]:
+        if not isinstance(item, Mapping):
+            continue
+        hashes = item.get("hashes")
+        if not isinstance(hashes, Mapping):
+            continue
+        for value in hashes.values():
+            candidate = _remote_text(value, max_length=128).casefold()
+            if candidate == normalized_hash:
+                return True
+    return False
 
 
 def _request_civitai_json(
@@ -122,11 +143,13 @@ def _request_civitai_json(
 
 @lru_cache(maxsize=128)
 def _cached_civitai_resource_by_hash(
-    normalized_sha256: str,
+    normalized_hash: str,
 ) -> CivitaiResourceDescriptor | None:
     data = _request_civitai_json(
-        f"{_CIVITAI_API_ROOT}/model-versions/by-hash/{normalized_sha256}"
+        f"{_CIVITAI_API_ROOT}/model-versions/by-hash/{normalized_hash}"
     )
+    if not _response_proves_hash(data, normalized_hash):
+        return None
     air = _remote_text(data.get("air"))
     if air and not _SAFE_AIR_RE.fullmatch(air):
         air = ""
@@ -148,10 +171,10 @@ def _cached_civitai_resource_by_hash(
 
 
 def _fetch_civitai_resource_by_hash(
-    sha256: str,
+    resource_hash: str,
 ) -> CivitaiResourceDescriptor | None:
-    normalized = str(sha256 or "").strip().casefold()
-    if not re.fullmatch(r"[0-9a-f]{64}", normalized):
+    normalized = str(resource_hash or "").strip().casefold()
+    if not _LOOKUP_HASH_RE.fullmatch(normalized):
         return None
     try:
         return _cached_civitai_resource_by_hash(normalized)

--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import math
 import os
 import re
 import tempfile
 import threading
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import MappingProxyType
 from typing import cast
@@ -20,19 +17,24 @@ from typing import cast
 from .native_civitai import (
     _fetch_civitai_autov3_hash as _fetch_civitai_autov3_hash,
 )
-from .native_civitai import _fetch_civitai_resource_by_hash
+from .native_civitai import (
+    _fetch_civitai_resource_by_hash,
+)
+from .native_resource_hashes import (
+    _EMBEDDING_RE,
+    _HEX_HASH_RE,
+    _local_resource_hashes,
+    _manual_resource_hashes,
+    _resource_name,
+    _ResourceHash,
+)
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 _JPEG_EXIF_LIMIT = 65_000
 _MAX_REMOTE_RESOURCES = 32
-_MAX_MANUAL_HASHES = 30
-_MAX_MANUAL_HASH_TEXT = 8_192
 _USER_COMMENT_PREFIX = b"UNICODE\0"
 _LORA_TAG_RE = re.compile(r"<lora:([^>:]+)(?::([^>]+))?>", re.IGNORECASE)
-_EMBEDDING_RE = re.compile(r"embedding:([^,\s()]+)", re.IGNORECASE)
-_SAFE_HASH_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
-_HEX_HASH_RE = re.compile(r"^[0-9A-Fa-f]{8,128}$")
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _SAVE_LOCK = threading.Lock()
 
@@ -56,19 +58,6 @@ class NativeImageMetadata:
 
 
 @dataclass(frozen=True, slots=True)
-class _ResourceHash:
-    display_name: str
-    metadata_key: str
-    path: Path | None
-    sha256: str
-    weight: float | None = None
-
-    @property
-    def short_hash(self) -> str:
-        return self.sha256[:10]
-
-
-@dataclass(frozen=True, slots=True)
 class _SerializedMetadata:
     pnginfo: object | None
     exif_bytes: bytes | None
@@ -83,207 +72,6 @@ def _compact_json(value: object, *, ascii_only: bool) -> str:
         ensure_ascii=ascii_only,
         separators=(",", ":"),
     )
-
-
-def _supported_model_extensions() -> set[str]:
-    try:
-        import folder_paths  # type: ignore
-
-        return set(getattr(folder_paths, "supported_pt_extensions", ())) | {".gguf"}
-    except Exception:
-        return {".safetensors", ".pt", ".ckpt", ".bin", ".pth", ".gguf"}
-
-
-def _resource_name(value: str) -> str:
-    filename = str(value or "").strip().replace("\\", "/").strip("/").rsplit("/", 1)[-1]
-    stem, extension = os.path.splitext(filename)
-    return stem if extension.casefold() in _supported_model_extensions() else filename
-
-
-def _lora_metadata_name(value: str) -> str:
-    normalized = str(value or "").strip().replace("\\", "/").strip("/")
-    stem, extension = os.path.splitext(normalized)
-    return stem if extension.casefold() in _supported_model_extensions() else normalized
-
-
-def _resolve_resource_path(folder_names: Sequence[str], name: str) -> Path | None:
-    if not str(name or "").strip():
-        return None
-    try:
-        import folder_paths  # type: ignore
-    except Exception:
-        return None
-
-    get_full_path = getattr(folder_paths, "get_full_path", None)
-    if not callable(get_full_path):
-        return None
-    for folder_name in folder_names:
-        try:
-            value = get_full_path(folder_name, name)
-        except Exception as exc:
-            logger.warning(
-                "[EasyUseAnima] Could not resolve %s resource %r: %s",
-                folder_name,
-                name,
-                exc,
-            )
-            continue
-        if not value:
-            continue
-        path = Path(str(value)).resolve(strict=False)
-        if path.is_file():
-            return path
-    return None
-
-
-@lru_cache(maxsize=128)
-def _hash_file_revision(path_text: str, size: int, modified_ns: int) -> str:
-    del size, modified_ns
-    digest = hashlib.sha256()
-    with Path(path_text).open("rb") as handle:
-        for block in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
-
-
-def _hash_file(path: Path) -> str:
-    stat = path.stat()
-    return _hash_file_revision(str(path), stat.st_size, stat.st_mtime_ns)
-
-
-def _local_resource_hashes(
-    modelname: str,
-    applied_loras: object,
-) -> list[_ResourceHash]:
-    resources: list[_ResourceHash] = []
-    model_path = _resolve_resource_path(("diffusion_models", "checkpoints"), modelname)
-    if model_path is not None:
-        try:
-            resources.append(
-                _ResourceHash(
-                    display_name=_resource_name(modelname),
-                    metadata_key="model",
-                    path=model_path,
-                    sha256=_hash_file(model_path),
-                )
-            )
-        except OSError as exc:
-            logger.warning(
-                "[EasyUseAnima] Could not hash model %r; continuing without its hash: %s",
-                modelname,
-                exc,
-            )
-
-    values = applied_loras if isinstance(applied_loras, (list, tuple)) else ()
-    seen_names: set[str] = set()
-    for item in values:
-        if not isinstance(item, Mapping):
-            continue
-        source_name = str(item.get("name") or "").strip()
-        metadata_name = _lora_metadata_name(source_name)
-        if not metadata_name or metadata_name.casefold() in seen_names:
-            continue
-        seen_names.add(metadata_name.casefold())
-        lora_path = _resolve_resource_path(("loras",), source_name)
-        if lora_path is None:
-            logger.warning(
-                "[EasyUseAnima] Could not locate LoRA %r; continuing without its Civitai hash.",
-                source_name,
-            )
-            continue
-        try:
-            strength = float(item.get("strength_model", 1.0))
-        except (TypeError, ValueError):
-            strength = 1.0
-        if not math.isfinite(strength):
-            strength = 1.0
-        try:
-            sha256 = _hash_file(lora_path)
-        except OSError as exc:
-            logger.warning(
-                "[EasyUseAnima] Could not hash LoRA %r; continuing without its hash: %s",
-                source_name,
-                exc,
-            )
-            continue
-        resources.append(
-            _ResourceHash(
-                display_name=metadata_name,
-                metadata_key=f"LORA:{metadata_name}",
-                path=lora_path,
-                sha256=sha256,
-                weight=strength,
-            )
-        )
-    return resources
-
-
-def _manual_resource_hashes(value: str) -> list[_ResourceHash]:
-    text = str(value or "")[:_MAX_MANUAL_HASH_TEXT]
-    resources: list[_ResourceHash] = []
-    unnamed_index = 0
-    seen_hashes: set[str] = set()
-    for raw_entry in text.replace("\r", "\n").replace("\n", ",").split(","):
-        entry = raw_entry.strip()
-        if not entry:
-            continue
-        pieces = [part.strip() for part in entry.split(":")]
-        if not all(pieces):
-            logger.warning("[EasyUseAnima] Skipping malformed additional Civitai hash entry: %r", entry)
-            continue
-        if len(pieces) > 3:
-            logger.warning("[EasyUseAnima] Skipping ambiguous additional Civitai hash entry: %r", entry)
-            continue
-        weight: float | None = None
-        if len(pieces) == 3:
-            try:
-                weight = float(pieces[-1])
-            except ValueError:
-                logger.warning("[EasyUseAnima] Skipping ambiguous additional Civitai hash entry: %r", entry)
-                continue
-            if not math.isfinite(weight):
-                logger.warning("[EasyUseAnima] Skipping non-finite additional Civitai hash weight: %r", entry)
-                continue
-            name, hash_value = pieces[0], pieces[1]
-        elif len(pieces) == 2:
-            first, second = pieces
-            try:
-                shorthand_weight = float(second)
-            except ValueError:
-                shorthand_weight = None
-            if shorthand_weight is not None and _HEX_HASH_RE.fullmatch(first):
-                if not math.isfinite(shorthand_weight):
-                    logger.warning("[EasyUseAnima] Skipping non-finite additional Civitai hash weight: %r", entry)
-                    continue
-                unnamed_index += 1
-                name = f"manual{unnamed_index}"
-                hash_value = first
-                weight = shorthand_weight
-            else:
-                name, hash_value = first, second
-        else:
-            unnamed_index += 1
-            name = f"manual{unnamed_index}"
-            hash_value = pieces[0]
-        if not name or _CONTROL_RE.search(name) or not _SAFE_HASH_RE.fullmatch(hash_value):
-            logger.warning("[EasyUseAnima] Skipping invalid additional Civitai hash entry: %r", entry)
-            continue
-        normalized_hash = hash_value.casefold()
-        if normalized_hash in seen_hashes:
-            continue
-        seen_hashes.add(normalized_hash)
-        resources.append(
-            _ResourceHash(
-                display_name=name,
-                metadata_key=name,
-                path=None,
-                sha256=hash_value,
-                weight=weight,
-            )
-        )
-        if len(resources) >= _MAX_MANUAL_HASHES:
-            break
-    return resources
 
 
 def _clean_prompt_for_remix(prompt: str) -> str:
@@ -313,9 +101,20 @@ def _civitai_resource_entries(
     resources: Sequence[_ResourceHash],
 ) -> list[dict[str, str | float | int]]:
     entries: list[dict[str, str | float | int]] = []
-    for resource in resources[:_MAX_REMOTE_RESOURCES]:
-        if len(resource.sha256) != 64:
+    seen_hashes: set[str] = set()
+    seen_identifiers: set[str] = set()
+    attempts = 0
+    for resource in resources:
+        normalized_hash = resource.sha256.casefold()
+        if (
+            not _HEX_HASH_RE.fullmatch(normalized_hash)
+            or normalized_hash in seen_hashes
+        ):
             continue
+        if attempts >= _MAX_REMOTE_RESOURCES:
+            break
+        seen_hashes.add(normalized_hash)
+        attempts += 1
         descriptor = _fetch_civitai_resource_by_hash(resource.sha256)
         if descriptor is None:
             continue
@@ -328,9 +127,14 @@ def _civitai_resource_entries(
             entry["weight"] = resource.weight
         if descriptor.air:
             entry["air"] = descriptor.air
+            identifier = f"air:{descriptor.air.casefold()}"
         elif descriptor.model_version_id is not None:
             entry["modelVersionId"] = descriptor.model_version_id
-        if "air" in entry or "modelVersionId" in entry:
+            identifier = f"version:{descriptor.model_version_id}"
+        else:
+            continue
+        if identifier not in seen_identifiers:
+            seen_identifiers.add(identifier)
             entries.append(entry)
     return entries
 
@@ -355,26 +159,44 @@ def _build_native_metadata(
     download_civitai_data: bool,
     easy_remix: bool,
 ) -> NativeImageMetadata:
-    local_resources = _local_resource_hashes(modelname, applied_loras)
+    local_resources = _local_resource_hashes(
+        modelname,
+        applied_loras,
+        (positive, negative),
+    )
     manual_resources = _manual_resource_hashes(additional_hashes)
     resources = [*local_resources, *manual_resources]
 
     hashes: dict[str, str] = {}
     final_parts: list[str] = []
     seen_hashes: set[str] = set()
+    seen_metadata_keys: set[str] = set()
     for resource in resources:
-        short_hash = resource.short_hash
-        normalized_hash = short_hash.casefold()
-        if not short_hash or normalized_hash in seen_hashes:
+        metadata_hash = resource.metadata_hash
+        normalized_hash = resource.sha256.casefold()
+        normalized_key = resource.metadata_key.casefold()
+        if (
+            not metadata_hash
+            or normalized_hash in seen_hashes
+            or normalized_key in seen_metadata_keys
+        ):
+            if normalized_key in seen_metadata_keys and resource.preserve_hash:
+                logger.warning(
+                    "[EasyUseAnima] Skipping manual hash %r because that metadata key "
+                    "was already emitted; verified local resources and the first "
+                    "manual entry take precedence.",
+                    resource.metadata_key,
+                )
             continue
         seen_hashes.add(normalized_hash)
-        hashes[resource.metadata_key] = short_hash
+        seen_metadata_keys.add(normalized_key)
+        hashes[resource.metadata_key] = metadata_hash
         weight = (
             f":{resource.weight:g}"
             if resource.weight is not None
             else ""
         )
-        final_parts.append(f"{resource.display_name}:{short_hash}{weight}")
+        final_parts.append(f"{resource.display_name}:{metadata_hash}{weight}")
 
     model_hash = hashes.get("model", "")
     visible_positive = (
@@ -406,7 +228,7 @@ def _build_native_metadata(
         fields.append(f"Hashes: {_compact_json(hashes, ascii_only=False)}")
     fields.append("Version: ComfyUI")
     if download_civitai_data:
-        civitai_resources = _civitai_resource_entries(local_resources)
+        civitai_resources = _civitai_resource_entries(resources)
         if civitai_resources:
             fields.append(
                 f"Civitai resources: {_compact_json(civitai_resources, ascii_only=False)}"

--- a/easyuse_anima/aio/native_resource_hashes.py
+++ b/easyuse_anima/aio/native_resource_hashes.py
@@ -1,0 +1,656 @@
+"""Inventory-bound resource discovery and contained SHA-256 caching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import tempfile
+import threading
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import cast
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+_HASH_BLOCK_SIZE = 1024 * 1024
+_HASH_CACHE_SCHEMA = 1
+_HASH_CACHE_MAX_BYTES = 1024 * 1024
+_HASH_CACHE_MAX_ENTRIES = 128
+_HASH_CACHE_FILENAME = "resource-hashes.v1.json"
+_MAX_LOCAL_EMBEDDINGS = 32
+_MAX_MANUAL_HASHES = 30
+_MAX_MANUAL_HASH_TEXT = 8_192
+_EMBEDDING_RE = re.compile(r"embedding:([^,\s():]+)", re.IGNORECASE)
+_SAFE_HASH_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_HEX_HASH_RE = re.compile(r"^[0-9A-Fa-f]{8,128}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_RESERVED_METADATA_KEYS = frozenset({"model"})
+_HASH_CACHE_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True, slots=True)
+class _ResourceHash:
+    display_name: str
+    metadata_key: str
+    path: Path | None
+    sha256: str
+    weight: float | None = None
+    preserve_hash: bool = False
+
+    @property
+    def metadata_hash(self) -> str:
+        return self.sha256 if self.preserve_hash else self.sha256[:10]
+
+
+def _supported_model_extensions() -> set[str]:
+    try:
+        import folder_paths  # type: ignore
+
+        return set(getattr(folder_paths, "supported_pt_extensions", ())) | {".gguf"}
+    except Exception:
+        return {".safetensors", ".pt", ".ckpt", ".bin", ".pth", ".gguf"}
+
+
+def _resource_name(value: str) -> str:
+    filename = str(value or "").strip().replace("\\", "/").strip("/").rsplit("/", 1)[-1]
+    stem, extension = os.path.splitext(filename)
+    return stem if extension.casefold() in _supported_model_extensions() else filename
+
+
+def _lora_metadata_name(value: str) -> str:
+    normalized = str(value or "").strip().replace("\\", "/").strip("/")
+    stem, extension = os.path.splitext(normalized)
+    return stem if extension.casefold() in _supported_model_extensions() else normalized
+
+
+def _resolve_resource_path(folder_names: Sequence[str], name: str) -> Path | None:
+    if not str(name or "").strip():
+        return None
+    try:
+        import folder_paths  # type: ignore
+    except Exception:
+        return None
+
+    get_full_path = getattr(folder_paths, "get_full_path", None)
+    if not callable(get_full_path):
+        return None
+    for folder_name in folder_names:
+        try:
+            value = get_full_path(folder_name, name)
+        except Exception as exc:
+            logger.warning(
+                "[EasyUseAnima] Could not resolve %s resource %r: %s",
+                folder_name,
+                name,
+                exc,
+            )
+            continue
+        if not value:
+            continue
+        path = Path(str(value)).resolve(strict=False)
+        if path.is_file():
+            return path
+    return None
+
+
+def _hash_cache_path() -> Path | None:
+    try:
+        import folder_paths  # type: ignore
+    except Exception:
+        return None
+
+    get_user_directory = getattr(folder_paths, "get_user_directory", None)
+    if not callable(get_user_directory):
+        return None
+    try:
+        user_root = Path(str(get_user_directory())).resolve(strict=True)
+        cache_parent = (user_root / "easyuse_anima" / "cache").resolve(strict=False)
+        cache_parent.relative_to(user_root)
+    except (OSError, RuntimeError, ValueError):
+        logger.warning(
+            "[EasyUseAnima] Persistent resource hash cache is unavailable; "
+            "continuing with the in-memory cache."
+        )
+        return None
+    return cache_parent / _HASH_CACHE_FILENAME
+
+
+def _read_hash_cache(cache_path: Path) -> dict[str, dict[str, int | str]]:
+    if not cache_path.exists():
+        return {}
+    if cache_path.is_symlink():
+        raise OSError("resource hash cache path must not be a symbolic link")
+    if cache_path.stat().st_size > _HASH_CACHE_MAX_BYTES:
+        raise ValueError("resource hash cache exceeds its size limit")
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping) or payload.get("version") != _HASH_CACHE_SCHEMA:
+        raise ValueError("resource hash cache schema is invalid")
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, Mapping):
+        raise ValueError("resource hash cache entries are invalid")
+
+    entries: dict[str, dict[str, int | str]] = {}
+    for key, raw_entry in list(raw_entries.items())[-_HASH_CACHE_MAX_ENTRIES:]:
+        if not isinstance(key, str) or not _SHA256_RE.fullmatch(key):
+            continue
+        if not isinstance(raw_entry, Mapping):
+            continue
+        size = raw_entry.get("size")
+        modified_ns = raw_entry.get("modified_ns")
+        changed_ns = raw_entry.get("changed_ns")
+        device = raw_entry.get("device")
+        inode = raw_entry.get("inode")
+        sha256 = raw_entry.get("sha256")
+        if (
+            isinstance(size, int)
+            and not isinstance(size, bool)
+            and size >= 0
+            and isinstance(modified_ns, int)
+            and not isinstance(modified_ns, bool)
+            and modified_ns >= 0
+            and isinstance(changed_ns, int)
+            and not isinstance(changed_ns, bool)
+            and changed_ns >= 0
+            and isinstance(device, int)
+            and not isinstance(device, bool)
+            and device >= 0
+            and isinstance(inode, int)
+            and not isinstance(inode, bool)
+            and inode >= 0
+            and isinstance(sha256, str)
+            and _SHA256_RE.fullmatch(sha256.casefold())
+        ):
+            entries[key] = {
+                "size": size,
+                "modified_ns": modified_ns,
+                "changed_ns": changed_ns,
+                "device": device,
+                "inode": inode,
+                "sha256": sha256.casefold(),
+            }
+    return entries
+
+
+def _atomic_write_hash_cache(
+    cache_path: Path,
+    entries: Mapping[str, Mapping[str, int | str]],
+) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_parent = cache_path.parent.resolve(strict=True)
+    verified_path = _hash_cache_path()
+    if (
+        verified_path is None
+        or os.path.normcase(str(verified_path.parent.resolve(strict=True)))
+        != os.path.normcase(str(resolved_parent))
+        or verified_path.name != cache_path.name
+    ):
+        raise OSError("resource hash cache escaped its user-data root")
+    target = verified_path
+    if target.is_symlink():
+        raise OSError("resource hash cache path must not be a symbolic link")
+    value = json.dumps(
+        {"version": _HASH_CACHE_SCHEMA, "entries": dict(entries)},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".easyuse-anima-hashes-",
+        suffix=".tmp",
+        dir=resolved_parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(value)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _hash_cache_key(path: Path) -> str:
+    normalized = os.path.normcase(str(path.resolve(strict=True)))
+    return hashlib.sha256(normalized.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _new_hash_progress(total: int) -> object | None:
+    try:
+        from comfy.utils import ProgressBar  # type: ignore
+
+        return ProgressBar(total)
+    except Exception:
+        return None
+
+
+def _stat_revision(stat: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        stat.st_size,
+        stat.st_mtime_ns,
+        stat.st_ctime_ns,
+        stat.st_dev,
+        stat.st_ino,
+    )
+
+
+def _calculate_file_sha256(
+    path: Path,
+    size: int,
+    modified_ns: int,
+    changed_ns: int,
+    device: int,
+    inode: int,
+) -> str:
+    del changed_ns
+    digest = hashlib.sha256()
+    progress = _new_hash_progress(size)
+    consumed = 0
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        expected_stable_fields = (size, modified_ns, device, inode)
+        before_stable_fields = (
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_dev,
+            before.st_ino,
+        )
+        if before_stable_fields != expected_stable_fields:
+            raise OSError("resource changed before hashing began")
+        for block in iter(lambda: handle.read(_HASH_BLOCK_SIZE), b""):
+            digest.update(block)
+            consumed += len(block)
+            if progress is not None:
+                try:
+                    update_absolute = getattr(progress, "update_absolute")
+                    update_absolute(consumed, size)
+                except Exception:
+                    progress = None
+        after = os.fstat(handle.fileno())
+        after_stable_fields = (
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_dev,
+            after.st_ino,
+        )
+        if (
+            after_stable_fields != expected_stable_fields
+            or after.st_ctime_ns != before.st_ctime_ns
+        ):
+            raise OSError("resource changed while it was being hashed")
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=128)
+def _hash_file_revision(
+    path_text: str,
+    size: int,
+    modified_ns: int,
+    changed_ns: int,
+    device: int,
+    inode: int,
+) -> str:
+    path = Path(path_text)
+    cache_key = _hash_cache_key(path)
+    with _HASH_CACHE_LOCK:
+        cache_path = _hash_cache_path()
+        entries: dict[str, dict[str, int | str]] = {}
+        if cache_path is not None:
+            try:
+                entries = _read_hash_cache(cache_path)
+            except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "[EasyUseAnima] Ignoring invalid persistent resource hash cache (%s).",
+                    type(exc).__name__,
+                )
+        cached = entries.get(cache_key)
+        if (
+            cached is not None
+            and cached.get("size") == size
+            and cached.get("modified_ns") == modified_ns
+            and cached.get("changed_ns") == changed_ns
+            and cached.get("device") == device
+            and cached.get("inode") == inode
+        ):
+            cached_hash = cached.get("sha256")
+            if isinstance(cached_hash, str) and _SHA256_RE.fullmatch(cached_hash):
+                return cached_hash
+
+        sha256 = _calculate_file_sha256(
+            path,
+            size,
+            modified_ns,
+            changed_ns,
+            device,
+            inode,
+        )
+        if cache_path is not None:
+            entries.pop(cache_key, None)
+            entries[cache_key] = {
+                "size": size,
+                "modified_ns": modified_ns,
+                "changed_ns": changed_ns,
+                "device": device,
+                "inode": inode,
+                "sha256": sha256,
+            }
+            while len(entries) > _HASH_CACHE_MAX_ENTRIES:
+                entries.pop(next(iter(entries)))
+            try:
+                _atomic_write_hash_cache(cache_path, entries)
+            except OSError as exc:
+                logger.warning(
+                    "[EasyUseAnima] Could not update the persistent resource hash cache (%s); "
+                    "continuing with the calculated hash.",
+                    type(exc).__name__,
+                )
+        return sha256
+
+
+def _hash_file(path: Path) -> str:
+    resolved = path.resolve(strict=True)
+    stat = resolved.stat()
+    return _hash_file_revision(str(resolved), *_stat_revision(stat))
+
+
+def _safe_inventory_name(value: object) -> str:
+    name = str(value or "").strip().replace("\\", "/")
+    posix_path = PurePosixPath(name)
+    windows_path = PureWindowsPath(name)
+    if (
+        not name
+        or len(name) > 512
+        or _CONTROL_RE.search(name)
+        or name.startswith("/")
+        or name.endswith("/")
+        or posix_path.is_absolute()
+        or windows_path.drive
+        or windows_path.root
+        or any(part in {"", ".", ".."} or ":" in part for part in posix_path.parts)
+    ):
+        return ""
+    return "/".join(posix_path.parts)
+
+
+def _without_supported_extension(value: str) -> str:
+    suffix = PurePosixPath(value).suffix
+    if suffix.casefold() in _supported_model_extensions():
+        return value[:-len(suffix)]
+    return value
+
+
+def _inventory_resource_name(folder_name: str, requested_name: str) -> str | None:
+    requested = _safe_inventory_name(requested_name)
+    if not requested:
+        return None
+    try:
+        import folder_paths  # type: ignore
+    except Exception:
+        return None
+    get_filename_list = getattr(folder_paths, "get_filename_list", None)
+    if not callable(get_filename_list):
+        return None
+    try:
+        values = cast(Iterable[object], get_filename_list(folder_name))
+        inventory = [
+            safe_name
+            for value in values
+            if (safe_name := _safe_inventory_name(value))
+        ]
+    except Exception as exc:
+        logger.warning(
+            "[EasyUseAnima] Could not read the %s inventory: %s",
+            folder_name,
+            exc,
+        )
+        return None
+
+    requested_folded = requested.casefold()
+    exact = [name for name in inventory if name.casefold() == requested_folded]
+    if len(exact) == 1:
+        return exact[0]
+    requested_stem = _without_supported_extension(requested).casefold()
+    stem_matches = [
+        name
+        for name in inventory
+        if _without_supported_extension(name).casefold() == requested_stem
+    ]
+    if len(stem_matches) == 1:
+        return stem_matches[0]
+    if "/" not in requested:
+        basename_matches = [
+            name
+            for name in inventory
+            if PurePosixPath(_without_supported_extension(name)).name.casefold()
+            == requested_stem
+        ]
+        if len(basename_matches) == 1:
+            return basename_matches[0]
+        if len(basename_matches) > 1:
+            logger.warning(
+                "[EasyUseAnima] Embedding reference %r is ambiguous; skipping its hash.",
+                requested_name,
+            )
+    return None
+
+
+def _weighted_prompt_segments(prompt: str) -> Iterable[tuple[str, float]]:
+    value = str(prompt or "")
+    try:
+        from comfy.sd1_clip import (  # type: ignore
+            escape_important,
+            token_weights,
+            unescape_important,
+        )
+
+        parsed = token_weights(escape_important(value), 1.0)
+    except Exception:
+        return ((value, 1.0),)
+
+    segments: list[tuple[str, float]] = []
+    try:
+        for text, weight in parsed:
+            numeric_weight = float(weight)
+            if not math.isfinite(numeric_weight):
+                numeric_weight = 1.0
+            segments.append((str(unescape_important(text)), numeric_weight))
+    except Exception:
+        return ((value, 1.0),)
+    return tuple(segments)
+
+
+def _embedding_resource_hashes(prompts: Sequence[str]) -> list[_ResourceHash]:
+    resources: list[_ResourceHash] = []
+    seen_names: set[str] = set()
+    for prompt in prompts:
+        for segment, weight in _weighted_prompt_segments(prompt):
+            for match in _EMBEDDING_RE.finditer(segment):
+                if len(resources) >= _MAX_LOCAL_EMBEDDINGS:
+                    logger.warning(
+                        "[EasyUseAnima] Ignoring embedding references beyond the %d-resource limit.",
+                        _MAX_LOCAL_EMBEDDINGS,
+                    )
+                    return resources
+                requested_name = match.group(1)
+                inventory_name = _inventory_resource_name("embeddings", requested_name)
+                if inventory_name is None:
+                    continue
+                metadata_name = _lora_metadata_name(inventory_name)
+                normalized_name = metadata_name.casefold()
+                if not metadata_name or normalized_name in seen_names:
+                    continue
+                path = _resolve_resource_path(("embeddings",), inventory_name)
+                if path is None:
+                    continue
+                try:
+                    sha256 = _hash_file(path)
+                except OSError as exc:
+                    logger.warning(
+                        "[EasyUseAnima] Could not hash embedding %r; continuing without its hash: %s",
+                        inventory_name,
+                        exc,
+                    )
+                    continue
+                seen_names.add(normalized_name)
+                resources.append(
+                    _ResourceHash(
+                        display_name=metadata_name,
+                        metadata_key=f"embed:{metadata_name}",
+                        path=path,
+                        sha256=sha256,
+                        weight=weight,
+                    )
+                )
+    return resources
+
+
+def _local_resource_hashes(
+    modelname: str,
+    applied_loras: object,
+    prompts: Sequence[str] = (),
+) -> list[_ResourceHash]:
+    resources: list[_ResourceHash] = []
+    model_path = _resolve_resource_path(("diffusion_models", "checkpoints"), modelname)
+    if model_path is not None:
+        try:
+            resources.append(
+                _ResourceHash(
+                    display_name=_resource_name(modelname),
+                    metadata_key="model",
+                    path=model_path,
+                    sha256=_hash_file(model_path),
+                )
+            )
+        except OSError as exc:
+            logger.warning(
+                "[EasyUseAnima] Could not hash model %r; continuing without its hash: %s",
+                modelname,
+                exc,
+            )
+
+    values = applied_loras if isinstance(applied_loras, (list, tuple)) else ()
+    seen_names: set[str] = set()
+    for item in values:
+        if not isinstance(item, Mapping):
+            continue
+        source_name = str(item.get("name") or "").strip()
+        metadata_name = _lora_metadata_name(source_name)
+        if not metadata_name or metadata_name.casefold() in seen_names:
+            continue
+        seen_names.add(metadata_name.casefold())
+        lora_path = _resolve_resource_path(("loras",), source_name)
+        if lora_path is None:
+            logger.warning(
+                "[EasyUseAnima] Could not locate LoRA %r; continuing without its Civitai hash.",
+                source_name,
+            )
+            continue
+        try:
+            strength = float(item.get("strength_model", 1.0))
+        except (TypeError, ValueError):
+            strength = 1.0
+        if not math.isfinite(strength):
+            strength = 1.0
+        try:
+            sha256 = _hash_file(lora_path)
+        except OSError as exc:
+            logger.warning(
+                "[EasyUseAnima] Could not hash LoRA %r; continuing without its hash: %s",
+                source_name,
+                exc,
+            )
+            continue
+        resources.append(
+            _ResourceHash(
+                display_name=metadata_name,
+                metadata_key=f"LORA:{metadata_name}",
+                path=lora_path,
+                sha256=sha256,
+                weight=strength,
+            )
+        )
+    resources.extend(_embedding_resource_hashes(prompts))
+    return resources
+
+
+def _manual_resource_hashes(value: str) -> list[_ResourceHash]:
+    text = str(value or "")[:_MAX_MANUAL_HASH_TEXT]
+    resources: list[_ResourceHash] = []
+    unnamed_index = 0
+    seen_hashes: set[str] = set()
+    for raw_entry in text.replace("\r", "\n").replace("\n", ",").split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        pieces = [part.strip() for part in entry.split(":")]
+        if not all(pieces):
+            logger.warning("[EasyUseAnima] Skipping malformed additional Civitai hash entry: %r", entry)
+            continue
+        if len(pieces) > 3:
+            logger.warning("[EasyUseAnima] Skipping ambiguous additional Civitai hash entry: %r", entry)
+            continue
+        weight: float | None = None
+        if len(pieces) == 3:
+            try:
+                weight = float(pieces[-1])
+            except ValueError:
+                logger.warning("[EasyUseAnima] Skipping ambiguous additional Civitai hash entry: %r", entry)
+                continue
+            if not math.isfinite(weight):
+                logger.warning("[EasyUseAnima] Skipping non-finite additional Civitai hash weight: %r", entry)
+                continue
+            name, hash_value = pieces[0], pieces[1]
+        elif len(pieces) == 2:
+            first, second = pieces
+            try:
+                shorthand_weight = float(second)
+            except ValueError:
+                shorthand_weight = None
+            if shorthand_weight is not None and _HEX_HASH_RE.fullmatch(first):
+                if not math.isfinite(shorthand_weight):
+                    logger.warning("[EasyUseAnima] Skipping non-finite additional Civitai hash weight: %r", entry)
+                    continue
+                unnamed_index += 1
+                name = f"manual{unnamed_index}"
+                hash_value = first
+                weight = shorthand_weight
+            else:
+                name, hash_value = first, second
+        else:
+            unnamed_index += 1
+            name = f"manual{unnamed_index}"
+            hash_value = pieces[0]
+        if not name or _CONTROL_RE.search(name) or not _SAFE_HASH_RE.fullmatch(hash_value):
+            logger.warning("[EasyUseAnima] Skipping invalid additional Civitai hash entry: %r", entry)
+            continue
+        if name.casefold() in _RESERVED_METADATA_KEYS:
+            logger.warning(
+                "[EasyUseAnima] Skipping additional Civitai hash entry with reserved key %r.",
+                name,
+            )
+            continue
+        normalized_hash = hash_value.casefold()
+        if normalized_hash in seen_hashes:
+            continue
+        seen_hashes.add(normalized_hash)
+        resources.append(
+            _ResourceHash(
+                display_name=name,
+                metadata_key=name,
+                path=None,
+                sha256=hash_value,
+                weight=weight,
+                preserve_hash=True,
+            )
+        )
+        if len(resources) >= _MAX_MANUAL_HASHES:
+            break
+    return resources
+
+
+__all__ = ()

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9034,7 +9034,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 59
+            "line": 80
           }
         ],
         "classification": "external",
@@ -9042,7 +9042,7 @@
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 60,
+        "line": 81,
         "name": null,
         "optional": true,
         "requested": "requests",
@@ -9069,23 +9069,6 @@
       },
       {
         "alias": null,
-        "bound_name": "hashlib",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "hashlib",
-        "kind": "static_import",
-        "line": 5,
-        "name": null,
-        "optional": false,
-        "requested": "hashlib",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "alias": null,
         "bound_name": "json",
         "branch_context": [],
         "classification": "external",
@@ -9093,7 +9076,7 @@
         "conditional": false,
         "imported": "json",
         "kind": "static_import",
-        "line": 6,
+        "line": 5,
         "name": null,
         "optional": false,
         "requested": "json",
@@ -9110,27 +9093,10 @@
         "conditional": false,
         "imported": "logging",
         "kind": "static_import",
-        "line": 7,
+        "line": 6,
         "name": null,
         "optional": false,
         "requested": "logging",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "math",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "math",
-        "kind": "static_import",
-        "line": 8,
-        "name": null,
-        "optional": false,
-        "requested": "math",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -9144,7 +9110,7 @@
         "conditional": false,
         "imported": "os",
         "kind": "static_import",
-        "line": 9,
+        "line": 7,
         "name": null,
         "optional": false,
         "requested": "os",
@@ -9161,7 +9127,7 @@
         "conditional": false,
         "imported": "re",
         "kind": "static_import",
-        "line": 10,
+        "line": 8,
         "name": null,
         "optional": false,
         "requested": "re",
@@ -9178,7 +9144,7 @@
         "conditional": false,
         "imported": "tempfile",
         "kind": "static_import",
-        "line": 11,
+        "line": 9,
         "name": null,
         "optional": false,
         "requested": "tempfile",
@@ -9195,7 +9161,7 @@
         "conditional": false,
         "imported": "threading",
         "kind": "static_import",
-        "line": 12,
+        "line": 10,
         "name": null,
         "optional": false,
         "requested": "threading",
@@ -9212,7 +9178,7 @@
         "conditional": false,
         "imported": "collections.abc:Iterable",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "name": "Iterable",
         "optional": false,
         "requested": "collections.abc",
@@ -9229,7 +9195,7 @@
         "conditional": false,
         "imported": "collections.abc:Mapping",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "name": "Mapping",
         "optional": false,
         "requested": "collections.abc",
@@ -9246,7 +9212,7 @@
         "conditional": false,
         "imported": "collections.abc:Sequence",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "name": "Sequence",
         "optional": false,
         "requested": "collections.abc",
@@ -9263,27 +9229,10 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 14,
+        "line": 12,
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "lru_cache",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "functools:lru_cache",
-        "kind": "static_from",
-        "line": 15,
-        "name": "lru_cache",
-        "optional": false,
-        "requested": "functools",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -9297,7 +9246,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -9314,7 +9263,7 @@
         "conditional": false,
         "imported": "pathlib:PurePosixPath",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "name": "PurePosixPath",
         "optional": false,
         "requested": "pathlib",
@@ -9331,7 +9280,7 @@
         "conditional": false,
         "imported": "pathlib:PureWindowsPath",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "name": "PureWindowsPath",
         "optional": false,
         "requested": "pathlib",
@@ -9348,7 +9297,7 @@
         "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
-        "line": 17,
+        "line": 14,
         "name": "MappingProxyType",
         "optional": false,
         "requested": "types",
@@ -9365,7 +9314,7 @@
         "conditional": false,
         "imported": "typing:cast",
         "kind": "static_from",
-        "line": 18,
+        "line": 15,
         "name": "cast",
         "optional": false,
         "requested": "typing",
@@ -9382,7 +9331,7 @@
         "conditional": false,
         "imported": ".native_civitai:_fetch_civitai_autov3_hash",
         "kind": "static_from",
-        "line": 20,
+        "line": 17,
         "name": "_fetch_civitai_autov3_hash",
         "optional": false,
         "requested": ".native_civitai",
@@ -9400,7 +9349,7 @@
         "conditional": false,
         "imported": ".native_civitai:_fetch_civitai_resource_by_hash",
         "kind": "static_from",
-        "line": 23,
+        "line": 20,
         "name": "_fetch_civitai_resource_by_hash",
         "optional": false,
         "requested": ".native_civitai",
@@ -9411,53 +9360,111 @@
       },
       {
         "alias": null,
-        "bound_name": "folder_paths",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 89
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 90,
-        "name": null,
-        "optional": true,
-        "requested": "folder_paths",
-        "role": "optional_dependency",
-        "scope": "_supported_model_extensions",
-        "source": "easyuse_anima/aio/native_image_output.py"
+        "bound_name": "_EMBEDDING_RE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_EMBEDDING_RE",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_EMBEDDING_RE",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
         "alias": null,
-        "bound_name": "folder_paths",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 112
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 113,
-        "name": null,
-        "optional": true,
-        "requested": "folder_paths",
-        "role": "optional_dependency",
-        "scope": "_resolve_resource_path",
-        "source": "easyuse_anima/aio/native_image_output.py"
+        "bound_name": "_HEX_HASH_RE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_HEX_HASH_RE",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_HEX_HASH_RE",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_ResourceHash",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_ResourceHash",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_ResourceHash",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_local_resource_hashes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_local_resource_hashes",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_local_resource_hashes",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_manual_resource_hashes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_manual_resource_hashes",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_manual_resource_hashes",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resource_name",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_resource_hashes:_resource_name",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_resource_name",
+        "optional": false,
+        "requested": ".native_resource_hashes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
         "alias": null,
@@ -9468,7 +9475,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 423
+            "line": 245
           }
         ],
         "classification": "external",
@@ -9476,7 +9483,7 @@
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 424,
+        "line": 246,
         "name": "args",
         "optional": true,
         "requested": "comfy.cli_args",
@@ -9493,7 +9500,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 440,
+        "line": 262,
         "name": "ExifTags",
         "optional": false,
         "requested": "PIL",
@@ -9510,7 +9517,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 440,
+        "line": 262,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -9525,7 +9532,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 495,
+            "line": 317,
             "type_checking": false
           }
         ],
@@ -9534,7 +9541,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 496,
+        "line": 318,
         "name": "PngInfo",
         "optional": false,
         "requested": "PIL.PngImagePlugin",
@@ -9551,7 +9558,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 525,
+        "line": 347,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -9568,13 +9575,519 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 526,
+        "line": 348,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
         "role": "ordinary",
         "scope": "_tensor_to_pil",
         "source": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "hashlib",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "hashlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "math",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 10,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "tempfile",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 11,
+        "name": null,
+        "optional": false,
+        "requested": "tempfile",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 12,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Iterable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Iterable",
+        "kind": "static_from",
+        "line": 13,
+        "name": "Iterable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 13,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Sequence",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 13,
+        "name": "Sequence",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 14,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "lru_cache",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "functools:lru_cache",
+        "kind": "static_from",
+        "line": 15,
+        "name": "lru_cache",
+        "optional": false,
+        "requested": "functools",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 16,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PurePosixPath",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:PurePosixPath",
+        "kind": "static_from",
+        "line": 16,
+        "name": "PurePosixPath",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PureWindowsPath",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:PureWindowsPath",
+        "kind": "static_from",
+        "line": 16,
+        "name": "PureWindowsPath",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 17,
+        "name": "cast",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 53
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 54,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_supported_model_extensions",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 76
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 77,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_resolve_resource_path",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 104
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 105,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_hash_cache_path",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProgressBar",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 224
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.utils:ProgressBar",
+        "kind": "static_from",
+        "line": 225,
+        "name": "ProgressBar",
+        "optional": true,
+        "requested": "comfy.utils",
+        "role": "optional_dependency",
+        "scope": "_new_hash_progress",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 391
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 392,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_inventory_resource_name",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "escape_important",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.sd1_clip:escape_important",
+        "kind": "static_from",
+        "line": 445,
+        "name": "escape_important",
+        "optional": true,
+        "requested": "comfy.sd1_clip",
+        "role": "optional_dependency",
+        "scope": "_weighted_prompt_segments",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "token_weights",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.sd1_clip:token_weights",
+        "kind": "static_from",
+        "line": 445,
+        "name": "token_weights",
+        "optional": true,
+        "requested": "comfy.sd1_clip",
+        "role": "optional_dependency",
+        "scope": "_weighted_prompt_segments",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "unescape_important",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.sd1_clip:unescape_important",
+        "kind": "static_from",
+        "line": 445,
+        "name": "unescape_important",
+        "optional": true,
+        "requested": "comfy.sd1_clip",
+        "role": "optional_dependency",
+        "scope": "_weighted_prompt_segments",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
         "alias": null,
@@ -43059,6 +43572,10 @@
         "to": "easyuse_anima/aio/native_civitai.py"
       },
       {
+        "from": "easyuse_anima/aio/native_image_output.py",
+        "to": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
         "from": "easyuse_anima/aio/negpip.py",
         "to": "easyuse_anima/aio/generation_values.py"
       },
@@ -45087,6 +45604,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/native_resource_hashes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/negpip.py"
         ]
       },
@@ -46041,7 +46564,7 @@
     ]
   },
   "inventory": {
-    "module_count": 197,
+    "module_count": 198,
     "modules": [
       {
         "functions": [
@@ -48750,292 +49273,410 @@
         "functions": [
           {
             "async": false,
-            "end_line": 38,
+            "end_line": 40,
             "kind": "function",
-            "line": 32,
+            "line": 34,
             "loc": 7,
             "qualified_name": "_remote_text"
           },
           {
             "async": false,
-            "end_line": 48,
+            "end_line": 50,
             "kind": "function",
-            "line": 41,
+            "line": 43,
             "loc": 8,
             "qualified_name": "_positive_int"
           },
           {
             "async": false,
-            "end_line": 120,
+            "end_line": 69,
             "kind": "function",
-            "line": 51,
+            "line": 53,
+            "loc": 17,
+            "qualified_name": "_response_proves_hash"
+          },
+          {
+            "async": false,
+            "end_line": 141,
+            "kind": "function",
+            "line": 72,
             "loc": 70,
             "qualified_name": "_request_civitai_json"
           },
           {
             "async": false,
-            "end_line": 147,
+            "end_line": 170,
             "kind": "function",
-            "line": 123,
-            "loc": 25,
+            "line": 144,
+            "loc": 27,
             "qualified_name": "_cached_civitai_resource_by_hash"
           },
           {
             "async": false,
-            "end_line": 165,
+            "end_line": 188,
             "kind": "function",
-            "line": 150,
+            "line": 173,
             "loc": 16,
             "qualified_name": "_fetch_civitai_resource_by_hash"
           },
           {
             "async": false,
-            "end_line": 256,
+            "end_line": 279,
             "kind": "function",
-            "line": 168,
+            "line": 191,
             "loc": 89,
             "qualified_name": "_fetch_civitai_autov3_hash"
           }
         ],
         "is_package": false,
-        "loc": 259,
+        "loc": 282,
         "module": "easyuse_anima.aio.native_civitai",
-        "normalized_git_blob_sha1": "c0be61eccc8ba683ff2b4f746da62fed37b4a813",
+        "normalized_git_blob_sha1": "17eede629aa37731c706f801fc5ddd4f7f161d5e",
         "path": "easyuse_anima/aio/native_civitai.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 6,
-          "global_count": 7
+          "function_count": 7,
+          "global_count": 9
         }
       },
       {
         "functions": [
           {
             "async": false,
-            "end_line": 68,
-            "kind": "method",
-            "line": 66,
-            "loc": 3,
-            "qualified_name": "_ResourceHash.short_hash"
-          },
-          {
-            "async": false,
-            "end_line": 85,
+            "end_line": 74,
             "kind": "function",
-            "line": 79,
+            "line": 68,
             "loc": 7,
             "qualified_name": "_compact_json"
           },
           {
             "async": false,
-            "end_line": 94,
+            "end_line": 84,
             "kind": "function",
-            "line": 88,
-            "loc": 7,
-            "qualified_name": "_supported_model_extensions"
-          },
-          {
-            "async": false,
-            "end_line": 100,
-            "kind": "function",
-            "line": 97,
-            "loc": 4,
-            "qualified_name": "_resource_name"
-          },
-          {
-            "async": false,
-            "end_line": 106,
-            "kind": "function",
-            "line": 103,
-            "loc": 4,
-            "qualified_name": "_lora_metadata_name"
-          },
-          {
-            "async": false,
-            "end_line": 136,
-            "kind": "function",
-            "line": 109,
-            "loc": 28,
-            "qualified_name": "_resolve_resource_path"
-          },
-          {
-            "async": false,
-            "end_line": 146,
-            "kind": "function",
-            "line": 139,
-            "loc": 8,
-            "qualified_name": "_hash_file_revision"
-          },
-          {
-            "async": false,
-            "end_line": 151,
-            "kind": "function",
-            "line": 149,
-            "loc": 3,
-            "qualified_name": "_hash_file"
-          },
-          {
-            "async": false,
-            "end_line": 218,
-            "kind": "function",
-            "line": 154,
-            "loc": 65,
-            "qualified_name": "_local_resource_hashes"
-          },
-          {
-            "async": false,
-            "end_line": 286,
-            "kind": "function",
-            "line": 221,
-            "loc": 66,
-            "qualified_name": "_manual_resource_hashes"
-          },
-          {
-            "async": false,
-            "end_line": 296,
-            "kind": "function",
-            "line": 289,
+            "line": 77,
             "loc": 8,
             "qualified_name": "_clean_prompt_for_remix"
           },
           {
             "async": false,
-            "end_line": 294,
+            "end_line": 82,
             "kind": "function",
-            "line": 292,
+            "line": 80,
             "loc": 3,
             "qualified_name": "_clean_prompt_for_remix.simplify_embedding"
           },
           {
             "async": false,
-            "end_line": 309,
+            "end_line": 97,
             "kind": "function",
-            "line": 299,
+            "line": 87,
             "loc": 11,
             "qualified_name": "_civitai_sampler_name"
           },
           {
             "async": false,
-            "end_line": 335,
+            "end_line": 139,
             "kind": "function",
-            "line": 312,
-            "loc": 24,
+            "line": 100,
+            "loc": 40,
             "qualified_name": "_civitai_resource_entries"
           },
           {
             "async": false,
-            "end_line": 419,
+            "end_line": 241,
             "kind": "function",
-            "line": 338,
-            "loc": 82,
+            "line": 142,
+            "loc": 100,
             "qualified_name": "_build_native_metadata"
           },
           {
             "async": false,
-            "end_line": 428,
+            "end_line": 250,
             "kind": "function",
-            "line": 422,
+            "line": 244,
             "loc": 7,
             "qualified_name": "_comfy_metadata_enabled"
           },
           {
             "async": false,
-            "end_line": 432,
+            "end_line": 254,
             "kind": "function",
-            "line": 431,
+            "line": 253,
             "loc": 2,
             "qualified_name": "_encode_user_comment"
           },
           {
             "async": false,
-            "end_line": 452,
+            "end_line": 274,
             "kind": "function",
-            "line": 435,
+            "line": 257,
             "loc": 18,
             "qualified_name": "_build_exif_bytes"
           },
           {
             "async": false,
-            "end_line": 521,
+            "end_line": 343,
             "kind": "function",
-            "line": 455,
+            "line": 277,
             "loc": 67,
             "qualified_name": "_serialize_metadata"
           },
           {
             "async": false,
-            "end_line": 543,
+            "end_line": 365,
             "kind": "function",
-            "line": 524,
+            "line": 346,
             "loc": 20,
             "qualified_name": "_tensor_to_pil"
           },
           {
             "async": false,
-            "end_line": 590,
+            "end_line": 412,
             "kind": "function",
-            "line": 546,
+            "line": 368,
             "loc": 45,
             "qualified_name": "_allocate_filenames"
           },
           {
             "async": false,
-            "end_line": 558,
+            "end_line": 380,
             "kind": "function",
-            "line": 554,
+            "line": 376,
             "loc": 5,
             "qualified_name": "_allocate_filenames.occupied"
           },
           {
             "async": false,
-            "end_line": 608,
+            "end_line": 430,
             "kind": "function",
-            "line": 593,
+            "line": 415,
             "loc": 16,
             "qualified_name": "_atomic_save_image"
           },
           {
             "async": false,
-            "end_line": 623,
+            "end_line": 445,
             "kind": "function",
-            "line": 611,
+            "line": 433,
             "loc": 13,
             "qualified_name": "_atomic_write_text"
           },
           {
             "async": false,
-            "end_line": 660,
+            "end_line": 482,
             "kind": "function",
-            "line": 626,
+            "line": 448,
             "loc": 35,
             "qualified_name": "_resolve_native_output_folder"
           },
           {
             "async": false,
-            "end_line": 683,
+            "end_line": 505,
             "kind": "function",
-            "line": 663,
+            "line": 485,
             "loc": 21,
             "qualified_name": "_image_save_options"
           },
           {
             "async": false,
-            "end_line": 791,
+            "end_line": 613,
             "kind": "function",
-            "line": 686,
+            "line": 508,
             "loc": 106,
             "qualified_name": "_save_native_images"
           }
         ],
         "is_package": false,
-        "loc": 794,
+        "loc": 616,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "9d3891695083f95ac80cd9cd79070141912cae07",
+        "normalized_git_blob_sha1": "667b61622af439d90ba47cd102665ea1e8533fc0",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
-          "class_count": 3,
-          "function_count": 24,
-          "global_count": 14
+          "class_count": 2,
+          "function_count": 16,
+          "global_count": 9
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 49,
+            "kind": "method",
+            "line": 47,
+            "loc": 3,
+            "qualified_name": "_ResourceHash.metadata_hash"
+          },
+          {
+            "async": false,
+            "end_line": 58,
+            "kind": "function",
+            "line": 52,
+            "loc": 7,
+            "qualified_name": "_supported_model_extensions"
+          },
+          {
+            "async": false,
+            "end_line": 64,
+            "kind": "function",
+            "line": 61,
+            "loc": 4,
+            "qualified_name": "_resource_name"
+          },
+          {
+            "async": false,
+            "end_line": 70,
+            "kind": "function",
+            "line": 67,
+            "loc": 4,
+            "qualified_name": "_lora_metadata_name"
+          },
+          {
+            "async": false,
+            "end_line": 100,
+            "kind": "function",
+            "line": 73,
+            "loc": 28,
+            "qualified_name": "_resolve_resource_path"
+          },
+          {
+            "async": false,
+            "end_line": 122,
+            "kind": "function",
+            "line": 103,
+            "loc": 20,
+            "qualified_name": "_hash_cache_path"
+          },
+          {
+            "async": false,
+            "end_line": 178,
+            "kind": "function",
+            "line": 125,
+            "loc": 54,
+            "qualified_name": "_read_hash_cache"
+          },
+          {
+            "async": false,
+            "end_line": 215,
+            "kind": "function",
+            "line": 181,
+            "loc": 35,
+            "qualified_name": "_atomic_write_hash_cache"
+          },
+          {
+            "async": false,
+            "end_line": 220,
+            "kind": "function",
+            "line": 218,
+            "loc": 3,
+            "qualified_name": "_hash_cache_key"
+          },
+          {
+            "async": false,
+            "end_line": 229,
+            "kind": "function",
+            "line": 223,
+            "loc": 7,
+            "qualified_name": "_new_hash_progress"
+          },
+          {
+            "async": false,
+            "end_line": 239,
+            "kind": "function",
+            "line": 232,
+            "loc": 8,
+            "qualified_name": "_stat_revision"
+          },
+          {
+            "async": false,
+            "end_line": 286,
+            "kind": "function",
+            "line": 242,
+            "loc": 45,
+            "qualified_name": "_calculate_file_sha256"
+          },
+          {
+            "async": false,
+            "end_line": 352,
+            "kind": "function",
+            "line": 289,
+            "loc": 64,
+            "qualified_name": "_hash_file_revision"
+          },
+          {
+            "async": false,
+            "end_line": 358,
+            "kind": "function",
+            "line": 355,
+            "loc": 4,
+            "qualified_name": "_hash_file"
+          },
+          {
+            "async": false,
+            "end_line": 377,
+            "kind": "function",
+            "line": 361,
+            "loc": 17,
+            "qualified_name": "_safe_inventory_name"
+          },
+          {
+            "async": false,
+            "end_line": 384,
+            "kind": "function",
+            "line": 380,
+            "loc": 5,
+            "qualified_name": "_without_supported_extension"
+          },
+          {
+            "async": false,
+            "end_line": 439,
+            "kind": "function",
+            "line": 387,
+            "loc": 53,
+            "qualified_name": "_inventory_resource_name"
+          },
+          {
+            "async": false,
+            "end_line": 464,
+            "kind": "function",
+            "line": 442,
+            "loc": 23,
+            "qualified_name": "_weighted_prompt_segments"
+          },
+          {
+            "async": false,
+            "end_line": 509,
+            "kind": "function",
+            "line": 467,
+            "loc": 43,
+            "qualified_name": "_embedding_resource_hashes"
+          },
+          {
+            "async": false,
+            "end_line": 578,
+            "kind": "function",
+            "line": 512,
+            "loc": 67,
+            "qualified_name": "_local_resource_hashes"
+          },
+          {
+            "async": false,
+            "end_line": 653,
+            "kind": "function",
+            "line": 581,
+            "loc": 73,
+            "qualified_name": "_manual_resource_hashes"
+          }
+        ],
+        "is_package": false,
+        "loc": 656,
+        "module": "easyuse_anima.aio.native_resource_hashes",
+        "normalized_git_blob_sha1": "7bbc99cc120dcb1ead20d12d1cf69f6aa8a527b6",
+        "path": "easyuse_anima/aio/native_resource_hashes.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 20,
+          "global_count": 17
         }
       },
       {
@@ -62043,14 +62684,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 59
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 60,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_civitai.py"
@@ -62070,7 +62711,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "hashlib",
+        "imported": "json",
         "kind": "static_import",
         "line": 5,
         "optional": false,
@@ -62081,7 +62722,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "json",
+        "imported": "logging",
         "kind": "static_import",
         "line": 6,
         "optional": false,
@@ -62092,7 +62733,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "logging",
+        "imported": "os",
         "kind": "static_import",
         "line": 7,
         "optional": false,
@@ -62103,7 +62744,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "math",
+        "imported": "re",
         "kind": "static_import",
         "line": 8,
         "optional": false,
@@ -62114,7 +62755,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
+        "imported": "tempfile",
         "kind": "static_import",
         "line": 9,
         "optional": false,
@@ -62125,7 +62766,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "re",
+        "imported": "threading",
         "kind": "static_import",
         "line": 10,
         "optional": false,
@@ -62136,31 +62777,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "tempfile",
-        "kind": "static_import",
-        "line": 11,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "threading",
-        "kind": "static_import",
-        "line": 12,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "collections.abc:Iterable",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62171,7 +62790,7 @@
         "conditional": false,
         "imported": "collections.abc:Mapping",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62182,7 +62801,7 @@
         "conditional": false,
         "imported": "collections.abc:Sequence",
         "kind": "static_from",
-        "line": 13,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62193,18 +62812,7 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 14,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "functools:lru_cache",
-        "kind": "static_from",
-        "line": 15,
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62215,7 +62823,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62226,7 +62834,7 @@
         "conditional": false,
         "imported": "pathlib:PurePosixPath",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62237,7 +62845,7 @@
         "conditional": false,
         "imported": "pathlib:PureWindowsPath",
         "kind": "static_from",
-        "line": 16,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62248,7 +62856,7 @@
         "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
-        "line": 17,
+        "line": 14,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62259,7 +62867,7 @@
         "conditional": false,
         "imported": "typing:cast",
         "kind": "static_from",
-        "line": 18,
+        "line": 15,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62271,52 +62879,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 89
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 90,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 112
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 113,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 423
+            "line": 245
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 424,
+        "line": 246,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62327,7 +62897,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 440,
+        "line": 262,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62338,7 +62908,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 440,
+        "line": 262,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62348,7 +62918,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 495,
+            "line": 317,
             "type_checking": false
           }
         ],
@@ -62356,7 +62926,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 496,
+        "line": 318,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62367,7 +62937,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 525,
+        "line": 347,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -62378,10 +62948,360 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 526,
+        "line": 348,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 11,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 12,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Iterable",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 14,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "functools:lru_cache",
+        "kind": "static_from",
+        "line": 15,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 16,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:PurePosixPath",
+        "kind": "static_from",
+        "line": 16,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:PureWindowsPath",
+        "kind": "static_from",
+        "line": 16,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 53
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 54,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 76
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 77,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 104
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 105,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 224
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.utils:ProgressBar",
+        "kind": "static_from",
+        "line": 225,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 391
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 392,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:escape_important",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:token_weights",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:unescape_important",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
         "branch_context": [],
@@ -69333,14 +70253,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 59
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 60,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_civitai.py"
@@ -69352,55 +70272,169 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 89
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 90,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 112
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 113,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 423
+            "line": 245
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 424,
+        "line": 246,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 53
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 54,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 76
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 77,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 104
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 105,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 224
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.utils:ProgressBar",
+        "kind": "static_from",
+        "line": 225,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 391
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 392,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:escape_important",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:token_weights",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 444
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.sd1_clip:unescape_important",
+        "kind": "static_from",
+        "line": 445,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
         "branch_context": [
@@ -70435,6 +71469,7 @@
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/native_civitai.py",
       "easyuse_anima/aio/native_image_output.py",
+      "easyuse_anima/aio/native_resource_hashes.py",
       "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
@@ -70632,6 +71667,7 @@
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/native_civitai.py",
       "easyuse_anima/aio/native_image_output.py",
+      "easyuse_anima/aio/native_resource_hashes.py",
       "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
@@ -71779,7 +72815,7 @@
         "column": 14,
         "context": "assign:_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 17,
+        "line": 18,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71788,7 +72824,16 @@
         "column": 16,
         "context": "assign:_SAFE_HASH_RE",
         "kind": "import_time_call",
-        "line": 18,
+        "line": 19,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 18,
+        "context": "assign:_LOOKUP_HASH_RE",
+        "kind": "import_time_call",
+        "line": 20,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71797,7 +72842,7 @@
         "column": 15,
         "context": "assign:_SAFE_AIR_RE",
         "kind": "import_time_call",
-        "line": 19,
+        "line": 21,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71806,7 +72851,7 @@
         "column": 1,
         "context": "decorator:CivitaiResourceDescriptor",
         "kind": "import_time_call",
-        "line": 22,
+        "line": 24,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71815,7 +72860,7 @@
         "column": 1,
         "context": "decorator:_cached_civitai_resource_by_hash",
         "kind": "import_time_call",
-        "line": 123,
+        "line": 144,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71824,7 +72869,7 @@
         "column": 1,
         "context": "decorator:_fetch_civitai_autov3_hash",
         "kind": "import_time_call",
-        "line": 168,
+        "line": 191,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -71833,7 +72878,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 25,
+        "line": 32,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71842,34 +72887,7 @@
         "column": 15,
         "context": "assign:_LORA_TAG_RE",
         "kind": "import_time_call",
-        "line": 32,
-        "module": "easyuse_anima/aio/native_image_output.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 16,
-        "context": "assign:_EMBEDDING_RE",
-        "kind": "import_time_call",
-        "line": 33,
-        "module": "easyuse_anima/aio/native_image_output.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 16,
-        "context": "assign:_SAFE_HASH_RE",
-        "kind": "import_time_call",
-        "line": 34,
-        "module": "easyuse_anima/aio/native_image_output.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 15,
-        "context": "assign:_HEX_HASH_RE",
-        "kind": "import_time_call",
-        "line": 35,
+        "line": 37,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71878,7 +72896,7 @@
         "column": 14,
         "context": "assign:_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 36,
+        "line": 38,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71887,7 +72905,7 @@
         "column": 13,
         "context": "assign:_SAVE_LOCK",
         "kind": "import_time_call",
-        "line": 37,
+        "line": 39,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71896,7 +72914,7 @@
         "column": 25,
         "context": "assign:_CIVITAI_SAMPLER_NAMES",
         "kind": "import_time_call",
-        "line": 39,
+        "line": 41,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71905,16 +72923,7 @@
         "column": 1,
         "context": "decorator:NativeImageMetadata",
         "kind": "import_time_call",
-        "line": 51,
-        "module": "easyuse_anima/aio/native_image_output.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:_ResourceHash",
-        "kind": "import_time_call",
-        "line": 58,
+        "line": 53,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -71923,8 +72932,89 @@
         "column": 1,
         "context": "decorator:_SerializedMetadata",
         "kind": "import_time_call",
-        "line": 71,
+        "line": 60,
         "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 19,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 16,
+        "context": "assign:_EMBEDDING_RE",
+        "kind": "import_time_call",
+        "line": 29,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 16,
+        "context": "assign:_SAFE_HASH_RE",
+        "kind": "import_time_call",
+        "line": 30,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 15,
+        "context": "assign:_HEX_HASH_RE",
+        "kind": "import_time_call",
+        "line": 31,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 13,
+        "context": "assign:_SHA256_RE",
+        "kind": "import_time_call",
+        "line": 32,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 14,
+        "context": "assign:_CONTROL_RE",
+        "kind": "import_time_call",
+        "line": 33,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 26,
+        "context": "assign:_RESERVED_METADATA_KEYS",
+        "kind": "import_time_call",
+        "line": 34,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Lock",
+        "column": 19,
+        "context": "assign:_HASH_CACHE_LOCK",
+        "kind": "import_time_call",
+        "line": 35,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_ResourceHash",
+        "kind": "import_time_call",
+        "line": 38,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
         "scope": "<module>"
       },
       {
@@ -71932,8 +73022,8 @@
         "column": 1,
         "context": "decorator:_hash_file_revision",
         "kind": "import_time_call",
-        "line": 139,
-        "module": "easyuse_anima/aio/native_image_output.py",
+        "line": 289,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
         "scope": "<module>"
       },
       {
@@ -73705,9 +74795,18 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 37,
+        "line": 39,
         "module": "easyuse_anima/aio/native_image_output.py",
         "name": "_SAVE_LOCK"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "threading.Lock",
+        "line": 35,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "name": "_HASH_CACHE_LOCK"
       },
       {
         "categories": [

--- a/tests/fixtures/python_file_disposition_contract.v1.json
+++ b/tests/fixtures/python_file_disposition_contract.v1.json
@@ -4,7 +4,7 @@
   "inventory_owner": {
     "path": "tests/fixtures/python_backend_baseline.json",
     "expected_baseline_files": 191,
-    "expected_target_files": 197
+    "expected_target_files": 198
   },
   "linked_contracts": {
     "compatibility_registry": "docs/architecture/python-compatibility-shims.md",
@@ -881,12 +881,17 @@
       "path": "easyuse_anima/aio/native_image_output.py",
       "role": "aio-native-image-output",
       "owner_group": "aio",
-      "disposition": "cohesive_retain",
+      "disposition": "split",
       "status": "complete",
       "targets": [
         {
           "path": "easyuse_anima/aio/native_image_output.py",
           "role": "aio-native-image-output",
+          "owner_group": "aio"
+        },
+        {
+          "path": "easyuse_anima/aio/native_resource_hashes.py",
+          "role": "aio-native-resource-hashes",
           "owner_group": "aio"
         }
       ],
@@ -894,8 +899,8 @@
         "tests/test_aio_native_image_output.py"
       ],
       "compatibility_registry_key": null,
-      "task_id": null,
-      "rollback_unit": null,
+      "task_id": "ISSUE-689",
+      "rollback_unit": "Revert the cohesive Issue #689 native resource metadata and hash-owner split.",
       "replacement_owner": null,
       "size_exception_verdicts": []
     },

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -271,16 +271,28 @@
       "thread_safety": "functools.lru_cache serializes cache access with its internal lock; duplicate in-flight HTTP reads may occur without corrupting cache state."
     },
     {
-      "categories": ["cache", "lock"],
-      "cleanup": "No production reset; the revision-keyed SHA-256 cache is bounded to 128 entries and the save lock owns no disposable resource.",
+      "categories": ["lock"],
+      "cleanup": "No production reset; the save lock owns no disposable resource.",
       "id": "native-image-output-runtime",
-      "lifetime": "Process lifetime from module import; one save lock coordinates filename allocation and atomic publication, while the bounded cache retains completed file hashes by path, size, and modification time.",
+      "lifetime": "Process lifetime from module import; one save lock coordinates filename allocation and publication.",
       "module": "easyuse_anima/aio/native_image_output.py",
       "owner": "easyuse_anima.aio.native_image_output",
-      "symbols": ["_SAVE_LOCK", "_hash_file_revision"],
+      "symbols": ["_SAVE_LOCK"],
       "target_phase": "native-image-output-complete",
       "test_evidence": ["tests/test_aio_native_image_output.py"],
-      "thread_safety": "The module Lock serializes output-name reservation and publication; functools.lru_cache provides its own lock for bounded hash-cache access."
+      "thread_safety": "The module Lock serializes output-name reservation and publication."
+    },
+    {
+      "categories": ["cache", "lock", "persistent_cache"],
+      "cleanup": "No production reset; the in-memory revision cache and persistent hash cache are each bounded to 128 entries, and the persistent JSON document is capped at 1 MiB.",
+      "id": "native-resource-hash-runtime",
+      "lifetime": "Process lifetime from module import for the lock and in-memory LRU; the validated persistent cache survives restarts under the ComfyUI user directory.",
+      "module": "easyuse_anima/aio/native_resource_hashes.py",
+      "owner": "easyuse_anima.aio.native_resource_hashes",
+      "symbols": ["_HASH_CACHE_LOCK", "_hash_file_revision"],
+      "target_phase": "native-image-metadata-parity-complete",
+      "test_evidence": ["tests/test_aio_native_image_output.py"],
+      "thread_safety": "The module Lock serializes persistent cache load and publication; functools.lru_cache provides its own lock for bounded process-cache access."
     },
     {
       "categories": ["directory_initialization", "import_effect", "route_registration"],

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import tempfile
 import types
@@ -14,6 +15,7 @@ from PIL import ExifTags, Image
 
 from easyuse_anima.aio import native_civitai as civitai
 from easyuse_anima.aio import native_image_output as native
+from easyuse_anima.aio import native_resource_hashes as resources
 
 
 class FakeTensor:
@@ -30,7 +32,12 @@ class FakeTensor:
         return self.value
 
 
-def fake_folder_paths(files: dict[tuple[str, str], Path]) -> types.ModuleType:
+def fake_folder_paths(
+    files: dict[tuple[str, str], Path],
+    *,
+    filenames: dict[str, list[str]] | None = None,
+    user_directory: Path | None = None,
+) -> types.ModuleType:
     module = types.ModuleType("folder_paths")
     module.supported_pt_extensions = {
         ".safetensors",
@@ -40,6 +47,9 @@ def fake_folder_paths(files: dict[tuple[str, str], Path]) -> types.ModuleType:
         ".pth",
     }
     module.get_full_path = lambda folder, name: str(files[(folder, name)]) if (folder, name) in files else None
+    module.get_filename_list = lambda folder: list((filenames or {}).get(folder, []))
+    if user_directory is not None:
+        module.get_user_directory = lambda: str(user_directory)
     return module
 
 
@@ -54,7 +64,7 @@ def exif_user_comment(exif: Image.Exif) -> bytes:
 
 class AIONativeImageOutputTests(unittest.TestCase):
     def setUp(self):
-        native._hash_file_revision.cache_clear()
+        resources._hash_file_revision.cache_clear()
         civitai._fetch_civitai_autov3_hash.cache_clear()
         civitai._cached_civitai_resource_by_hash.cache_clear()
 
@@ -121,6 +131,193 @@ class AIONativeImageOutputTests(unittest.TestCase):
             resource_files,
             {"anima.safetensors", "style.safetensors"},
             "hashing must not write cache files beside model resources",
+        )
+
+    def test_embedding_hashes_use_comfy_inventory_weights_and_safe_matching(self):
+        self.assertEqual(resources._safe_inventory_name("/absolute/embed.pt"), "")
+        self.assertEqual(resources._safe_inventory_name(r"C:\outside\embed.pt"), "")
+        self.assertEqual(resources._safe_inventory_name("../outside.pt"), "")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            easy_path = root / "easy.pt"
+            negative_path = root / "bad.safetensors"
+            duplicate_one = root / "duplicate-one.pt"
+            duplicate_two = root / "duplicate-two.pt"
+            easy_path.write_bytes(b"easy embedding")
+            negative_path.write_bytes(b"negative embedding")
+            duplicate_one.write_bytes(b"duplicate one")
+            duplicate_two.write_bytes(b"duplicate two")
+            folder_paths = fake_folder_paths(
+                {
+                    ("embeddings", "sub/easy.pt"): easy_path,
+                    ("embeddings", "negative/bad.safetensors"): negative_path,
+                    ("embeddings", "one/duplicate.pt"): duplicate_one,
+                    ("embeddings", "two/duplicate.pt"): duplicate_two,
+                },
+                filenames={
+                    "embeddings": [
+                        "sub/easy.pt",
+                        "negative/bad.safetensors",
+                        "one/duplicate.pt",
+                        "two/duplicate.pt",
+                    ]
+                },
+            )
+            comfy = types.ModuleType("comfy")
+            sd1_clip = types.ModuleType("comfy.sd1_clip")
+            sd1_clip.escape_important = lambda value: value
+            sd1_clip.unescape_important = lambda value: value
+
+            def token_weights(value, _default):
+                if "sub/easy" in value:
+                    return [
+                        ("embedding:sub/easy", 0.65),
+                        ("embedding:../outside", 1.0),
+                        ("embedding:duplicate", 1.0),
+                    ]
+                return [
+                    ("embedding:negative/bad", 1.25),
+                    ("embedding:sub/easy", 2.0),
+                ]
+
+            sd1_clip.token_weights = token_weights
+            comfy.sd1_clip = sd1_clip
+            with (
+                patch.dict(
+                    sys.modules,
+                    {
+                        "folder_paths": folder_paths,
+                        "comfy": comfy,
+                        "comfy.sd1_clip": sd1_clip,
+                    },
+                ),
+                self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+            ):
+                metadata = native._build_native_metadata(
+                    modelname="",
+                    positive="(embedding:sub/easy:0.65), embedding:../outside, embedding:duplicate",
+                    negative="embedding:negative/bad",
+                    width=1,
+                    height=1,
+                    seed=1,
+                    steps=1,
+                    cfg=1.0,
+                    sampler_name="euler",
+                    scheduler_name="normal",
+                    denoise=1.0,
+                    clip_skip=0,
+                    custom="",
+                    additional_hashes="",
+                    applied_loras=[],
+                    download_civitai_data=False,
+                    easy_remix=True,
+                )
+
+        easy_hash = hashlib.sha256(b"easy embedding").hexdigest()[:10]
+        negative_hash = hashlib.sha256(b"negative embedding").hexdigest()[:10]
+        self.assertEqual(
+            metadata.hashes,
+            {
+                "embed:sub/easy": easy_hash,
+                "embed:negative/bad": negative_hash,
+            },
+        )
+        self.assertEqual(
+            metadata.final_hashes,
+            f"sub/easy:{easy_hash}:0.65,negative/bad:{negative_hash}:1.25",
+        )
+        self.assertIn("embedding:easy", metadata.parameters)
+        self.assertNotIn("embed:duplicate", metadata.hashes)
+
+    def test_manual_hashes_preserve_values_and_cannot_replace_local_model_hash(self):
+        first = "ABCDEF1234AAAAAA"
+        second = "ABCDEF1234BBBBBB"
+        with tempfile.TemporaryDirectory() as temp:
+            model_path = Path(temp) / "anima.safetensors"
+            model_path.write_bytes(b"verified model")
+            folder_paths = fake_folder_paths({
+                ("diffusion_models", "anima.safetensors"): model_path,
+            })
+            with (
+                patch.dict(sys.modules, {"folder_paths": folder_paths}),
+                self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+            ):
+                metadata = native._build_native_metadata(
+                    modelname="anima.safetensors",
+                    positive="",
+                    negative="",
+                    width=1,
+                    height=1,
+                    seed=1,
+                    steps=1,
+                    cfg=1.0,
+                    sampler_name="euler",
+                    scheduler_name="normal",
+                    denoise=1.0,
+                    clip_skip=0,
+                    custom="",
+                    additional_hashes=(
+                        f"first:{first},second:{second},MODEL:DEADBEEF12,"
+                        "duplicate:AAAABBBB12,duplicate:CCCCDDDD34"
+                    ),
+                    applied_loras=[],
+                    download_civitai_data=False,
+                    easy_remix=False,
+                )
+
+        model_hash = hashlib.sha256(b"verified model").hexdigest()[:10]
+        self.assertEqual(metadata.hashes["model"], model_hash)
+        self.assertNotIn("MODEL", metadata.hashes)
+        self.assertEqual(metadata.hashes["first"], first)
+        self.assertEqual(metadata.hashes["second"], second)
+        self.assertEqual(metadata.hashes["duplicate"], "AAAABBBB12")
+        self.assertIn(f"first:{first}", metadata.final_hashes)
+        self.assertIn(f"second:{second}", metadata.final_hashes)
+
+    def test_manual_full_and_short_hashes_receive_proven_civitai_descriptors(self):
+        full_hash = "a" * 64
+        short_hash = "ABCDEF1234"
+
+        def descriptor(resource_hash):
+            identifier = 1 if resource_hash == full_hash else 2
+            return civitai.CivitaiResourceDescriptor(
+                model_name=f"Resource {identifier}",
+                version_name=f"v{identifier}",
+                air="",
+                model_version_id=identifier,
+            )
+
+        with patch.object(
+            native,
+            "_fetch_civitai_resource_by_hash",
+            side_effect=descriptor,
+        ) as fetch:
+            metadata = native._build_native_metadata(
+                modelname="",
+                positive="",
+                negative="",
+                width=1,
+                height=1,
+                seed=1,
+                steps=1,
+                cfg=1.0,
+                sampler_name="euler",
+                scheduler_name="normal",
+                denoise=1.0,
+                clip_skip=0,
+                custom="",
+                additional_hashes=f"Full:{full_hash}:0.4,Auto:{short_hash}:0.7",
+                applied_loras=[],
+                download_civitai_data=True,
+                easy_remix=False,
+            )
+
+        self.assertEqual([call.args[0] for call in fetch.call_args_list], [full_hash, short_hash])
+        self.assertEqual(metadata.hashes["Full"], full_hash)
+        self.assertEqual(metadata.hashes["Auto"], short_hash)
+        self.assertIn(
+            'Civitai resources: [{"modelName":"Resource 1","versionName":"v1","weight":0.4,"modelVersionId":1},{"modelName":"Resource 2","versionName":"v2","weight":0.7,"modelVersionId":2}]',
+            metadata.parameters,
         )
 
     def test_civitai_resource_lookup_is_opt_in_and_keeps_hashes(self):
@@ -197,13 +394,13 @@ class AIONativeImageOutputTests(unittest.TestCase):
 
     def test_manual_hash_parser_rejects_ambiguous_and_non_finite_entries(self):
         with self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"):
-            resources = native._manual_resource_hashes(
+            parsed_resources = resources._manual_resource_hashes(
                 "valid:ABCDEF1234,numeric:1234567890,DEADBEEF12:0.5,"
                 "ambiguous:name:hash,bad:FEEDFACE12:nan,weighted:CAFEBABE10:0.25"
             )
 
         self.assertEqual(
-            [(item.display_name, item.sha256, item.weight) for item in resources],
+            [(item.display_name, item.sha256, item.weight) for item in parsed_resources],
             [
                 ("valid", "ABCDEF1234", None),
                 ("numeric", "1234567890", None),
@@ -326,10 +523,15 @@ class AIONativeImageOutputTests(unittest.TestCase):
             "name": "v1",
             "air": "urn:air:sdxl:checkpoint:civitai:1@123",
             "model": {"name": "Anima"},
+            "files": [{"hashes": {"SHA256": "b" * 64}}],
             "images": [{"url": "x" * 100_000}],
         }
-        with patch.object(civitai, "_request_civitai_json", return_value=remote):
+        with patch.object(civitai, "_request_civitai_json", return_value=remote) as request:
             descriptor = civitai._fetch_civitai_resource_by_hash("b" * 64)
+            self.assertEqual(
+                civitai._fetch_civitai_resource_by_hash("b" * 64),
+                descriptor,
+            )
 
         self.assertEqual(
             descriptor,
@@ -341,13 +543,202 @@ class AIONativeImageOutputTests(unittest.TestCase):
             ),
         )
         self.assertFalse(hasattr(descriptor, "images"))
+        request.assert_called_once()
 
         civitai._cached_civitai_resource_by_hash.cache_clear()
         remote["air"] = "urn:air:invalid value"
+        remote["files"] = [{"hashes": {"SHA256": "c" * 64}}]
         with patch.object(civitai, "_request_civitai_json", return_value=remote):
             descriptor = civitai._fetch_civitai_resource_by_hash("c" * 64)
         self.assertEqual(descriptor.air, "")
         self.assertEqual(descriptor.model_version_id, 123)
+
+    def test_civitai_resource_lookup_requires_exact_hash_proof(self):
+        remote = {
+            "id": 123,
+            "name": "v1",
+            "model": {"name": "Anima"},
+            "files": [{"hashes": {"AutoV3": "ABCDEF1234"}}],
+        }
+        with patch.object(civitai, "_request_civitai_json", return_value=remote):
+            descriptor = civitai._fetch_civitai_resource_by_hash("abcdef1234")
+        self.assertEqual(descriptor.model_version_id, 123)
+
+        civitai._cached_civitai_resource_by_hash.cache_clear()
+        with patch.object(civitai, "_request_civitai_json", return_value=remote):
+            self.assertIsNone(civitai._fetch_civitai_resource_by_hash("deadbeef12"))
+
+        civitai._cached_civitai_resource_by_hash.cache_clear()
+        malformed = {**remote, "files": [{"hashes": ["ABCDEF1234"]}]}
+        with patch.object(civitai, "_request_civitai_json", return_value=malformed):
+            self.assertIsNone(civitai._fetch_civitai_resource_by_hash("abcdef1234"))
+
+        with patch.object(civitai, "_request_civitai_json") as request:
+            self.assertIsNone(civitai._fetch_civitai_resource_by_hash("not-a-hash"))
+        request.assert_not_called()
+
+    def test_civitai_resource_enrichment_attempts_are_bounded(self):
+        resource_items = [
+            resources._ResourceHash(
+                display_name=f"resource-{index}",
+                metadata_key=f"resource-{index}",
+                path=None,
+                sha256=f"{index + 1:064x}",
+                preserve_hash=True,
+            )
+            for index in range(native._MAX_REMOTE_RESOURCES + 5)
+        ]
+        with patch.object(
+            native,
+            "_fetch_civitai_resource_by_hash",
+            return_value=None,
+        ) as fetch:
+            self.assertEqual(native._civitai_resource_entries(resource_items), [])
+
+        self.assertEqual(fetch.call_count, native._MAX_REMOTE_RESOURCES)
+
+    def test_persistent_hash_cache_reuses_revision_and_reports_uncached_progress(self):
+        progress_updates = []
+
+        class ProgressBar:
+            def __init__(self, total):
+                self.total = total
+
+            def update_absolute(self, value, total):
+                progress_updates.append((value, total, self.total))
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            user_directory = root / "user"
+            model_directory = root / "models"
+            user_directory.mkdir()
+            model_directory.mkdir()
+            model_path = model_directory / "model.safetensors"
+            first_bytes = b"first revision"
+            second_bytes = b"other revision"
+            self.assertEqual(len(first_bytes), len(second_bytes))
+            model_path.write_bytes(first_bytes)
+            folder_paths = fake_folder_paths({}, user_directory=user_directory)
+            comfy = types.ModuleType("comfy")
+            comfy_utils = types.ModuleType("comfy.utils")
+            comfy_utils.ProgressBar = ProgressBar
+            comfy.utils = comfy_utils
+            with patch.dict(
+                sys.modules,
+                {
+                    "folder_paths": folder_paths,
+                    "comfy": comfy,
+                    "comfy.utils": comfy_utils,
+                },
+            ):
+                first = resources._hash_file(model_path)
+                cache_path = (
+                    user_directory
+                    / "easyuse_anima"
+                    / "cache"
+                    / resources._HASH_CACHE_FILENAME
+                )
+                self.assertTrue(cache_path.is_file())
+                self.assertEqual(
+                    {path.name for path in model_directory.iterdir()},
+                    {"model.safetensors"},
+                )
+                self.assertEqual(progress_updates[-1][0], len(first_bytes))
+
+                resources._hash_file_revision.cache_clear()
+                with patch.object(
+                    resources,
+                    "_calculate_file_sha256",
+                    side_effect=AssertionError("persistent cache miss"),
+                ):
+                    self.assertEqual(resources._hash_file(model_path), first)
+
+                original_stat = model_path.stat()
+                replacement = model_directory / "replacement.tmp"
+                replacement.write_bytes(second_bytes)
+                os.utime(
+                    replacement,
+                    ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+                )
+                os.replace(replacement, model_path)
+                os.utime(
+                    model_path,
+                    ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+                )
+                replaced_stat = model_path.stat()
+                self.assertEqual(replaced_stat.st_size, original_stat.st_size)
+                self.assertEqual(replaced_stat.st_mtime_ns, original_stat.st_mtime_ns)
+                resources._hash_file_revision.cache_clear()
+                calculate = resources._calculate_file_sha256
+                with patch.object(
+                    resources,
+                    "_calculate_file_sha256",
+                    wraps=calculate,
+                ) as recalculated:
+                    second = resources._hash_file(model_path)
+                self.assertNotEqual(second, first)
+                self.assertEqual(second, hashlib.sha256(second_bytes).hexdigest())
+                recalculated.assert_called_once()
+
+                cache_path.write_text("not-json", encoding="utf-8")
+                resources._hash_file_revision.cache_clear()
+                with (
+                    patch.object(
+                        resources,
+                        "_calculate_file_sha256",
+                        wraps=calculate,
+                    ) as recomputed,
+                    self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+                ):
+                    self.assertEqual(resources._hash_file(model_path), second)
+                recomputed.assert_called_once()
+                self.assertEqual(
+                    json.loads(cache_path.read_text(encoding="utf-8"))["version"],
+                    resources._HASH_CACHE_SCHEMA,
+                )
+
+    def test_persistent_hash_cache_is_bounded_and_write_failures_are_nonfatal(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            user_directory = root / "user"
+            user_directory.mkdir()
+            paths = []
+            for index in range(3):
+                path = root / f"resource-{index}.safetensors"
+                path.write_bytes(f"resource-{index}".encode("ascii"))
+                paths.append(path)
+            folder_paths = fake_folder_paths({}, user_directory=user_directory)
+            with (
+                patch.dict(sys.modules, {"folder_paths": folder_paths}),
+                patch.object(resources, "_HASH_CACHE_MAX_ENTRIES", 2),
+            ):
+                for path in paths:
+                    resources._hash_file(path)
+                cache_path = (
+                    user_directory
+                    / "easyuse_anima"
+                    / "cache"
+                    / resources._HASH_CACHE_FILENAME
+                )
+                payload = json.loads(cache_path.read_text(encoding="utf-8"))
+                self.assertEqual(len(payload["entries"]), 2)
+
+                resources._hash_file_revision.cache_clear()
+                uncached_path = root / "write-failure.safetensors"
+                uncached_path.write_bytes(b"still returns a hash")
+                with (
+                    patch.object(
+                        resources,
+                        "_atomic_write_hash_cache",
+                        side_effect=OSError("read-only user directory"),
+                    ),
+                    self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+                ):
+                    result = resources._hash_file(uncached_path)
+                self.assertEqual(
+                    result,
+                    hashlib.sha256(b"still returns a hash").hexdigest(),
+                )
 
     def test_png_jpeg_and_webp_round_trip_a1111_and_comfy_workflow_metadata(self):
         metadata = native.NativeImageMetadata(

--- a/tests/test_python_file_disposition_contract.py
+++ b/tests/test_python_file_disposition_contract.py
@@ -60,9 +60,9 @@ class PythonFileDispositionContractTests(unittest.TestCase):
         self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
         contract = self.validate(self.document)
         self.assertEqual(contract["expected_baseline_files"], 191)
-        self.assertEqual(contract["expected_target_files"], 197)
+        self.assertEqual(contract["expected_target_files"], 198)
         self.assertEqual(len(contract["entries"]), 191)
-        self.assertEqual(len(contract["target_paths"]), 197)
+        self.assertEqual(len(contract["target_paths"]), 198)
 
     def test_inventory_requires_every_source_exactly_once(self):
         missing = copy.deepcopy(self.document)


### PR DESCRIPTION
## 목적과 변경 경계

Native Image Saver가 외부 Image Saver 없이 로컬 checkpoint, LoRA, embedding provenance를 A1111 metadata와 Civitai metadata에 일관되게 기록하도록 보완합니다.

Base: `dev` at `f644efed895ffb6aff68499639fb46fa4cc9bd19`
Head: `83a1861e79e7d84c9a252549f057881e4d49e030`

## 주요 변경

- positive/negative prompt의 ComfyUI embedding token을 해석하고 안전하게 로컬 embedding SHA-256을 기록
- checkpoint, LoRA, embedding hash를 동일한 검증·중복 제거 계약으로 통합
- 수동 hash를 조용히 자르지 않고 검증된 원문 그대로 보존
- 예약된 `model` 수동 키가 로컬 checkpoint provenance를 덮어쓰지 못하도록 차단
- Civitai 응답의 파일 hash가 요청 hash와 정확히 일치할 때만 descriptor 채택
- Civitai 조회 32건, 응답 파일 256건 상한
- user directory에 경로 비노출, 크기 제한, 원자적 교체를 적용한 persistent hash cache 추가
- 새 런타임 state와 Python split disposition 계약 갱신

## 보존 계약

- 기존 PNG/JPEG/WebP 저장 형식, A1111 parameters, Comfy workflow/prompt payload 유지
- 해시는 ComfyUI `folder_paths`가 해석한 로컬 파일만 대상으로 계산
- 모델 디렉터리에는 캐시나 보조 파일을 쓰지 않음
- Civitai enrichment 실패는 이미지 저장을 막지 않음

## 검증

- `tests.test_aio_native_image_output`: 26 passed
- `tests.test_python_backend_analyzer`: 19 passed
- `tests.test_python_runtime_state_ownership`: 7 passed
- `tests.test_python_file_disposition_contract`: 7 passed
- full: 1563 passed, 2 skipped
- frontend: 121 JavaScript files passed
- ComfyUI v0.34.0 / frontend 1.49.6
- user/manual instance unchanged

## 위험과 롤백

- Windows junction/symlink 교체 경쟁과 OS crash 직전 publication 내구성은 이 PR 범위 밖이며 #694에서 별도 강화
- 롤백 단위는 이 PR 전체

Addresses #689
Addresses #690
Addresses #692
Addresses #693

Next: #694