### PR TITLE
fix(aio): bound Civitai enrichment work

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -70,13 +70,23 @@ Civitai Hash Fetcher rows resolve an AutoV3 value. Both paths use fixed
 
 - no user-provided URL is accepted;
 - redirects are disabled and normal TLS verification remains enabled;
-- connect/read timeouts are bounded;
+- connect/read timeouts are bounded, and all Civitai paths in one save share a
+  12-second wall-clock deadline plus a 16-request HTTP-call budget;
 - response bodies are streamed with a 2 MiB hard limit;
-- one save performs remote enrichment for at most 32 distinct local or manual resources and processes at most 32 enabled hash-fetcher rows;
+- one AutoV3 row consumes one call for model search and, when matched, one more
+  for its selected version; those calls share the same budget as local/manual
+  resource enrichment;
+- once either budget ends, remaining remote lookups are skipped and the image
+  is still saved with hashes and metadata already available;
+- a timed-out transport may finish on one daemon worker, but a process-wide
+  single request slot prevents abandoned slow streams from accumulating;
+- one save considers at most 32 distinct local or manual resources and at most
+  32 enabled hash-fetcher rows before the stricter shared budgets apply;
 - remote names and identifiers are length/control-character validated;
 - a by-hash response is accepted only when one returned file contains an exact
   match for the requested full or short hexadecimal hash;
-- successful lookups cache only a small validated hash string or descriptor in memory;
+- successful lookups cache only a small validated hash string or descriptor in
+  memory, after whitespace trimming and case normalization of cache keys;
 - transport, HTTP, size, and parse failures are logged as metadata misses and
   never block image saving.
 

--- a/docs/development/registry-scanner-safety.md
+++ b/docs/development/registry-scanner-safety.md
@@ -52,7 +52,9 @@ updating a release branch that will be scanned by Registry automation.
   backend is called.
 - Native Civitai enrichment is disabled by default. `Civitai data` is the
   explicit opt-in, and `easyuse_anima/aio/native_civitai.py` owns the only
-  fixed-host GET boundary used by native image output.
+  fixed-host GET boundary used by native image output. All fetcher and resource
+  requests in one save share a 12-second deadline and a 16-call budget; budget
+  exhaustion skips optional enrichment without failing image output.
 - AiO ResShift execution is fail-closed before optional-node lookup. Its saved
   settings remain readable, but re-enabling the adapter requires the safe
   loader contract tracked in issue #679.
@@ -111,3 +113,5 @@ and guarded by the explicit remote API allow setting.
 Expected exception: `easyuse_anima/aio/native_civitai.py` contains one
 `requests.get` call. It must remain fixed to the Civitai HTTPS API, disabled by
 default behind `Civitai data`, redirect-disabled, timeout-bound, and size-bound.
+It must also remain behind the per-save deadline/call budget and the bounded
+process-wide draining-request slot.

--- a/docs/nodes/anima-aio-generator.en.md
+++ b/docs/nodes/anima-aio-generator.en.md
@@ -122,7 +122,9 @@ and cannot replace the locally owned `model` hash. `Civitai data` is disabled by
 default; explicitly enable it to enrich local and manual hashes through fixed
 `https://civitai.com/api/v1` endpoints. A short-hash result is accepted only
 when the response contains an exact matching file hash. Failures are logged and
-do not block image saving. Civitai Hash Fetcher rows likewise store username,
+do not block image saving. Hash Fetcher and local/manual enrichment share a
+12-second, 16-request budget per save; remaining lookups are skipped when
+either limit is reached. Civitai Hash Fetcher rows likewise store username,
 model name, and version and add `model_name:AutoV3` entries.
 
 ## Required Node Packs

--- a/easyuse_anima/aio/native_civitai.py
+++ b/easyuse_anima/aio/native_civitai.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import json
 import logging
 import re
-from collections.abc import Mapping
-from dataclasses import dataclass
+import threading
+import time
+from collections.abc import Callable, Mapping
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, cast
 
@@ -14,11 +17,70 @@ logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 _CIVITAI_API_ROOT = "https://civitai.com/api/v1"
 _CIVITAI_RESPONSE_LIMIT = 2 * 1024 * 1024
+_CIVITAI_ENRICHMENT_TIMEOUT_SECONDS = 12.0
+_CIVITAI_HTTP_CALL_LIMIT = 16
 _MAX_REMOTE_FILES = 256
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _SAFE_HASH_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 _LOOKUP_HASH_RE = re.compile(r"^[0-9a-f]{8,128}$")
 _SAFE_AIR_RE = re.compile(r"^urn:air:[A-Za-z0-9][A-Za-z0-9._~:@%+\-]{0,503}$")
+_CIVITAI_REQUEST_SLOT = threading.BoundedSemaphore(1)
+
+
+class CivitaiLookupBudgetExhausted(RuntimeError):
+    """The optional network-enrichment budget for one save was exhausted."""
+
+
+@dataclass(slots=True)
+class CivitaiLookupBudget:
+    """Shared deadline and HTTP-call allowance for one image-save operation."""
+
+    timeout_seconds: float = _CIVITAI_ENRICHMENT_TIMEOUT_SECONDS
+    http_call_limit: int = _CIVITAI_HTTP_CALL_LIMIT
+    clock: Callable[[], float] = time.monotonic
+    _deadline: float | None = field(default=None, init=False, repr=False)
+    _calls_started: int = field(default=0, init=False, repr=False)
+    _lock: Any = field(default_factory=threading.Lock, init=False, repr=False)
+
+    @property
+    def calls_started(self) -> int:
+        with self._lock:
+            return self._calls_started
+
+    def reserve_http_call(self) -> float:
+        """Consume one call and return its remaining wall-clock allowance."""
+
+        with self._lock:
+            now = float(self.clock())
+            if self._deadline is None:
+                self._deadline = now + max(0.0, float(self.timeout_seconds))
+            if now >= self._deadline:
+                raise CivitaiLookupBudgetExhausted(
+                    "Civitai enrichment deadline was exhausted"
+                )
+            if self._calls_started >= max(0, int(self.http_call_limit)):
+                raise CivitaiLookupBudgetExhausted(
+                    "Civitai enrichment HTTP-call budget was exhausted"
+                )
+            self._calls_started += 1
+            return self._deadline - now
+
+    def require_time_remaining(self) -> float:
+        with self._lock:
+            if self._deadline is None:
+                return max(0.0, float(self.timeout_seconds))
+            remaining = self._deadline - float(self.clock())
+        if remaining <= 0:
+            raise CivitaiLookupBudgetExhausted(
+                "Civitai enrichment deadline was exhausted"
+            )
+        return remaining
+
+
+_ACTIVE_CIVITAI_BUDGET: ContextVar[CivitaiLookupBudget | None] = ContextVar(
+    "easyuse_anima_civitai_budget",
+    default=None,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +91,18 @@ class CivitaiResourceDescriptor:
     version_name: str
     air: str
     model_version_id: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class _CivitaiModelLookup:
+    """Preserve first-request spelling while comparing normalized cache keys."""
+
+    username_key: str
+    model_name_key: str
+    version_key: str
+    username: str = field(compare=False)
+    model_name: str = field(compare=False)
+    version: str = field(compare=False)
 
 
 def _remote_text(value: object, *, max_length: int = 512) -> str:
@@ -69,34 +143,34 @@ def _response_proves_hash(data: Mapping[str, object], normalized_hash: str) -> b
     return False
 
 
-def _request_civitai_json(
+def _default_civitai_transport(
     endpoint: str,
     *,
-    params: Mapping[str, str | int] | None = None,
+    params: Mapping[str, str | int] | None,
+    timeout: tuple[float, float],
+) -> Any:
+    import requests
+
+    return requests.get(
+        endpoint,
+        params=dict(params or {}),
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "ComfyUI-EasyUseAnima/native-image-output",
+        },
+        timeout=timeout,
+        allow_redirects=False,
+        stream=True,
+    )
+
+
+def _read_civitai_response(
+    response: Any,
+    *,
+    budget: CivitaiLookupBudget,
 ) -> dict[str, Any]:
-    if not endpoint.startswith(f"{_CIVITAI_API_ROOT}/"):
-        raise RuntimeError("[EasyUseAnima] Refusing a non-Civitai metadata endpoint.")
-
     try:
-        import requests
-
-        response = requests.get(
-            endpoint,
-            params=dict(params or {}),
-            headers={
-                "Accept": "application/json",
-                "User-Agent": "ComfyUI-EasyUseAnima/native-image-output",
-            },
-            timeout=(3.05, 10),
-            allow_redirects=False,
-            stream=True,
-        )
-    except Exception as exc:
-        raise RuntimeError(
-            f"Civitai request failed ({type(exc).__name__})"
-        ) from exc
-
-    try:
+        budget.require_time_remaining()
         if response.status_code != 200:
             raise RuntimeError(f"Civitai returned HTTP {response.status_code}")
         length_header = response.headers.get("Content-Length")
@@ -111,6 +185,7 @@ def _request_civitai_json(
 
         payload = bytearray()
         for chunk in response.iter_content(chunk_size=64 * 1024):
+            budget.require_time_remaining()
             if not chunk:
                 continue
             if len(chunk) > _CIVITAI_RESPONSE_LIMIT - len(payload):
@@ -118,6 +193,7 @@ def _request_civitai_json(
                     "Civitai response exceeded the metadata size limit"
                 )
             payload.extend(chunk)
+        budget.require_time_remaining()
         value = json.loads(payload.decode("utf-8"))
     except RuntimeError:
         raise
@@ -136,6 +212,80 @@ def _request_civitai_json(
                 type(exc).__name__,
             )
 
+    if not isinstance(value, dict):
+        raise RuntimeError("Civitai returned an invalid metadata object")
+    return cast(dict[str, Any], value)
+
+
+def _request_civitai_json(
+    endpoint: str,
+    *,
+    params: Mapping[str, str | int] | None = None,
+    budget: CivitaiLookupBudget | None = None,
+    transport: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    if not endpoint.startswith(f"{_CIVITAI_API_ROOT}/"):
+        raise RuntimeError("[EasyUseAnima] Refusing a non-Civitai metadata endpoint.")
+
+    active_budget = budget or _ACTIVE_CIVITAI_BUDGET.get() or CivitaiLookupBudget()
+    remaining = active_budget.reserve_http_call()
+    if not _CIVITAI_REQUEST_SLOT.acquire(blocking=False):
+        raise CivitaiLookupBudgetExhausted(
+            "A previous Civitai request is still draining after its deadline"
+        )
+
+    outcome: dict[str, object] = {}
+    completed = threading.Event()
+    request_transport = transport or _default_civitai_transport
+    timeout = (
+        max(0.001, min(3.05, remaining)),
+        max(0.001, min(10.0, remaining)),
+    )
+
+    def worker() -> None:
+        try:
+            try:
+                response = request_transport(
+                    endpoint,
+                    params=params,
+                    timeout=timeout,
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Civitai request failed ({type(exc).__name__})"
+                ) from exc
+            outcome["value"] = _read_civitai_response(
+                response,
+                budget=active_budget,
+            )
+        except Exception as exc:
+            outcome["error"] = exc
+        finally:
+            _CIVITAI_REQUEST_SLOT.release()
+            completed.set()
+
+    thread = threading.Thread(
+        target=worker,
+        name="EasyUseAnima-Civitai",
+        daemon=True,
+    )
+    try:
+        thread.start()
+    except Exception as exc:
+        _CIVITAI_REQUEST_SLOT.release()
+        raise RuntimeError(
+            f"Civitai request worker failed ({type(exc).__name__})"
+        ) from exc
+
+    if not completed.wait(timeout=remaining):
+        raise CivitaiLookupBudgetExhausted(
+            "Civitai enrichment deadline was exhausted"
+        )
+    active_budget.require_time_remaining()
+    error = outcome.get("error")
+    if isinstance(error, BaseException):
+        raise error
+    value = outcome.get("value")
     if not isinstance(value, dict):
         raise RuntimeError("Civitai returned an invalid metadata object")
     return cast(dict[str, Any], value)
@@ -172,12 +322,21 @@ def _cached_civitai_resource_by_hash(
 
 def _fetch_civitai_resource_by_hash(
     resource_hash: str,
+    *,
+    budget: CivitaiLookupBudget | None = None,
 ) -> CivitaiResourceDescriptor | None:
     normalized = str(resource_hash or "").strip().casefold()
     if not _LOOKUP_HASH_RE.fullmatch(normalized):
         return None
+    token = (
+        _ACTIVE_CIVITAI_BUDGET.set(budget)
+        if budget is not None
+        else None
+    )
     try:
         return _cached_civitai_resource_by_hash(normalized)
+    except CivitaiLookupBudgetExhausted:
+        raise
     except RuntimeError as exc:
         logger.warning(
             "[EasyUseAnima] Civitai resource lookup failed for hash %.10s; "
@@ -186,32 +345,20 @@ def _fetch_civitai_resource_by_hash(
             exc,
         )
         return None
+    finally:
+        if token is not None:
+            _ACTIVE_CIVITAI_BUDGET.reset(token)
 
 
 @lru_cache(maxsize=128)
-def _fetch_civitai_autov3_hash(
-    username: str,
-    model_name: str,
-    version: str = "",
+def _cached_civitai_autov3_hash(
+    lookup: _CivitaiModelLookup,
 ) -> str | None:
-    safe_username = str(username or "").strip()
-    safe_model_name = str(model_name or "").strip()
-    safe_version = str(version or "").strip()
-    values = (safe_username, safe_model_name, safe_version)
-    if (
-        not safe_username
-        or not safe_model_name
-        or any(len(value) > 200 or _CONTROL_RE.search(value) for value in values)
-    ):
-        raise RuntimeError(
-            "Civitai hash lookup fields must contain 1-200 printable characters."
-        )
-
     data = _request_civitai_json(
         f"{_CIVITAI_API_ROOT}/models",
         params={
-            "username": safe_username,
-            "query": safe_model_name,
+            "username": lookup.username,
+            "query": lookup.model_name,
             "limit": 20,
             "nsfw": "true",
         },
@@ -219,7 +366,7 @@ def _fetch_civitai_autov3_hash(
     items = data.get("items")
     if not isinstance(items, list):
         return None
-    target = safe_model_name.casefold()
+    target = lookup.model_name_key
     candidates = [item for item in items if isinstance(item, dict)]
     model = next(
         (
@@ -250,12 +397,12 @@ def _fetch_civitai_autov3_hash(
             (
                 item
                 for item in version_candidates
-                if safe_version.casefold()
+                if lookup.version_key
                 in _remote_text(item.get("name"), max_length=200).casefold()
             ),
             None,
         )
-        if safe_version
+        if lookup.version_key
         else (version_candidates[0] if version_candidates else None)
     )
     if chosen is None:
@@ -277,6 +424,59 @@ def _fetch_civitai_autov3_hash(
         if _SAFE_HASH_RE.fullmatch(hash_value):
             return hash_value
     return None
+
+
+def _fetch_civitai_autov3_hash(
+    username: str,
+    model_name: str,
+    version: str = "",
+    *,
+    budget: CivitaiLookupBudget | None = None,
+) -> str | None:
+    values = tuple(
+        str(value or "").strip()
+        for value in (username, model_name, version)
+    )
+    safe_username, safe_model_name, safe_version = values
+    if (
+        not safe_username
+        or not safe_model_name
+        or any(len(value) > 200 or _CONTROL_RE.search(value) for value in values)
+    ):
+        raise RuntimeError(
+            "Civitai hash lookup fields must contain 1-200 printable characters."
+        )
+    normalized = tuple(value.casefold() for value in values)
+    if any(len(value) > 200 for value in normalized):
+        raise RuntimeError(
+            "Civitai hash lookup fields must contain 1-200 printable characters."
+        )
+    lookup = _CivitaiModelLookup(
+        username_key=normalized[0],
+        model_name_key=normalized[1],
+        version_key=normalized[2],
+        username=safe_username,
+        model_name=safe_model_name,
+        version=safe_version,
+    )
+
+    token = (
+        _ACTIVE_CIVITAI_BUDGET.set(budget)
+        if budget is not None
+        else None
+    )
+    try:
+        return _cached_civitai_autov3_hash(lookup)
+    finally:
+        if token is not None:
+            _ACTIVE_CIVITAI_BUDGET.reset(token)
+
+
+setattr(
+    _fetch_civitai_autov3_hash,
+    "cache_clear",
+    _cached_civitai_autov3_hash.cache_clear,
+)
 
 
 __all__ = ()

--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -13,10 +13,12 @@ from types import MappingProxyType
 from typing import cast
 
 from .native_civitai import (
-    _fetch_civitai_autov3_hash as _fetch_civitai_autov3_hash,
+    CivitaiLookupBudget,
+    CivitaiLookupBudgetExhausted,
+    _fetch_civitai_resource_by_hash,
 )
 from .native_civitai import (
-    _fetch_civitai_resource_by_hash,
+    _fetch_civitai_autov3_hash as _fetch_civitai_autov3_hash,
 )
 from .native_output_publication import (
     OutputDirectoryBinding,
@@ -102,6 +104,8 @@ def _civitai_sampler_name(sampler_name: str, scheduler_name: str) -> str:
 
 def _civitai_resource_entries(
     resources: Sequence[_ResourceHash],
+    *,
+    budget: CivitaiLookupBudget | None = None,
 ) -> list[dict[str, str | float | int]]:
     entries: list[dict[str, str | float | int]] = []
     seen_hashes: set[str] = set()
@@ -118,7 +122,21 @@ def _civitai_resource_entries(
             break
         seen_hashes.add(normalized_hash)
         attempts += 1
-        descriptor = _fetch_civitai_resource_by_hash(resource.sha256)
+        try:
+            if budget is None:
+                descriptor = _fetch_civitai_resource_by_hash(resource.sha256)
+            else:
+                descriptor = _fetch_civitai_resource_by_hash(
+                    resource.sha256,
+                    budget=budget,
+                )
+        except CivitaiLookupBudgetExhausted as exc:
+            logger.warning(
+                "[EasyUseAnima] Civitai resource enrichment budget ended; "
+                "saving with available metadata: %s",
+                exc,
+            )
+            break
         if descriptor is None:
             continue
         entry: dict[str, str | float | int] = {}
@@ -161,6 +179,7 @@ def _build_native_metadata(
     applied_loras: object,
     download_civitai_data: bool,
     easy_remix: bool,
+    civitai_budget: CivitaiLookupBudget | None = None,
 ) -> NativeImageMetadata:
     local_resources = _local_resource_hashes(
         modelname,
@@ -231,7 +250,10 @@ def _build_native_metadata(
         fields.append(f"Hashes: {_compact_json(hashes, ascii_only=False)}")
     fields.append("Version: ComfyUI")
     if download_civitai_data:
-        civitai_resources = _civitai_resource_entries(resources)
+        civitai_resources = _civitai_resource_entries(
+            resources,
+            budget=civitai_budget,
+        )
         if civitai_resources:
             fields.append(
                 f"Civitai resources: {_compact_json(civitai_resources, ascii_only=False)}"

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -15,6 +15,7 @@ from ..common.values import _as_bool, _as_float, _as_int
 from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from ..lora.preset import _format_strength
 from .generation_defaults import AIO_GENERATION_DEFAULT_SETTINGS
+from .native_civitai import CivitaiLookupBudget, CivitaiLookupBudgetExhausted
 from .native_image_output import (
     NativeImageMetadata,
     _build_native_metadata,
@@ -327,6 +328,8 @@ def _resolve_image_saver_runtime(
 
 def _aio_image_saver_civitai_hash_fetcher_entries(
     image_saver: dict[str, Any],
+    *,
+    budget: CivitaiLookupBudget | None = None,
 ) -> list[str]:
     enabled_settings = [
         item
@@ -357,9 +360,27 @@ def _aio_image_saver_civitai_hash_fetcher_entries(
                 "[EasyUseAnima] Civitai Hash Fetcher requires both username and model_name."
             )
         try:
-            hash_text = str(
-                _fetch_civitai_autov3_hash(username, model_name, version) or ""
-            ).strip()
+            if budget is None:
+                fetched_hash = _fetch_civitai_autov3_hash(
+                    username,
+                    model_name,
+                    version,
+                )
+            else:
+                fetched_hash = _fetch_civitai_autov3_hash(
+                    username,
+                    model_name,
+                    version,
+                    budget=budget,
+                )
+            hash_text = str(fetched_hash or "").strip()
+        except CivitaiLookupBudgetExhausted as exc:
+            logger.warning(
+                "[EasyUseAnima] Civitai Hash Fetcher budget ended; "
+                "saving with available metadata: %s",
+                exc,
+            )
+            break
         except Exception as exc:
             logger.warning(
                 "[EasyUseAnima] Civitai Hash Fetcher failed for username=%r model=%r version=%r; skipping metadata hash: %s",
@@ -383,7 +404,11 @@ def _aio_image_saver_civitai_hash_fetcher_entries(
     return entries
 
 
-def _aio_image_saver_additional_hashes(image_saver: dict[str, Any]) -> str:
+def _aio_image_saver_additional_hashes(
+    image_saver: dict[str, Any],
+    *,
+    budget: CivitaiLookupBudget | None = None,
+) -> str:
     parts = []
     base = str(image_saver.get("additional_hashes") or "").strip(" ,\n\r\t")
     if base:
@@ -391,9 +416,15 @@ def _aio_image_saver_additional_hashes(image_saver: dict[str, Any]) -> str:
     parts.extend(
         _normalize_aio_hash_bundles(image_saver.get("additional_hash_bundles"))
     )
-    parts.extend(
-        _aio_image_saver_civitai_hash_fetcher_entries(image_saver)
-    )
+    if budget is None:
+        parts.extend(_aio_image_saver_civitai_hash_fetcher_entries(image_saver))
+    else:
+        parts.extend(
+            _aio_image_saver_civitai_hash_fetcher_entries(
+                image_saver,
+                budget=budget,
+            )
+        )
     return ",".join(part for part in parts if part)
 
 
@@ -490,6 +521,7 @@ def _save_image_with_image_saver(
     )
 
     if _comfy_metadata_enabled():
+        civitai_budget = CivitaiLookupBudget()
         save_prompt_metadata = _as_bool(
             runtime.settings.get("save_prompt_metadata"),
             runtime.defaults["save_prompt_metadata"],
@@ -522,12 +554,16 @@ def _save_image_with_image_saver(
             denoise=runtime.denoise,
             clip_skip=runtime.clip_skip,
             custom=runtime.custom,
-            additional_hashes=_aio_image_saver_additional_hashes(runtime.settings),
+            additional_hashes=_aio_image_saver_additional_hashes(
+                runtime.settings,
+                budget=civitai_budget,
+            ),
             applied_loras=applied_loras,
             download_civitai_data=download_civitai_data,
             easy_remix=_as_bool(
                 runtime.settings.get("easy_remix"), runtime.defaults["easy_remix"]
             ),
+            civitai_budget=civitai_budget,
         )
     else:
         metadata = NativeImageMetadata(parameters="", final_hashes="", hashes={})

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8942,6 +8942,57 @@
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "time",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "time",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Mapping",
         "branch_context": [],
         "classification": "external",
@@ -8949,10 +9000,27 @@
         "conditional": false,
         "imported": "collections.abc:Mapping",
         "kind": "static_from",
-        "line": 8,
+        "line": 10,
         "name": "Mapping",
         "optional": false,
         "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ContextVar",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextvars:ContextVar",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ContextVar",
+        "optional": false,
+        "requested": "contextvars",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/native_civitai.py"
@@ -8966,8 +9034,25 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "field",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 12,
+        "name": "field",
         "optional": false,
         "requested": "dataclasses",
         "role": "ordinary",
@@ -8983,7 +9068,7 @@
         "conditional": false,
         "imported": "functools:lru_cache",
         "kind": "static_from",
-        "line": 10,
+        "line": 13,
         "name": "lru_cache",
         "optional": false,
         "requested": "functools",
@@ -9000,7 +9085,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 11,
+        "line": 14,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -9017,7 +9102,7 @@
         "conditional": false,
         "imported": "typing:cast",
         "kind": "static_from",
-        "line": 11,
+        "line": 14,
         "name": "cast",
         "optional": false,
         "requested": "typing",
@@ -9028,26 +9113,18 @@
       {
         "alias": null,
         "bound_name": "requests",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 80
-          }
-        ],
+        "branch_context": [],
         "classification": "external",
-        "column": 8,
-        "conditional": true,
+        "column": 4,
+        "conditional": false,
         "imported": "requests",
         "kind": "static_import",
-        "line": 81,
+        "line": 152,
         "name": null,
-        "optional": true,
+        "optional": false,
         "requested": "requests",
-        "role": "optional_dependency",
-        "scope": "_request_civitai_json",
+        "role": "ordinary",
+        "scope": "_default_civitai_transport",
         "source": "easyuse_anima/aio/native_civitai.py"
       },
       {
@@ -9289,16 +9366,34 @@
         "source": "easyuse_anima/aio/native_image_output.py"
       },
       {
-        "alias": "_fetch_civitai_autov3_hash",
-        "bound_name": "_fetch_civitai_autov3_hash",
+        "alias": null,
+        "bound_name": "CivitaiLookupBudget",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".native_civitai:_fetch_civitai_autov3_hash",
+        "imported": ".native_civitai:CivitaiLookupBudget",
         "kind": "static_from",
         "line": 15,
-        "name": "_fetch_civitai_autov3_hash",
+        "name": "CivitaiLookupBudget",
+        "optional": false,
+        "requested": ".native_civitai",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "CivitaiLookupBudgetExhausted",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_civitai:CivitaiLookupBudgetExhausted",
+        "kind": "static_from",
+        "line": 15,
+        "name": "CivitaiLookupBudgetExhausted",
         "optional": false,
         "requested": ".native_civitai",
         "role": "ordinary",
@@ -9315,8 +9410,26 @@
         "conditional": false,
         "imported": ".native_civitai:_fetch_civitai_resource_by_hash",
         "kind": "static_from",
-        "line": 18,
+        "line": 15,
         "name": "_fetch_civitai_resource_by_hash",
+        "optional": false,
+        "requested": ".native_civitai",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": "_fetch_civitai_autov3_hash",
+        "bound_name": "_fetch_civitai_autov3_hash",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_civitai:_fetch_civitai_autov3_hash",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_fetch_civitai_autov3_hash",
         "optional": false,
         "requested": ".native_civitai",
         "role": "ordinary",
@@ -9333,7 +9446,7 @@
         "conditional": false,
         "imported": ".native_output_publication:OutputDirectoryBinding",
         "kind": "static_from",
-        "line": 21,
+        "line": 23,
         "name": "OutputDirectoryBinding",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9351,7 +9464,7 @@
         "conditional": false,
         "imported": ".native_output_publication:PublicationCollision",
         "kind": "static_from",
-        "line": 21,
+        "line": 23,
         "name": "PublicationCollision",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9369,7 +9482,7 @@
         "conditional": false,
         "imported": ".native_output_publication:publish_image_transaction",
         "kind": "static_from",
-        "line": 21,
+        "line": 23,
         "name": "publish_image_transaction",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9387,7 +9500,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_EMBEDDING_RE",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_EMBEDDING_RE",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9405,7 +9518,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_HEX_HASH_RE",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_HEX_HASH_RE",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9423,7 +9536,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_ResourceHash",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_ResourceHash",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9441,7 +9554,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_local_resource_hashes",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_local_resource_hashes",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9459,7 +9572,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_manual_resource_hashes",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_manual_resource_hashes",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9477,7 +9590,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_resource_name",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_resource_name",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9495,7 +9608,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 248
+            "line": 270
           }
         ],
         "classification": "external",
@@ -9503,7 +9616,7 @@
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 249,
+        "line": 271,
         "name": "args",
         "optional": true,
         "requested": "comfy.cli_args",
@@ -9520,7 +9633,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 265,
+        "line": 287,
         "name": "ExifTags",
         "optional": false,
         "requested": "PIL",
@@ -9537,7 +9650,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 265,
+        "line": 287,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -9552,7 +9665,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 320,
+            "line": 342,
             "type_checking": false
           }
         ],
@@ -9561,7 +9674,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 321,
+        "line": 343,
         "name": "PngInfo",
         "optional": false,
         "requested": "PIL.PngImagePlugin",
@@ -9578,7 +9691,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 350,
+        "line": 372,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -9595,7 +9708,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 351,
+        "line": 373,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -11058,6 +11171,42 @@
       },
       {
         "alias": null,
+        "bound_name": "CivitaiLookupBudget",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_civitai:CivitaiLookupBudget",
+        "kind": "static_from",
+        "line": 18,
+        "name": "CivitaiLookupBudget",
+        "optional": false,
+        "requested": ".native_civitai",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "CivitaiLookupBudgetExhausted",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_civitai:CivitaiLookupBudgetExhausted",
+        "kind": "static_from",
+        "line": 18,
+        "name": "CivitaiLookupBudgetExhausted",
+        "optional": false,
+        "requested": ".native_civitai",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "alias": null,
         "bound_name": "NativeImageMetadata",
         "branch_context": [],
         "classification": "internal",
@@ -11065,7 +11214,7 @@
         "conditional": false,
         "imported": ".native_image_output:NativeImageMetadata",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "NativeImageMetadata",
         "optional": false,
         "requested": ".native_image_output",
@@ -11083,7 +11232,7 @@
         "conditional": false,
         "imported": ".native_image_output:_build_native_metadata",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "_build_native_metadata",
         "optional": false,
         "requested": ".native_image_output",
@@ -11101,7 +11250,7 @@
         "conditional": false,
         "imported": ".native_image_output:_comfy_metadata_enabled",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "_comfy_metadata_enabled",
         "optional": false,
         "requested": ".native_image_output",
@@ -11119,7 +11268,7 @@
         "conditional": false,
         "imported": ".native_image_output:_fetch_civitai_autov3_hash",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "_fetch_civitai_autov3_hash",
         "optional": false,
         "requested": ".native_image_output",
@@ -11137,7 +11286,7 @@
         "conditional": false,
         "imported": ".native_image_output:_save_native_images",
         "kind": "static_from",
-        "line": 18,
+        "line": 19,
         "name": "_save_native_images",
         "optional": false,
         "requested": ".native_image_output",
@@ -11155,7 +11304,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 25,
+        "line": 26,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".output_settings",
@@ -11173,7 +11322,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -11191,7 +11340,7 @@
         "conditional": false,
         "imported": ".sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".sampling",
@@ -11209,7 +11358,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 79
+            "line": 80
           }
         ],
         "classification": "external",
@@ -11217,7 +11366,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 80,
+        "line": 81,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11234,7 +11383,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
@@ -11242,7 +11391,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11259,7 +11408,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 436
           }
         ],
         "classification": "external",
@@ -11267,7 +11416,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 406,
+        "line": 437,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -44025,6 +44174,10 @@
       },
       {
         "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
         "to": "easyuse_anima/aio/native_image_output.py"
       },
       {
@@ -49711,207 +49864,263 @@
         "functions": [
           {
             "async": false,
-            "end_line": 40,
+            "end_line": 48,
+            "kind": "method",
+            "line": 45,
+            "loc": 4,
+            "qualified_name": "CivitaiLookupBudget.calls_started"
+          },
+          {
+            "async": false,
+            "end_line": 66,
+            "kind": "method",
+            "line": 50,
+            "loc": 17,
+            "qualified_name": "CivitaiLookupBudget.reserve_http_call"
+          },
+          {
+            "async": false,
+            "end_line": 77,
+            "kind": "method",
+            "line": 68,
+            "loc": 10,
+            "qualified_name": "CivitaiLookupBudget.require_time_remaining"
+          },
+          {
+            "async": false,
+            "end_line": 114,
             "kind": "function",
-            "line": 34,
+            "line": 108,
             "loc": 7,
             "qualified_name": "_remote_text"
           },
           {
             "async": false,
-            "end_line": 50,
+            "end_line": 124,
             "kind": "function",
-            "line": 43,
+            "line": 117,
             "loc": 8,
             "qualified_name": "_positive_int"
           },
           {
             "async": false,
-            "end_line": 69,
+            "end_line": 143,
             "kind": "function",
-            "line": 53,
+            "line": 127,
             "loc": 17,
             "qualified_name": "_response_proves_hash"
           },
           {
             "async": false,
-            "end_line": 141,
+            "end_line": 164,
             "kind": "function",
-            "line": 72,
-            "loc": 70,
+            "line": 146,
+            "loc": 19,
+            "qualified_name": "_default_civitai_transport"
+          },
+          {
+            "async": false,
+            "end_line": 217,
+            "kind": "function",
+            "line": 167,
+            "loc": 51,
+            "qualified_name": "_read_civitai_response"
+          },
+          {
+            "async": false,
+            "end_line": 291,
+            "kind": "function",
+            "line": 220,
+            "loc": 72,
             "qualified_name": "_request_civitai_json"
           },
           {
             "async": false,
-            "end_line": 170,
+            "end_line": 265,
             "kind": "function",
-            "line": 144,
+            "line": 245,
+            "loc": 21,
+            "qualified_name": "_request_civitai_json.worker"
+          },
+          {
+            "async": false,
+            "end_line": 320,
+            "kind": "function",
+            "line": 294,
             "loc": 27,
             "qualified_name": "_cached_civitai_resource_by_hash"
           },
           {
             "async": false,
-            "end_line": 188,
+            "end_line": 350,
             "kind": "function",
-            "line": 173,
-            "loc": 16,
+            "line": 323,
+            "loc": 28,
             "qualified_name": "_fetch_civitai_resource_by_hash"
           },
           {
             "async": false,
-            "end_line": 279,
+            "end_line": 426,
             "kind": "function",
-            "line": 191,
-            "loc": 89,
+            "line": 353,
+            "loc": 74,
+            "qualified_name": "_cached_civitai_autov3_hash"
+          },
+          {
+            "async": false,
+            "end_line": 472,
+            "kind": "function",
+            "line": 429,
+            "loc": 44,
             "qualified_name": "_fetch_civitai_autov3_hash"
           }
         ],
         "is_package": false,
-        "loc": 282,
+        "loc": 482,
         "module": "easyuse_anima.aio.native_civitai",
-        "normalized_git_blob_sha1": "17eede629aa37731c706f801fc5ddd4f7f161d5e",
+        "normalized_git_blob_sha1": "d7c632c631d1f5878ce26dfb01a1ec365aacd2d6",
         "path": "easyuse_anima/aio/native_civitai.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 7,
-          "global_count": 9
+          "class_count": 4,
+          "function_count": 10,
+          "global_count": 13
         }
       },
       {
         "functions": [
           {
             "async": false,
-            "end_line": 77,
+            "end_line": 79,
             "kind": "function",
-            "line": 71,
+            "line": 73,
             "loc": 7,
             "qualified_name": "_compact_json"
           },
           {
             "async": false,
-            "end_line": 87,
+            "end_line": 89,
             "kind": "function",
-            "line": 80,
+            "line": 82,
             "loc": 8,
             "qualified_name": "_clean_prompt_for_remix"
           },
           {
             "async": false,
-            "end_line": 85,
+            "end_line": 87,
             "kind": "function",
-            "line": 83,
+            "line": 85,
             "loc": 3,
             "qualified_name": "_clean_prompt_for_remix.simplify_embedding"
           },
           {
             "async": false,
-            "end_line": 100,
+            "end_line": 102,
             "kind": "function",
-            "line": 90,
+            "line": 92,
             "loc": 11,
             "qualified_name": "_civitai_sampler_name"
           },
           {
             "async": false,
-            "end_line": 142,
+            "end_line": 160,
             "kind": "function",
-            "line": 103,
-            "loc": 40,
+            "line": 105,
+            "loc": 56,
             "qualified_name": "_civitai_resource_entries"
           },
           {
             "async": false,
-            "end_line": 244,
+            "end_line": 266,
             "kind": "function",
-            "line": 145,
-            "loc": 100,
+            "line": 163,
+            "loc": 104,
             "qualified_name": "_build_native_metadata"
           },
           {
             "async": false,
-            "end_line": 253,
+            "end_line": 275,
             "kind": "function",
-            "line": 247,
+            "line": 269,
             "loc": 7,
             "qualified_name": "_comfy_metadata_enabled"
           },
           {
             "async": false,
-            "end_line": 257,
+            "end_line": 279,
             "kind": "function",
-            "line": 256,
+            "line": 278,
             "loc": 2,
             "qualified_name": "_encode_user_comment"
           },
           {
             "async": false,
-            "end_line": 277,
+            "end_line": 299,
             "kind": "function",
-            "line": 260,
+            "line": 282,
             "loc": 18,
             "qualified_name": "_build_exif_bytes"
           },
           {
             "async": false,
-            "end_line": 346,
+            "end_line": 368,
             "kind": "function",
-            "line": 280,
+            "line": 302,
             "loc": 67,
             "qualified_name": "_serialize_metadata"
           },
           {
             "async": false,
-            "end_line": 368,
+            "end_line": 390,
             "kind": "function",
-            "line": 349,
+            "line": 371,
             "loc": 20,
             "qualified_name": "_tensor_to_pil"
           },
           {
             "async": false,
-            "end_line": 416,
+            "end_line": 438,
             "kind": "function",
-            "line": 371,
+            "line": 393,
             "loc": 46,
             "qualified_name": "_allocate_filenames"
           },
           {
             "async": false,
-            "end_line": 384,
+            "end_line": 406,
             "kind": "function",
-            "line": 380,
+            "line": 402,
             "loc": 5,
             "qualified_name": "_allocate_filenames.occupied"
           },
           {
             "async": false,
-            "end_line": 453,
+            "end_line": 475,
             "kind": "function",
-            "line": 419,
+            "line": 441,
             "loc": 35,
             "qualified_name": "_resolve_native_output_folder"
           },
           {
             "async": false,
-            "end_line": 476,
+            "end_line": 498,
             "kind": "function",
-            "line": 456,
+            "line": 478,
             "loc": 21,
             "qualified_name": "_image_save_options"
           },
           {
             "async": false,
-            "end_line": 598,
+            "end_line": 620,
             "kind": "function",
-            "line": 479,
+            "line": 501,
             "loc": 120,
             "qualified_name": "_save_native_images"
           }
         ],
         "is_package": false,
-        "loc": 601,
+        "loc": 623,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "b914d3cbbdaddcb25c4482024cc1a010789d7e57",
+        "normalized_git_blob_sha1": "4db8ba4629832457a014a975a56f75e5411175dc",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
           "class_count": 2,
@@ -50557,153 +50766,153 @@
         "functions": [
           {
             "async": false,
-            "end_line": 67,
+            "end_line": 68,
             "kind": "function",
-            "line": 64,
+            "line": 65,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 75,
+            "end_line": 76,
             "kind": "function",
-            "line": 70,
+            "line": 71,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 96,
+            "end_line": 97,
             "kind": "function",
-            "line": 78,
+            "line": 79,
             "loc": 19,
             "qualified_name": "_comfy_output_directory"
           },
           {
             "async": false,
-            "end_line": 124,
+            "end_line": 125,
             "kind": "function",
-            "line": 99,
+            "line": 100,
             "loc": 26,
             "qualified_name": "_output_path_parts"
           },
           {
             "async": false,
-            "end_line": 151,
+            "end_line": 152,
             "kind": "function",
-            "line": 127,
+            "line": 128,
             "loc": 25,
             "qualified_name": "_validated_output_subpath"
           },
           {
             "async": false,
-            "end_line": 164,
+            "end_line": 165,
             "kind": "function",
-            "line": 154,
+            "line": 155,
             "loc": 11,
             "qualified_name": "_image_saver_model_names"
           },
           {
             "async": false,
-            "end_line": 171,
+            "end_line": 172,
             "kind": "function",
-            "line": 167,
+            "line": 168,
             "loc": 5,
             "qualified_name": "_image_saver_timestamp"
           },
           {
             "async": false,
-            "end_line": 235,
+            "end_line": 236,
             "kind": "function",
-            "line": 174,
+            "line": 175,
             "loc": 62,
             "qualified_name": "_render_image_saver_template"
           },
           {
             "async": false,
-            "end_line": 197,
+            "end_line": 198,
             "kind": "function",
-            "line": 196,
+            "line": 197,
             "loc": 2,
             "qualified_name": "_render_image_saver_template.replace_time"
           },
           {
             "async": false,
-            "end_line": 205,
+            "end_line": 206,
             "kind": "function",
-            "line": 199,
+            "line": 200,
             "loc": 7,
             "qualified_name": "_render_image_saver_template.replace_counter"
           },
           {
             "async": false,
-            "end_line": 325,
+            "end_line": 326,
             "kind": "function",
-            "line": 238,
+            "line": 239,
             "loc": 88,
             "qualified_name": "_resolve_image_saver_runtime"
           },
           {
             "async": false,
-            "end_line": 383,
+            "end_line": 404,
             "kind": "function",
-            "line": 328,
-            "loc": 56,
+            "line": 329,
+            "loc": 76,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 397,
+            "end_line": 428,
             "kind": "function",
-            "line": 386,
-            "loc": 12,
+            "line": 407,
+            "loc": 22,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 413,
+            "end_line": 444,
             "kind": "function",
-            "line": 400,
+            "line": 431,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 431,
+            "end_line": 462,
             "kind": "function",
-            "line": 416,
+            "line": 447,
             "loc": 16,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 456,
+            "end_line": 487,
             "kind": "function",
-            "line": 434,
+            "line": 465,
             "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 468,
+            "end_line": 499,
             "kind": "function",
-            "line": 459,
+            "line": 490,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 567,
+            "end_line": 603,
             "kind": "function",
-            "line": 471,
-            "loc": 97,
+            "line": 502,
+            "loc": 102,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 570,
+        "loc": 606,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "baea382362d328c96a4f6d9752150eaec4b53cc1",
+        "normalized_git_blob_sha1": "86c82ec2c0860e15bf1aba4046a61cc2ea645ed8",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,
@@ -63286,8 +63495,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Mapping",
-        "kind": "static_from",
+        "imported": "threading",
+        "kind": "static_import",
         "line": 8,
         "optional": false,
         "role": "ordinary",
@@ -63297,8 +63506,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "dataclasses:dataclass",
-        "kind": "static_from",
+        "imported": "time",
+        "kind": "static_import",
         "line": 9,
         "optional": false,
         "role": "ordinary",
@@ -63308,7 +63517,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "functools:lru_cache",
+        "imported": "collections.abc:Callable",
         "kind": "static_from",
         "line": 10,
         "optional": false,
@@ -63319,7 +63528,18 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "contextvars:ContextVar",
         "kind": "static_from",
         "line": 11,
         "optional": false,
@@ -63330,30 +63550,66 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:cast",
+        "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_civitai.py"
       },
       {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 80
-          }
-        ],
+        "branch_context": [],
         "classification": "external",
-        "conditional": true,
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "functools:lru_cache",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 14,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 14,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_civitai.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "requests",
         "kind": "static_import",
-        "line": 81,
-        "optional": true,
-        "role": "optional_dependency",
+        "line": 152,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/aio/native_civitai.py"
       },
       {
@@ -63517,14 +63773,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 248
+            "line": 270
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 249,
+        "line": 271,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63535,7 +63791,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 265,
+        "line": 287,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63546,7 +63802,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 265,
+        "line": 287,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63556,7 +63812,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 320,
+            "line": 342,
             "type_checking": false
           }
         ],
@@ -63564,7 +63820,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 321,
+        "line": 343,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63575,7 +63831,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 350,
+        "line": 372,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63586,7 +63842,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 351,
+        "line": 373,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64421,14 +64677,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 79
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 80,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -64440,14 +64696,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -64459,14 +64715,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 436
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 406,
+        "line": 437,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71155,33 +71411,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "requests",
-        "kind": "static_import",
-        "line": 81,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/aio/native_civitai.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 248
+            "line": 270
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 249,
+        "line": 271,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -71345,14 +71582,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 79
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 80,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71364,14 +71601,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71383,14 +71620,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 436
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 406,
+        "line": 437,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -73710,7 +73947,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 13,
+        "line": 16,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73719,7 +73956,7 @@
         "column": 14,
         "context": "assign:_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 18,
+        "line": 23,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73728,7 +73965,7 @@
         "column": 16,
         "context": "assign:_SAFE_HASH_RE",
         "kind": "import_time_call",
-        "line": 19,
+        "line": 24,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73737,7 +73974,7 @@
         "column": 18,
         "context": "assign:_LOOKUP_HASH_RE",
         "kind": "import_time_call",
-        "line": 20,
+        "line": 25,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73746,7 +73983,61 @@
         "column": 15,
         "context": "assign:_SAFE_AIR_RE",
         "kind": "import_time_call",
-        "line": 21,
+        "line": 26,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.BoundedSemaphore",
+        "column": 24,
+        "context": "assign:_CIVITAI_REQUEST_SLOT",
+        "kind": "import_time_call",
+        "line": 27,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:CivitaiLookupBudget",
+        "kind": "import_time_call",
+        "line": 34,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "field",
+        "column": 30,
+        "context": "assign:_deadline",
+        "kind": "import_time_call",
+        "line": 41,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "CivitaiLookupBudget"
+      },
+      {
+        "callee": "field",
+        "column": 26,
+        "context": "assign:_calls_started",
+        "kind": "import_time_call",
+        "line": 42,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "CivitaiLookupBudget"
+      },
+      {
+        "callee": "field",
+        "column": 17,
+        "context": "assign:_lock",
+        "kind": "import_time_call",
+        "line": 43,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "CivitaiLookupBudget"
+      },
+      {
+        "callee": "ContextVar",
+        "column": 65,
+        "context": "assign:_ACTIVE_CIVITAI_BUDGET",
+        "kind": "import_time_call",
+        "line": 80,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73755,25 +74046,70 @@
         "column": 1,
         "context": "decorator:CivitaiResourceDescriptor",
         "kind": "import_time_call",
-        "line": 24,
+        "line": 86,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_CivitaiModelLookup",
+        "kind": "import_time_call",
+        "line": 96,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "field",
+        "column": 20,
+        "context": "assign:username",
+        "kind": "import_time_call",
+        "line": 103,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "_CivitaiModelLookup"
+      },
+      {
+        "callee": "field",
+        "column": 22,
+        "context": "assign:model_name",
+        "kind": "import_time_call",
+        "line": 104,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "_CivitaiModelLookup"
+      },
+      {
+        "callee": "field",
+        "column": 19,
+        "context": "assign:version",
+        "kind": "import_time_call",
+        "line": 105,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "_CivitaiModelLookup"
       },
       {
         "callee": "lru_cache",
         "column": 1,
         "context": "decorator:_cached_civitai_resource_by_hash",
         "kind": "import_time_call",
-        "line": 144,
+        "line": 294,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
       {
         "callee": "lru_cache",
         "column": 1,
-        "context": "decorator:_fetch_civitai_autov3_hash",
+        "context": "decorator:_cached_civitai_autov3_hash",
         "kind": "import_time_call",
-        "line": 191,
+        "line": 353,
+        "module": "easyuse_anima/aio/native_civitai.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "setattr",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 475,
         "module": "easyuse_anima/aio/native_civitai.py",
         "scope": "<module>"
       },
@@ -73782,7 +74118,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 35,
+        "line": 37,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73791,7 +74127,7 @@
         "column": 15,
         "context": "assign:_LORA_TAG_RE",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 42,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73800,7 +74136,7 @@
         "column": 14,
         "context": "assign:_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 41,
+        "line": 43,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73809,7 +74145,7 @@
         "column": 13,
         "context": "assign:_SAVE_LOCK",
         "kind": "import_time_call",
-        "line": 42,
+        "line": 44,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73818,7 +74154,7 @@
         "column": 25,
         "context": "assign:_CIVITAI_SAMPLER_NAMES",
         "kind": "import_time_call",
-        "line": 44,
+        "line": 46,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73827,7 +74163,7 @@
         "column": 1,
         "context": "decorator:NativeImageMetadata",
         "kind": "import_time_call",
-        "line": 56,
+        "line": 58,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73836,7 +74172,7 @@
         "column": 1,
         "context": "decorator:_SerializedMetadata",
         "kind": "import_time_call",
-        "line": 63,
+        "line": 65,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -73989,7 +74325,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 33,
+        "line": 34,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -73998,7 +74334,7 @@
         "column": 30,
         "context": "assign:_IMAGE_SAVER_CUSTOM_TIME_RE",
         "kind": "import_time_call",
-        "line": 36,
+        "line": 37,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74007,7 +74343,7 @@
         "column": 33,
         "context": "assign:_IMAGE_SAVER_CUSTOM_COUNTER_RE",
         "kind": "import_time_call",
-        "line": 37,
+        "line": 38,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74016,7 +74352,7 @@
         "column": 21,
         "context": "assign:_OUTPUT_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 38,
+        "line": 39,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74025,7 +74361,7 @@
         "column": 1,
         "context": "decorator:_ImageSaverRuntime",
         "kind": "import_time_call",
-        "line": 42,
+        "line": 43,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -75726,7 +76062,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 42,
+        "line": 44,
         "module": "easyuse_anima/aio/native_image_output.py",
         "name": "_SAVE_LOCK"
       },

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -433,10 +433,18 @@ class AIONativeImageOutputTests(unittest.TestCase):
                 "Target Model",
                 "v2",
             )
+            cached_variant = civitai._fetch_civitai_autov3_hash(
+                " CREATOR ",
+                " target model ",
+                " V2 ",
+            )
 
         self.assertEqual(result, "ABCDEF1234")
+        self.assertEqual(cached_variant, result)
+        self.assertEqual(len(calls), 2, "normalized lookup variants must reuse the cache")
         self.assertEqual(calls[0][0], "https://civitai.com/api/v1/models")
         self.assertEqual(calls[0][1]["username"], "creator")
+        self.assertEqual(calls[0][1]["query"], "Target Model")
         self.assertEqual(calls[1], (
             "https://civitai.com/api/v1/model-versions/11",
             None,
@@ -499,6 +507,44 @@ class AIONativeImageOutputTests(unittest.TestCase):
             self.assertRaisesRegex(RuntimeError, "size limit"),
         ):
             civitai._request_civitai_json("https://civitai.com/api/v1/models")
+        response.close.assert_called_once_with()
+
+    def test_civitai_slow_stream_stops_at_shared_wall_clock_deadline(self):
+        class Clock:
+            now = 0.0
+
+            def __call__(self):
+                return self.now
+
+        clock = Clock()
+        response = Mock(status_code=200, headers={})
+
+        def chunks(*, chunk_size):
+            self.assertEqual(chunk_size, 64 * 1024)
+            yield b'{"items":'
+            clock.now = 6.0
+            yield b"[]}"
+
+        response.iter_content.side_effect = chunks
+        transport = Mock(return_value=response)
+        budget = civitai.CivitaiLookupBudget(
+            timeout_seconds=5.0,
+            http_call_limit=4,
+            clock=clock,
+        )
+
+        with self.assertRaisesRegex(
+            civitai.CivitaiLookupBudgetExhausted,
+            "deadline",
+        ):
+            civitai._request_civitai_json(
+                "https://civitai.com/api/v1/models",
+                budget=budget,
+                transport=transport,
+            )
+
+        self.assertEqual(budget.calls_started, 1)
+        self.assertEqual(transport.call_args.kwargs["timeout"], (3.05, 5.0))
         response.close.assert_called_once_with()
 
     def test_civitai_response_cleanup_failure_does_not_discard_valid_metadata(self):

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import types
 import unittest
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
+from easyuse_anima.aio import native_civitai as civitai
 from easyuse_anima.aio import output, output_settings
 from easyuse_anima.aio.generation_defaults import AIO_GENERATION_DEFAULT_SETTINGS
 from tests.comfy_host_fakes import patch_comfy_helper
@@ -155,6 +157,122 @@ class AIOOutputMoveTests(unittest.TestCase):
         self.assertEqual(len(entries), output._MAX_CIVITAI_HASH_FETCHERS)
         self.assertEqual(fetch.call_count, output._MAX_CIVITAI_HASH_FETCHERS)
         self.assertIn("ignoring 5 excess rows", "\n".join(logs.output))
+
+    def test_repeated_civitai_timeouts_stop_at_the_shared_call_budget(self):
+        civitai._fetch_civitai_autov3_hash.cache_clear()
+        budget = civitai.CivitaiLookupBudget(
+            timeout_seconds=100.0,
+            http_call_limit=3,
+        )
+        transport = Mock(side_effect=TimeoutError("socket stalled"))
+        settings = {
+            "civitai_hash_fetchers": [
+                {
+                    "enabled": True,
+                    "username": "creator",
+                    "model_name": f"timeout-{index}",
+                    "version": "",
+                }
+                for index in range(5)
+            ]
+        }
+
+        with (
+            patch.object(civitai, "_default_civitai_transport", transport),
+            self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING") as logs,
+        ):
+            self.assertEqual(
+                output._aio_image_saver_civitai_hash_fetcher_entries(
+                    settings,
+                    budget=budget,
+                ),
+                [],
+            )
+
+        self.assertEqual(transport.call_count, 3)
+        self.assertEqual(budget.calls_started, 3)
+        self.assertIn("HTTP-call budget", "\n".join(logs.output))
+
+    def test_fetcher_and_resource_enrichment_share_budget_and_still_save(self):
+        civitai._fetch_civitai_autov3_hash.cache_clear()
+        civitai._cached_civitai_resource_by_hash.cache_clear()
+        budget = civitai.CivitaiLookupBudget(
+            timeout_seconds=100.0,
+            http_call_limit=3,
+        )
+
+        def response(payload):
+            value = Mock(status_code=200, headers={})
+            value.iter_content.return_value = [
+                json.dumps(payload).encode("utf-8")
+            ]
+            return value
+
+        def transport(endpoint, *, params, timeout):
+            self.assertGreater(timeout[0], 0)
+            self.assertGreater(timeout[1], 0)
+            if endpoint.endswith("/models"):
+                self.assertEqual(params["query"], "Shared Model")
+                return response({
+                    "items": [{
+                        "name": "Shared Model",
+                        "modelVersions": [{"id": 11, "name": "v1"}],
+                    }]
+                })
+            if endpoint.endswith("/model-versions/11"):
+                return response({
+                    "files": [{"hashes": {"AutoV3": "ABCDEF1234"}}]
+                })
+            self.assertTrue(endpoint.endswith("/by-hash/deadbeef12"))
+            return response({
+                "id": 22,
+                "name": "manual-v1",
+                "model": {"name": "Manual Resource"},
+                "files": [{"hashes": {"AutoV3": "DEADBEEF12"}}],
+            })
+
+        settings = {
+            "image_saver": {
+                **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                "filename": "budgeted",
+                "path": "EasyUseAnima/Test",
+                "additional_hashes": "Manual:DEADBEEF12",
+                "download_civitai_data": True,
+                "civitai_hash_fetchers": [{
+                    "enabled": True,
+                    "username": "Creator",
+                    "model_name": "Shared Model",
+                    "version": "v1",
+                }],
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch.object(output, "CivitaiLookupBudget", return_value=budget),
+                patch.object(civitai, "_default_civitai_transport", side_effect=transport) as request,
+                patch.object(output, "_save_native_images", return_value="saved") as save,
+                self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING") as logs,
+            ):
+                result = output._save_image_with_image_saver(
+                    images="images",
+                    save_settings=settings,
+                    positive_prompt="prompt",
+                    negative_prompt="",
+                    width=64,
+                    height=64,
+                    sampler_settings={"seed": 1},
+                    resource_info={"unet_name": ""},
+                )
+
+        self.assertEqual(result, "saved")
+        self.assertEqual(request.call_count, 3)
+        self.assertEqual(budget.calls_started, 3)
+        metadata = save.call_args.kwargs["metadata"]
+        self.assertIn("Manual:DEADBEEF12", metadata.final_hashes)
+        self.assertIn('"modelVersionId":22', metadata.parameters)
+        self.assertIn("HTTP-call budget", "\n".join(logs.output))
 
     def test_additional_hash_and_lora_metadata_use_canonical_helpers(self):
         with (
@@ -329,6 +447,7 @@ class AIOOutputMoveTests(unittest.TestCase):
             applied_loras=[{"name": "x", "strength_model": 1}],
             download_civitai_data=save_settings["image_saver"]["download_civitai_data"],
             easy_remix=save_settings["image_saver"]["easy_remix"],
+            civitai_budget=ANY,
         )
         save.assert_called_once_with(
             "images",


### PR DESCRIPTION
## 목적과 변경 경계\n\nIssue #695의 optional Civitai enrichment queue-DoS 경계를 해결합니다. 한 번의 native save에서 Hash Fetcher와 local/manual resource enrichment가 같은 12초 wall-clock deadline과 16 HTTP-call budget을 사용합니다.\n\n## Base -> Head\n\n- Base: 687c9000172e4b0822967cf7b7284fca0a15335 (dev)\n- Head: c9c85509c3a687fc4a0e3e059acfc8a5ba934d75\n\n## 주요 변경과 보존 계약\n\n- AutoV3 한 행의 model search와 version detail을 각각 한 HTTP call로 명시적으로 계산합니다.\n- 예산 소진 시 남은 선택적 조회만 중단하고 로컬/이미 확보한 metadata로 이미지 저장을 계속합니다.\n- synchronous Requests slow-drip을 저장 queue에서 분리하기 위해 daemon worker와 프로세스 단일 draining-request slot을 사용합니다.\n- 캐시 키는 trim/casefold 후 비교하되 첫 실제 요청의 사용자 표기는 유지합니다.\n- fixed HTTPS host, redirects off, TLS verification, 2 MiB body cap, opt-in, 기존 node/workflow/save return 계약을 유지합니다.\n\n## 검증\n\n- changed-file Ruff: 통과\n- focused native image output: 31 passed\n- focused output adapter: 15 passed\n- focused native saver node: 7 passed\n- focused backend analyzer: 19 passed\n- quick profile: 통과\n- full candidate c9c8550: Python 1570 passed, 2 skipped; frontend 121 JS files; Pyright/import/size/disposition/support contracts 통과\n- ComfyUI stable: v0.34.0 (12d5279438bfefc058a269eae805ceab6047777f), frontend 1.49.6\n\n첫 full은 구현 결함이 아닌 generated backend-analyzer fixture drift 1건에서 멈췄고, source로 fixture를 재생성한 뒤 focused 19와 full 전체를 통과했습니다.\n\n## 남은 위험과 rollback\n\n- deadline을 넘긴 OS socket은 daemon worker에서 잠시 배출될 수 있습니다. 단일 slot 때문에 누적되지는 않으며, 그동안 새 Civitai 원격 조회만 fail-closed 되고 이미지 저장은 계속됩니다.\n- rollback 단위는 이 PR 전체입니다.\n\nCloses #695\n\nNext: #696 metadata/workflow resource budgets.