### PR TITLE
fix(aio): bound native metadata serialization

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -4,6 +4,7 @@
 - Runtime owner: `easyuse_anima.aio.native_image_output`
 - Publication owner: `easyuse_anima.aio.native_output_publication`
 - Remote metadata owner: `easyuse_anima.aio.native_civitai`
+- Metadata budget owner: `easyuse_anima.aio.native_metadata_budget`
 
 The AiO Generator owns its rich image output path. It no longer imports or
 looks up `ComfyUI-Image-Saver`. Existing settings remain compatible: the
@@ -29,6 +30,30 @@ the redundant execution prompt. If the payload is still too large, it removes
 the embedded workflow, preserves the A1111 block, and forces the JSON sidecar
 before any image is committed. If the A1111 block alone is too large, the save
 fails without publishing an image.
+
+## Metadata resource budgets
+
+Workflow-controlled metadata is validated before Pillow or the publication
+transaction receives it. JSON validation is iterative and rejects circular
+data, nesting deeper than 64 levels, more than 100,000 values/keys, or any
+single string above 1 MiB. Serialization uses bounded `iterencode` output rather
+than materializing an already-known oversized JSON string.
+
+| Payload | Limit |
+| --- | ---: |
+| A1111 parameters | 512 KiB |
+| execution prompt JSON | 2 MiB |
+| workflow JSON, embedded or sidecar | 4 MiB |
+| aggregate `extra_pnginfo` JSON | 6 MiB and 128 top-level keys |
+| embedded metadata per image | 8 MiB |
+| embedded plus sidecar metadata per save batch | 64 MiB |
+
+Cross-field and batch limits count repeated metadata for every image. Exceeding
+a limit fails the save before image encoding/publication instead of silently
+writing partial metadata. JPEG may still drop optional embedded prompt/extras
+and preserve its workflow in a bounded sidecar. PNG and WebP retain no separate
+pretty workflow string when a sidecar was not requested; their one compact
+workflow representation is reused for embedded metadata.
 
 ComfyUI's global `disable_metadata` flag suppresses A1111, prompt, workflow,
 and sidecar metadata. It also skips local hashing and Civitai requests; the

--- a/docs/development/registry-scanner-safety.md
+++ b/docs/development/registry-scanner-safety.md
@@ -55,6 +55,10 @@ updating a release branch that will be scanned by Registry automation.
   fixed-host GET boundary used by native image output. All fetcher and resource
   requests in one save share a 12-second deadline and a 16-call budget; budget
   exhaustion skips optional enrichment without failing image output.
+- Native image metadata has explicit parameters, prompt, workflow,
+  `extra_pnginfo`, depth/item/string, per-image, and per-save batch limits.
+  Limit failures must occur before image publication and must not be replaced
+  with unbounded fallback sidecars.
 - AiO ResShift execution is fail-closed before optional-node lookup. Its saved
   settings remain readable, but re-enabling the adapter requires the safe
   loader contract tracked in issue #679.

--- a/docs/nodes/anima-aio-generator.en.md
+++ b/docs/nodes/anima-aio-generator.en.md
@@ -103,6 +103,13 @@ enabled when saved images should reload into the same generation setup. Enable
 limit, EasyUse preserves the A1111 metadata and writes the workflow sidecar
 automatically instead of leaving a partially written image.
 
+Metadata is bounded independently of ComfyUI's request-size setting: A1111
+parameters are limited to 512 KiB, prompt JSON to 2 MiB, workflow JSON to 4 MiB,
+embedded metadata to 8 MiB per image, and repeated batch metadata to 64 MiB per
+save. JSON also has depth, item, string, and `extra_pnginfo` key limits. An
+oversized payload fails before image publication instead of producing a partial
+or unexpectedly large output.
+
 WebP is lossy when `Lossless WebP` is off; `JPEG/WebP quality` controls its
 quality/file-size tradeoff. When lossless mode is on, WebP preserves the pixel
 values supplied to the saver.

--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -10,7 +10,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import MappingProxyType
-from typing import cast
 
 from .native_civitai import (
     CivitaiLookupBudget,
@@ -19,6 +18,14 @@ from .native_civitai import (
 )
 from .native_civitai import (
     _fetch_civitai_autov3_hash as _fetch_civitai_autov3_hash,
+)
+from .native_metadata_budget import (
+    _MAX_PARAMETERS_BYTES,
+    _metadata_text_size,
+    _prepare_metadata_payload,
+    _sidecar_required_and_validate_batch,
+    _validate_embedded_metadata_size,
+    _validate_parameter_sources,
 )
 from .native_output_publication import (
     OutputDirectoryBinding,
@@ -68,6 +75,8 @@ class _SerializedMetadata:
     exif_bytes: bytes | None
     workflow_json: str | None
     force_workflow_sidecar: bool
+    embedded_size_bytes: int
+    sidecar_size_bytes: int
 
 
 def _compact_json(value: object, *, ascii_only: bool) -> str:
@@ -181,6 +190,13 @@ def _build_native_metadata(
     easy_remix: bool,
     civitai_budget: CivitaiLookupBudget | None = None,
 ) -> NativeImageMetadata:
+    _validate_parameter_sources(
+        modelname,
+        positive,
+        negative,
+        custom,
+        additional_hashes,
+    )
     local_resources = _local_resource_hashes(
         modelname,
         applied_loras,
@@ -259,8 +275,14 @@ def _build_native_metadata(
                 f"Civitai resources: {_compact_json(civitai_resources, ascii_only=False)}"
             )
     lines.append(", ".join(fields))
+    parameters = "\n".join(lines)
+    _metadata_text_size(
+        parameters,
+        label="A1111 parameters",
+        limit=_MAX_PARAMETERS_BYTES,
+    )
     return NativeImageMetadata(
-        parameters="\n".join(lines),
+        parameters=parameters,
         final_hashes=",".join(final_parts),
         hashes=hashes,
     )
@@ -310,34 +332,15 @@ def _serialize_metadata(
     write_metadata: bool,
 ) -> _SerializedMetadata:
     if not write_metadata:
-        return _SerializedMetadata(None, None, None, False)
+        return _SerializedMetadata(None, None, None, False, 0, 0)
 
-    workflow = (
-        extra_pnginfo.get("workflow")
-        if isinstance(extra_pnginfo, Mapping)
-        else None
+    payload = _prepare_metadata_payload(
+        parameters=parameters,
+        prompt=prompt,
+        extra_pnginfo=extra_pnginfo,
+        embed_workflow=embed_workflow,
+        save_workflow_as_json=save_workflow_as_json,
     )
-    workflow_json = (
-        json.dumps(workflow, allow_nan=False, ensure_ascii=False, indent=2)
-        if workflow is not None and (embed_workflow or save_workflow_as_json)
-        else None
-    )
-    prompt_json = (
-        _compact_json(prompt, ascii_only=True)
-        if embed_workflow and prompt is not None
-        else None
-    )
-    extra_json: list[tuple[str, str]] = []
-    if embed_workflow:
-        for key, value in cast(Mapping[str, object], extra_pnginfo or {}).items():
-            key_text = str(key)
-            if key_text in {"parameters", "prompt"}:
-                logger.warning(
-                    "[EasyUseAnima] Ignoring reserved extra_pnginfo key %r.",
-                    key_text,
-                )
-                continue
-            extra_json.append((key_text, _compact_json(value, ascii_only=True)))
 
     if extension == "png":
         from PIL.PngImagePlugin import PngInfo  # pyright: ignore[reportMissingImports]
@@ -345,19 +348,31 @@ def _serialize_metadata(
         pnginfo = PngInfo()
         if parameters:
             pnginfo.add_text("parameters", parameters)
-        if prompt_json is not None:
-            pnginfo.add_text("prompt", prompt_json)
-        for key, value in extra_json:
+        if payload.prompt_json is not None:
+            pnginfo.add_text("prompt", payload.prompt_json)
+        for key, value in payload.extra_json:
             pnginfo.add_text(key, value)
-        return _SerializedMetadata(pnginfo, None, workflow_json, False)
+        return _SerializedMetadata(
+            pnginfo,
+            None,
+            payload.workflow_json,
+            False,
+            payload.embedded_size,
+            payload.workflow_json_size,
+        )
 
-    exif_bytes = _build_exif_bytes(parameters, prompt_json, extra_json)
+    exif_bytes = _build_exif_bytes(
+        parameters,
+        payload.prompt_json,
+        payload.extra_json,
+    )
     force_sidecar = False
     if extension in {"jpg", "jpeg"} and len(exif_bytes) > _JPEG_EXIF_LIMIT:
-        exif_bytes = _build_exif_bytes(parameters, None, extra_json)
+        exif_bytes = _build_exif_bytes(parameters, None, payload.extra_json)
         if len(exif_bytes) > _JPEG_EXIF_LIMIT:
             exif_bytes = _build_exif_bytes(parameters, None, ())
-            force_sidecar = workflow_json is not None
+            payload.ensure_workflow_sidecar()
+            force_sidecar = payload.workflow_json is not None
         if len(exif_bytes) > _JPEG_EXIF_LIMIT:
             raise RuntimeError(
                 "[EasyUseAnima] A1111 metadata is too large for JPEG EXIF; use PNG/WebP or shorten the prompt."
@@ -365,7 +380,15 @@ def _serialize_metadata(
         logger.warning(
             "[EasyUseAnima] JPEG workflow metadata exceeded EXIF limits; preserving A1111 parameters and writing a workflow JSON sidecar."
         )
-    return _SerializedMetadata(None, exif_bytes, workflow_json, force_sidecar)
+    _validate_embedded_metadata_size(len(exif_bytes))
+    return _SerializedMetadata(
+        None,
+        exif_bytes,
+        payload.workflow_json,
+        force_sidecar,
+        len(exif_bytes),
+        payload.workflow_json_size,
+    )
 
 
 def _tensor_to_pil(image: object):
@@ -498,6 +521,21 @@ def _image_save_options(
     return options
 
 
+def _validated_sidecar_requirement(
+    serialized: _SerializedMetadata,
+    save_workflow_as_json: bool,
+    batch_count: int,
+) -> bool:
+    return _sidecar_required_and_validate_batch(
+        workflow_json=serialized.workflow_json,
+        force_workflow_sidecar=serialized.force_workflow_sidecar,
+        save_workflow_as_json=save_workflow_as_json,
+        embedded_size=serialized.embedded_size_bytes,
+        sidecar_size=serialized.sidecar_size_bytes,
+        batch_count=batch_count,
+    )
+
+
 def _save_native_images(
     images: Iterable[object],
     *,
@@ -550,8 +588,8 @@ def _save_native_images(
         "webp": "WEBP",
     }[safe_extension]
     results: list[dict[str, str]] = []
-    sidecar_required = serialized.workflow_json is not None and (
-        save_workflow_as_json or serialized.force_workflow_sidecar
+    sidecar_required = _validated_sidecar_requirement(
+        serialized, save_workflow_as_json, len(batch)
     )
     with _SAVE_LOCK, OutputDirectoryBinding(resolved_folder) as directory:
         pending_names = _allocate_filenames(

--- a/easyuse_anima/aio/native_metadata_budget.py
+++ b/easyuse_anima/aio/native_metadata_budget.py
@@ -1,0 +1,374 @@
+"""Resource budgets for workflow and image metadata serialization."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_ITEMS = 100_000
+_MAX_JSON_STRING_BYTES = 1 * 1024 * 1024
+_MAX_EXTRA_PNGINFO_KEYS = 128
+_MAX_EXTRA_KEY_BYTES = 256
+
+_MAX_PARAMETERS_BYTES = 512 * 1024
+_MAX_PROMPT_JSON_BYTES = 2 * 1024 * 1024
+_MAX_WORKFLOW_JSON_BYTES = 4 * 1024 * 1024
+_MAX_EXTRA_PNGINFO_JSON_BYTES = 6 * 1024 * 1024
+_MAX_EMBEDDED_METADATA_BYTES = 8 * 1024 * 1024
+_MAX_SAVE_METADATA_BYTES = 64 * 1024 * 1024
+
+_TEXT_CHUNK_CHARACTERS = 64 * 1024
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class MetadataLimitError(RuntimeError):
+    """A workflow-controlled metadata payload exceeded its explicit budget."""
+
+
+def _utf8_size(value: str, *, limit: int, label: str) -> int:
+    total = 0
+    for offset in range(0, len(value), _TEXT_CHUNK_CHARACTERS):
+        total += len(
+            value[offset : offset + _TEXT_CHUNK_CHARACTERS].encode("utf-8")
+        )
+        if total > limit:
+            raise MetadataLimitError(
+                f"[EasyUseAnima] AiO {label} exceeds the {limit}-byte metadata limit."
+            )
+    return total
+
+
+def _scalar_size(value: object) -> int:
+    if value is None:
+        return 4
+    if isinstance(value, bool):
+        return 5
+    if isinstance(value, int):
+        if value == 0:
+            return 1
+        return max(1, math.ceil(abs(value).bit_length() * math.log10(2))) + int(
+            value < 0
+        )
+    if isinstance(value, float):
+        return 32
+    return 64
+
+
+def _validate_json_structure(
+    value: object,
+    *,
+    label: str,
+    byte_limit: int,
+) -> None:
+    items_seen = 0
+    estimated_bytes = 0
+    active_containers: set[int] = set()
+    stack: list[tuple[object, int, bool]] = [(value, 0, False)]
+
+    def add_bytes(amount: int) -> None:
+        nonlocal estimated_bytes
+        estimated_bytes += amount
+        if estimated_bytes > byte_limit:
+            raise MetadataLimitError(
+                f"[EasyUseAnima] AiO {label} exceeds the {byte_limit}-byte metadata limit."
+            )
+
+    while stack:
+        current, depth, exiting = stack.pop()
+        if exiting:
+            active_containers.remove(id(current))
+            continue
+
+        items_seen += 1
+        if items_seen > _MAX_JSON_ITEMS:
+            raise MetadataLimitError(
+                f"[EasyUseAnima] AiO {label} exceeds the {_MAX_JSON_ITEMS}-item metadata limit."
+            )
+        if depth > _MAX_JSON_DEPTH:
+            raise MetadataLimitError(
+                f"[EasyUseAnima] AiO {label} exceeds the {_MAX_JSON_DEPTH}-level metadata limit."
+            )
+        if isinstance(current, str):
+            add_bytes(
+                _utf8_size(
+                    current,
+                    limit=_MAX_JSON_STRING_BYTES,
+                    label=f"{label} string",
+                )
+                + 2
+            )
+            continue
+
+        if isinstance(current, Mapping):
+            identity = id(current)
+            if identity in active_containers:
+                raise ValueError("Circular reference detected")
+            if items_seen + len(current) * 2 > _MAX_JSON_ITEMS:
+                raise MetadataLimitError(
+                    f"[EasyUseAnima] AiO {label} exceeds the {_MAX_JSON_ITEMS}-item metadata limit."
+                )
+            active_containers.add(identity)
+            stack.append((current, depth, True))
+            add_bytes(2 + max(0, len(current) - 1))
+            for key, child in current.items():
+                items_seen += 1
+                key_text = key if isinstance(key, str) else str(key)
+                add_bytes(
+                    _utf8_size(
+                        key_text,
+                        limit=_MAX_JSON_STRING_BYTES,
+                        label=f"{label} key",
+                    )
+                    + 3
+                )
+                stack.append((child, depth + 1, False))
+            continue
+
+        if isinstance(current, (list, tuple)):
+            identity = id(current)
+            if identity in active_containers:
+                raise ValueError("Circular reference detected")
+            if items_seen + len(current) > _MAX_JSON_ITEMS:
+                raise MetadataLimitError(
+                    f"[EasyUseAnima] AiO {label} exceeds the {_MAX_JSON_ITEMS}-item metadata limit."
+                )
+            active_containers.add(identity)
+            stack.append((current, depth, True))
+            add_bytes(2 + max(0, len(current) - 1))
+            for child in current:
+                stack.append((child, depth + 1, False))
+            continue
+
+        add_bytes(_scalar_size(current))
+
+
+def _json_dumps_limited(
+    value: object,
+    *,
+    label: str,
+    byte_limit: int,
+    ascii_only: bool,
+    pretty: bool = False,
+) -> tuple[str, int]:
+    _validate_json_structure(value, label=label, byte_limit=byte_limit)
+    if pretty:
+        encoder = json.JSONEncoder(
+            allow_nan=False,
+            ensure_ascii=ascii_only,
+            indent=2,
+        )
+    else:
+        encoder = json.JSONEncoder(
+            allow_nan=False,
+            ensure_ascii=ascii_only,
+            separators=(",", ":"),
+        )
+    parts: list[str] = []
+    total = 0
+    for part in encoder.iterencode(value):
+        part_size = _utf8_size(
+            part,
+            limit=byte_limit,
+            label=label,
+        )
+        if total > byte_limit - part_size:
+            raise MetadataLimitError(
+                f"[EasyUseAnima] AiO {label} exceeds the {byte_limit}-byte metadata limit."
+            )
+        total += part_size
+        parts.append(part)
+    return "".join(parts), total
+
+
+def _metadata_text_size(value: str, *, label: str, limit: int) -> int:
+    return _utf8_size(str(value or ""), limit=limit, label=label)
+
+
+def _validate_parameter_sources(*values: object) -> None:
+    total = 0
+    for value in values:
+        size = _utf8_size(
+            str(value or ""),
+            limit=_MAX_PARAMETERS_BYTES,
+            label="A1111 parameters",
+        )
+        if total > _MAX_PARAMETERS_BYTES - size:
+            raise MetadataLimitError(
+                "[EasyUseAnima] AiO A1111 parameters exceed the "
+                f"{_MAX_PARAMETERS_BYTES}-byte metadata limit."
+            )
+        total += size
+
+
+def _extra_pnginfo_key(value: object) -> str:
+    text = str(value)
+    if not text or _CONTROL_RE.search(text):
+        raise MetadataLimitError(
+            "[EasyUseAnima] AiO extra_pnginfo key is empty or contains control characters."
+        )
+    _utf8_size(text, limit=_MAX_EXTRA_KEY_BYTES, label="extra_pnginfo key")
+    return text
+
+
+def _validate_extra_pnginfo_count(value: Mapping[str, object]) -> None:
+    if len(value) > _MAX_EXTRA_PNGINFO_KEYS:
+        raise MetadataLimitError(
+            f"[EasyUseAnima] AiO extra_pnginfo exceeds the {_MAX_EXTRA_PNGINFO_KEYS}-key metadata limit."
+        )
+
+
+@dataclass(slots=True)
+class _PreparedMetadataPayload:
+    workflow: object | None
+    prompt_json: str | None
+    extra_json: list[tuple[str, str]]
+    workflow_json: str | None
+    workflow_json_size: int
+    embedded_size: int
+
+    def ensure_workflow_sidecar(self) -> None:
+        if self.workflow is None or self.workflow_json is not None:
+            return
+        self.workflow_json, self.workflow_json_size = _json_dumps_limited(
+            self.workflow,
+            label="workflow JSON sidecar",
+            byte_limit=_MAX_WORKFLOW_JSON_BYTES,
+            ascii_only=False,
+            pretty=True,
+        )
+
+
+def _prepare_metadata_payload(
+    *,
+    parameters: str,
+    prompt: object | None,
+    extra_pnginfo: Mapping[str, object] | None,
+    embed_workflow: bool,
+    save_workflow_as_json: bool,
+) -> _PreparedMetadataPayload:
+    parameters_size = _metadata_text_size(
+        parameters,
+        label="A1111 parameters",
+        limit=_MAX_PARAMETERS_BYTES,
+    )
+    workflow = (
+        extra_pnginfo.get("workflow")
+        if isinstance(extra_pnginfo, Mapping)
+        else None
+    )
+    workflow_compact: str | None = None
+    workflow_compact_size = 0
+    if workflow is not None and embed_workflow:
+        workflow_compact, workflow_compact_size = _json_dumps_limited(
+            workflow,
+            label="workflow JSON",
+            byte_limit=_MAX_WORKFLOW_JSON_BYTES,
+            ascii_only=True,
+        )
+
+    prompt_json: str | None = None
+    prompt_json_size = 0
+    if embed_workflow and prompt is not None:
+        prompt_json, prompt_json_size = _json_dumps_limited(
+            prompt,
+            label="prompt JSON",
+            byte_limit=_MAX_PROMPT_JSON_BYTES,
+            ascii_only=True,
+        )
+
+    extra_json: list[tuple[str, str]] = []
+    extra_json_size = 0
+    if embed_workflow:
+        extra_values = extra_pnginfo or {}
+        _validate_extra_pnginfo_count(extra_values)
+        for key, value in extra_values.items():
+            key_text = _extra_pnginfo_key(key)
+            if key_text in {"parameters", "prompt"}:
+                logger.warning(
+                    "[EasyUseAnima] Ignoring reserved extra_pnginfo key %r.",
+                    key_text,
+                )
+                continue
+            if key_text == "workflow" and workflow_compact is not None:
+                value_json = workflow_compact
+                value_size = workflow_compact_size
+            else:
+                value_json, value_size = _json_dumps_limited(
+                    value,
+                    label="extra_pnginfo value",
+                    byte_limit=_MAX_EXTRA_PNGINFO_JSON_BYTES,
+                    ascii_only=True,
+                )
+            key_size = _metadata_text_size(
+                key_text,
+                label="extra_pnginfo key",
+                limit=_MAX_EXTRA_PNGINFO_JSON_BYTES,
+            )
+            if (
+                extra_json_size
+                > _MAX_EXTRA_PNGINFO_JSON_BYTES - key_size - value_size
+            ):
+                raise MetadataLimitError(
+                    "[EasyUseAnima] AiO extra_pnginfo exceeds the "
+                    f"{_MAX_EXTRA_PNGINFO_JSON_BYTES}-byte metadata limit."
+                )
+            extra_json_size += key_size + value_size
+            extra_json.append((key_text, value_json))
+
+    payload = _PreparedMetadataPayload(
+        workflow=workflow,
+        prompt_json=prompt_json,
+        extra_json=extra_json,
+        workflow_json=None,
+        workflow_json_size=0,
+        embedded_size=parameters_size + prompt_json_size + extra_json_size,
+    )
+    _validate_embedded_metadata_size(payload.embedded_size)
+    if save_workflow_as_json:
+        payload.ensure_workflow_sidecar()
+    return payload
+
+
+def _validate_embedded_metadata_size(size: int) -> None:
+    if size > _MAX_EMBEDDED_METADATA_BYTES:
+        raise MetadataLimitError(
+            "[EasyUseAnima] AiO embedded image metadata exceeds the "
+            f"{_MAX_EMBEDDED_METADATA_BYTES}-byte limit."
+        )
+
+
+def _validate_save_metadata_size(*, per_image: int, batch_count: int) -> None:
+    if per_image * batch_count > _MAX_SAVE_METADATA_BYTES:
+        raise MetadataLimitError(
+            "[EasyUseAnima] AiO batch metadata exceeds the "
+            f"{_MAX_SAVE_METADATA_BYTES}-byte per-save limit."
+        )
+
+
+def _sidecar_required_and_validate_batch(
+    *,
+    workflow_json: str | None,
+    force_workflow_sidecar: bool,
+    save_workflow_as_json: bool,
+    embedded_size: int,
+    sidecar_size: int,
+    batch_count: int,
+) -> bool:
+    required = workflow_json is not None and (
+        save_workflow_as_json or force_workflow_sidecar
+    )
+    _validate_save_metadata_size(
+        per_image=embedded_size + (sidecar_size if required else 0),
+        batch_count=batch_count,
+    )
+    return required
+
+
+__all__ = ()

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -23,6 +23,7 @@ from .native_image_output import (
     _fetch_civitai_autov3_hash,
     _save_native_images,
 )
+from .native_metadata_budget import _validate_parameter_sources
 from .output_settings import (
     _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
 )
@@ -521,6 +522,11 @@ def _save_image_with_image_saver(
     )
 
     if _comfy_metadata_enabled():
+        _validate_parameter_sources(
+            positive_prompt,
+            negative_prompt,
+            runtime.custom,
+        )
         civitai_budget = CivitaiLookupBudget()
         save_prompt_metadata = _as_bool(
             runtime.settings.get("save_prompt_metadata"),

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9350,23 +9350,6 @@
       },
       {
         "alias": null,
-        "bound_name": "cast",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:cast",
-        "kind": "static_from",
-        "line": 13,
-        "name": "cast",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
-        "alias": null,
         "bound_name": "CivitaiLookupBudget",
         "branch_context": [],
         "classification": "internal",
@@ -9374,7 +9357,7 @@
         "conditional": false,
         "imported": ".native_civitai:CivitaiLookupBudget",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "CivitaiLookupBudget",
         "optional": false,
         "requested": ".native_civitai",
@@ -9392,7 +9375,7 @@
         "conditional": false,
         "imported": ".native_civitai:CivitaiLookupBudgetExhausted",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "CivitaiLookupBudgetExhausted",
         "optional": false,
         "requested": ".native_civitai",
@@ -9410,7 +9393,7 @@
         "conditional": false,
         "imported": ".native_civitai:_fetch_civitai_resource_by_hash",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "_fetch_civitai_resource_by_hash",
         "optional": false,
         "requested": ".native_civitai",
@@ -9428,7 +9411,7 @@
         "conditional": false,
         "imported": ".native_civitai:_fetch_civitai_autov3_hash",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "_fetch_civitai_autov3_hash",
         "optional": false,
         "requested": ".native_civitai",
@@ -9439,6 +9422,114 @@
       },
       {
         "alias": null,
+        "bound_name": "_MAX_PARAMETERS_BYTES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_MAX_PARAMETERS_BYTES",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_MAX_PARAMETERS_BYTES",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_metadata_text_size",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_metadata_text_size",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_metadata_text_size",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prepare_metadata_payload",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_prepare_metadata_payload",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_prepare_metadata_payload",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_sidecar_required_and_validate_batch",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_sidecar_required_and_validate_batch",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_sidecar_required_and_validate_batch",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_validate_embedded_metadata_size",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_validate_embedded_metadata_size",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_validate_embedded_metadata_size",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_validate_parameter_sources",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_validate_parameter_sources",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_validate_parameter_sources",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_image_output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
         "bound_name": "OutputDirectoryBinding",
         "branch_context": [],
         "classification": "internal",
@@ -9446,7 +9537,7 @@
         "conditional": false,
         "imported": ".native_output_publication:OutputDirectoryBinding",
         "kind": "static_from",
-        "line": 23,
+        "line": 30,
         "name": "OutputDirectoryBinding",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9464,7 +9555,7 @@
         "conditional": false,
         "imported": ".native_output_publication:PublicationCollision",
         "kind": "static_from",
-        "line": 23,
+        "line": 30,
         "name": "PublicationCollision",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9482,7 +9573,7 @@
         "conditional": false,
         "imported": ".native_output_publication:publish_image_transaction",
         "kind": "static_from",
-        "line": 23,
+        "line": 30,
         "name": "publish_image_transaction",
         "optional": false,
         "requested": ".native_output_publication",
@@ -9500,7 +9591,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_EMBEDDING_RE",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_EMBEDDING_RE",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9518,7 +9609,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_HEX_HASH_RE",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_HEX_HASH_RE",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9536,7 +9627,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_ResourceHash",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_ResourceHash",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9554,7 +9645,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_local_resource_hashes",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_local_resource_hashes",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9572,7 +9663,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_manual_resource_hashes",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_manual_resource_hashes",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9590,7 +9681,7 @@
         "conditional": false,
         "imported": ".native_resource_hashes:_resource_name",
         "kind": "static_from",
-        "line": 28,
+        "line": 35,
         "name": "_resource_name",
         "optional": false,
         "requested": ".native_resource_hashes",
@@ -9608,7 +9699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 270
+            "line": 292
           }
         ],
         "classification": "external",
@@ -9616,7 +9707,7 @@
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 271,
+        "line": 293,
         "name": "args",
         "optional": true,
         "requested": "comfy.cli_args",
@@ -9633,7 +9724,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "ExifTags",
         "optional": false,
         "requested": "PIL",
@@ -9650,7 +9741,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -9665,7 +9756,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 342,
+            "line": 345,
             "type_checking": false
           }
         ],
@@ -9674,7 +9765,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 343,
+        "line": 346,
         "name": "PngInfo",
         "optional": false,
         "requested": "PIL.PngImagePlugin",
@@ -9691,7 +9782,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 372,
+        "line": 395,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -9708,13 +9799,132 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 373,
+        "line": 396,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
         "role": "ordinary",
         "scope": "_tensor_to_pil",
         "source": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "math",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
       },
       {
         "alias": null,
@@ -11296,6 +11506,24 @@
         "target": "easyuse_anima/aio/native_image_output.py"
       },
       {
+        "alias": null,
+        "bound_name": "_validate_parameter_sources",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_metadata_budget:_validate_parameter_sources",
+        "kind": "static_from",
+        "line": 26,
+        "name": "_validate_parameter_sources",
+        "optional": false,
+        "requested": ".native_metadata_budget",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
         "alias": "_normalize_aio_civitai_hash_fetchers",
         "bound_name": "_normalize_aio_civitai_hash_fetchers",
         "branch_context": [],
@@ -11304,7 +11532,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".output_settings",
@@ -11322,7 +11550,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -11340,7 +11568,7 @@
         "conditional": false,
         "imported": ".sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 32,
+        "line": 33,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".sampling",
@@ -11358,7 +11586,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 81
           }
         ],
         "classification": "external",
@@ -11366,7 +11594,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 82,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11383,7 +11611,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 159
           }
         ],
         "classification": "external",
@@ -11391,7 +11619,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 159,
+        "line": 160,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11408,7 +11636,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 436
+            "line": 437
           }
         ],
         "classification": "external",
@@ -11416,7 +11644,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 437,
+        "line": 438,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -44150,6 +44378,10 @@
       },
       {
         "from": "easyuse_anima/aio/native_image_output.py",
+        "to": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "from": "easyuse_anima/aio/native_image_output.py",
         "to": "easyuse_anima/aio/native_output_publication.py"
       },
       {
@@ -44179,6 +44411,10 @@
       {
         "from": "easyuse_anima/aio/output.py",
         "to": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/aio/native_metadata_budget.py"
       },
       {
         "from": "easyuse_anima/aio/output.py",
@@ -46189,6 +46425,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/native_metadata_budget.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/native_output_publication.py"
         ]
       },
@@ -47155,7 +47397,7 @@
     ]
   },
   "inventory": {
-    "module_count": 199,
+    "module_count": 200,
     "modules": [
       {
         "functions": [
@@ -49990,142 +50232,276 @@
         "functions": [
           {
             "async": false,
-            "end_line": 79,
+            "end_line": 88,
             "kind": "function",
-            "line": 73,
+            "line": 82,
             "loc": 7,
             "qualified_name": "_compact_json"
           },
           {
             "async": false,
-            "end_line": 89,
+            "end_line": 98,
             "kind": "function",
-            "line": 82,
+            "line": 91,
             "loc": 8,
             "qualified_name": "_clean_prompt_for_remix"
           },
           {
             "async": false,
-            "end_line": 87,
+            "end_line": 96,
             "kind": "function",
-            "line": 85,
+            "line": 94,
             "loc": 3,
             "qualified_name": "_clean_prompt_for_remix.simplify_embedding"
           },
           {
             "async": false,
-            "end_line": 102,
+            "end_line": 111,
             "kind": "function",
-            "line": 92,
+            "line": 101,
             "loc": 11,
             "qualified_name": "_civitai_sampler_name"
           },
           {
             "async": false,
-            "end_line": 160,
+            "end_line": 169,
             "kind": "function",
-            "line": 105,
+            "line": 114,
             "loc": 56,
             "qualified_name": "_civitai_resource_entries"
           },
           {
             "async": false,
-            "end_line": 266,
+            "end_line": 288,
             "kind": "function",
-            "line": 163,
-            "loc": 104,
+            "line": 172,
+            "loc": 117,
             "qualified_name": "_build_native_metadata"
           },
           {
             "async": false,
-            "end_line": 275,
+            "end_line": 297,
             "kind": "function",
-            "line": 269,
+            "line": 291,
             "loc": 7,
             "qualified_name": "_comfy_metadata_enabled"
           },
           {
             "async": false,
-            "end_line": 279,
+            "end_line": 301,
             "kind": "function",
-            "line": 278,
+            "line": 300,
             "loc": 2,
             "qualified_name": "_encode_user_comment"
           },
           {
             "async": false,
-            "end_line": 299,
+            "end_line": 321,
             "kind": "function",
-            "line": 282,
+            "line": 304,
             "loc": 18,
             "qualified_name": "_build_exif_bytes"
           },
           {
             "async": false,
-            "end_line": 368,
+            "end_line": 391,
             "kind": "function",
-            "line": 302,
-            "loc": 67,
+            "line": 324,
+            "loc": 68,
             "qualified_name": "_serialize_metadata"
           },
           {
             "async": false,
-            "end_line": 390,
+            "end_line": 413,
             "kind": "function",
-            "line": 371,
+            "line": 394,
             "loc": 20,
             "qualified_name": "_tensor_to_pil"
           },
           {
             "async": false,
-            "end_line": 438,
+            "end_line": 461,
             "kind": "function",
-            "line": 393,
+            "line": 416,
             "loc": 46,
             "qualified_name": "_allocate_filenames"
           },
           {
             "async": false,
-            "end_line": 406,
+            "end_line": 429,
             "kind": "function",
-            "line": 402,
+            "line": 425,
             "loc": 5,
             "qualified_name": "_allocate_filenames.occupied"
           },
           {
             "async": false,
-            "end_line": 475,
+            "end_line": 498,
             "kind": "function",
-            "line": 441,
+            "line": 464,
             "loc": 35,
             "qualified_name": "_resolve_native_output_folder"
           },
           {
             "async": false,
-            "end_line": 498,
+            "end_line": 521,
             "kind": "function",
-            "line": 478,
+            "line": 501,
             "loc": 21,
             "qualified_name": "_image_save_options"
           },
           {
             "async": false,
-            "end_line": 620,
+            "end_line": 536,
             "kind": "function",
-            "line": 501,
+            "line": 524,
+            "loc": 13,
+            "qualified_name": "_validated_sidecar_requirement"
+          },
+          {
+            "async": false,
+            "end_line": 658,
+            "kind": "function",
+            "line": 539,
             "loc": 120,
             "qualified_name": "_save_native_images"
           }
         ],
         "is_package": false,
-        "loc": 623,
+        "loc": 661,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "4db8ba4629832457a014a975a56f75e5411175dc",
+        "normalized_git_blob_sha1": "db5dc7a0f962848f35bfd68ad830847b91d03eb2",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 14,
+          "function_count": 15,
           "global_count": 9
+        }
+      },
+      {
+        "functions": [
+          {
+            "async": false,
+            "end_line": 45,
+            "kind": "function",
+            "line": 35,
+            "loc": 11,
+            "qualified_name": "_utf8_size"
+          },
+          {
+            "async": false,
+            "end_line": 61,
+            "kind": "function",
+            "line": 48,
+            "loc": 14,
+            "qualified_name": "_scalar_size"
+          },
+          {
+            "async": false,
+            "end_line": 149,
+            "kind": "function",
+            "line": 64,
+            "loc": 86,
+            "qualified_name": "_validate_json_structure"
+          },
+          {
+            "async": false,
+            "end_line": 81,
+            "kind": "function",
+            "line": 75,
+            "loc": 7,
+            "qualified_name": "_validate_json_structure.add_bytes"
+          },
+          {
+            "async": false,
+            "end_line": 187,
+            "kind": "function",
+            "line": 152,
+            "loc": 36,
+            "qualified_name": "_json_dumps_limited"
+          },
+          {
+            "async": false,
+            "end_line": 191,
+            "kind": "function",
+            "line": 190,
+            "loc": 2,
+            "qualified_name": "_metadata_text_size"
+          },
+          {
+            "async": false,
+            "end_line": 207,
+            "kind": "function",
+            "line": 194,
+            "loc": 14,
+            "qualified_name": "_validate_parameter_sources"
+          },
+          {
+            "async": false,
+            "end_line": 217,
+            "kind": "function",
+            "line": 210,
+            "loc": 8,
+            "qualified_name": "_extra_pnginfo_key"
+          },
+          {
+            "async": false,
+            "end_line": 224,
+            "kind": "function",
+            "line": 220,
+            "loc": 5,
+            "qualified_name": "_validate_extra_pnginfo_count"
+          },
+          {
+            "async": false,
+            "end_line": 245,
+            "kind": "method",
+            "line": 236,
+            "loc": 10,
+            "qualified_name": "_PreparedMetadataPayload.ensure_workflow_sidecar"
+          },
+          {
+            "async": false,
+            "end_line": 336,
+            "kind": "function",
+            "line": 248,
+            "loc": 89,
+            "qualified_name": "_prepare_metadata_payload"
+          },
+          {
+            "async": false,
+            "end_line": 344,
+            "kind": "function",
+            "line": 339,
+            "loc": 6,
+            "qualified_name": "_validate_embedded_metadata_size"
+          },
+          {
+            "async": false,
+            "end_line": 352,
+            "kind": "function",
+            "line": 347,
+            "loc": 6,
+            "qualified_name": "_validate_save_metadata_size"
+          },
+          {
+            "async": false,
+            "end_line": 371,
+            "kind": "function",
+            "line": 355,
+            "loc": 17,
+            "qualified_name": "_sidecar_required_and_validate_batch"
+          }
+        ],
+        "is_package": false,
+        "loc": 374,
+        "module": "easyuse_anima.aio.native_metadata_budget",
+        "normalized_git_blob_sha1": "6f901c4ecd75af20318a224d58b7a1a15d32b3b0",
+        "path": "easyuse_anima/aio/native_metadata_budget.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 12,
+          "global_count": 15
         }
       },
       {
@@ -50766,153 +51142,153 @@
         "functions": [
           {
             "async": false,
-            "end_line": 68,
+            "end_line": 69,
             "kind": "function",
-            "line": 65,
+            "line": 66,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 76,
+            "end_line": 77,
             "kind": "function",
-            "line": 71,
+            "line": 72,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 97,
+            "end_line": 98,
             "kind": "function",
-            "line": 79,
+            "line": 80,
             "loc": 19,
             "qualified_name": "_comfy_output_directory"
           },
           {
             "async": false,
-            "end_line": 125,
+            "end_line": 126,
             "kind": "function",
-            "line": 100,
+            "line": 101,
             "loc": 26,
             "qualified_name": "_output_path_parts"
           },
           {
             "async": false,
-            "end_line": 152,
+            "end_line": 153,
             "kind": "function",
-            "line": 128,
+            "line": 129,
             "loc": 25,
             "qualified_name": "_validated_output_subpath"
           },
           {
             "async": false,
-            "end_line": 165,
+            "end_line": 166,
             "kind": "function",
-            "line": 155,
+            "line": 156,
             "loc": 11,
             "qualified_name": "_image_saver_model_names"
           },
           {
             "async": false,
-            "end_line": 172,
+            "end_line": 173,
             "kind": "function",
-            "line": 168,
+            "line": 169,
             "loc": 5,
             "qualified_name": "_image_saver_timestamp"
           },
           {
             "async": false,
-            "end_line": 236,
+            "end_line": 237,
             "kind": "function",
-            "line": 175,
+            "line": 176,
             "loc": 62,
             "qualified_name": "_render_image_saver_template"
           },
           {
             "async": false,
-            "end_line": 198,
+            "end_line": 199,
             "kind": "function",
-            "line": 197,
+            "line": 198,
             "loc": 2,
             "qualified_name": "_render_image_saver_template.replace_time"
           },
           {
             "async": false,
-            "end_line": 206,
+            "end_line": 207,
             "kind": "function",
-            "line": 200,
+            "line": 201,
             "loc": 7,
             "qualified_name": "_render_image_saver_template.replace_counter"
           },
           {
             "async": false,
-            "end_line": 326,
+            "end_line": 327,
             "kind": "function",
-            "line": 239,
+            "line": 240,
             "loc": 88,
             "qualified_name": "_resolve_image_saver_runtime"
           },
           {
             "async": false,
-            "end_line": 404,
+            "end_line": 405,
             "kind": "function",
-            "line": 329,
+            "line": 330,
             "loc": 76,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 428,
+            "end_line": 429,
             "kind": "function",
-            "line": 407,
+            "line": 408,
             "loc": 22,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 444,
+            "end_line": 445,
             "kind": "function",
-            "line": 431,
+            "line": 432,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 462,
+            "end_line": 463,
             "kind": "function",
-            "line": 447,
+            "line": 448,
             "loc": 16,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 487,
+            "end_line": 488,
             "kind": "function",
-            "line": 465,
+            "line": 466,
             "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 499,
+            "end_line": 500,
             "kind": "function",
-            "line": 490,
+            "line": 491,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 603,
+            "end_line": 609,
             "kind": "function",
-            "line": 502,
-            "loc": 102,
+            "line": 503,
+            "loc": 107,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 606,
+        "loc": 612,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "86c82ec2c0860e15bf1aba4046a61cc2ea645ed8",
+        "normalized_git_blob_sha1": "f159e7c3460e3839beec04c65bfe94a93fa49b54",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,
@@ -63756,31 +64132,20 @@
         "source": "easyuse_anima/aio/native_image_output.py"
       },
       {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:cast",
-        "kind": "static_from",
-        "line": 13,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/native_image_output.py"
-      },
-      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 270
+            "line": 292
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 271,
+        "line": 293,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63791,7 +64156,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63802,7 +64167,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63812,7 +64177,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 342,
+            "line": 345,
             "type_checking": false
           }
         ],
@@ -63820,7 +64185,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 343,
+        "line": 346,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63831,7 +64196,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 372,
+        "line": 395,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -63842,10 +64207,87 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 373,
+        "line": 396,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/native_metadata_budget.py"
       },
       {
         "branch_context": [],
@@ -64677,14 +65119,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 82,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -64696,14 +65138,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 159
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 159,
+        "line": 160,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -64715,14 +65157,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 436
+            "line": 437
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 437,
+        "line": 438,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71411,14 +71853,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 270
+            "line": 292
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 271,
+        "line": 293,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -71582,14 +72024,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 82,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71601,14 +72043,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 158
+            "line": 159
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 159,
+        "line": 160,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71620,14 +72062,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 436
+            "line": 437
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 437,
+        "line": 438,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72608,6 +73050,7 @@
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/native_civitai.py",
       "easyuse_anima/aio/native_image_output.py",
+      "easyuse_anima/aio/native_metadata_budget.py",
       "easyuse_anima/aio/native_output_publication.py",
       "easyuse_anima/aio/native_resource_hashes.py",
       "easyuse_anima/aio/negpip.py",
@@ -72807,6 +73250,7 @@
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/native_civitai.py",
       "easyuse_anima/aio/native_image_output.py",
+      "easyuse_anima/aio/native_metadata_budget.py",
       "easyuse_anima/aio/native_output_publication.py",
       "easyuse_anima/aio/native_resource_hashes.py",
       "easyuse_anima/aio/negpip.py",
@@ -74118,7 +74562,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 37,
+        "line": 44,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74127,7 +74571,7 @@
         "column": 15,
         "context": "assign:_LORA_TAG_RE",
         "kind": "import_time_call",
-        "line": 42,
+        "line": 49,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74136,7 +74580,7 @@
         "column": 14,
         "context": "assign:_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 43,
+        "line": 50,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74145,7 +74589,7 @@
         "column": 13,
         "context": "assign:_SAVE_LOCK",
         "kind": "import_time_call",
-        "line": 44,
+        "line": 51,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74154,7 +74598,7 @@
         "column": 25,
         "context": "assign:_CIVITAI_SAMPLER_NAMES",
         "kind": "import_time_call",
-        "line": 46,
+        "line": 53,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74163,7 +74607,7 @@
         "column": 1,
         "context": "decorator:NativeImageMetadata",
         "kind": "import_time_call",
-        "line": 58,
+        "line": 65,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74172,8 +74616,35 @@
         "column": 1,
         "context": "decorator:_SerializedMetadata",
         "kind": "import_time_call",
-        "line": 65,
+        "line": 72,
         "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 12,
+        "module": "easyuse_anima/aio/native_metadata_budget.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 14,
+        "context": "assign:_CONTROL_RE",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/aio/native_metadata_budget.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_PreparedMetadataPayload",
+        "kind": "import_time_call",
+        "line": 227,
+        "module": "easyuse_anima/aio/native_metadata_budget.py",
         "scope": "<module>"
       },
       {
@@ -74325,7 +74796,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 34,
+        "line": 35,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74334,7 +74805,7 @@
         "column": 30,
         "context": "assign:_IMAGE_SAVER_CUSTOM_TIME_RE",
         "kind": "import_time_call",
-        "line": 37,
+        "line": 38,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74343,7 +74814,7 @@
         "column": 33,
         "context": "assign:_IMAGE_SAVER_CUSTOM_COUNTER_RE",
         "kind": "import_time_call",
-        "line": 38,
+        "line": 39,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74352,7 +74823,7 @@
         "column": 21,
         "context": "assign:_OUTPUT_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 39,
+        "line": 40,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74361,7 +74832,7 @@
         "column": 1,
         "context": "decorator:_ImageSaverRuntime",
         "kind": "import_time_call",
-        "line": 43,
+        "line": 44,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -76062,7 +76533,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 44,
+        "line": 51,
         "module": "easyuse_anima/aio/native_image_output.py",
         "name": "_SAVE_LOCK"
       },

--- a/tests/fixtures/python_file_disposition_contract.v1.json
+++ b/tests/fixtures/python_file_disposition_contract.v1.json
@@ -4,7 +4,7 @@
   "inventory_owner": {
     "path": "tests/fixtures/python_backend_baseline.json",
     "expected_baseline_files": 191,
-    "expected_target_files": 199
+    "expected_target_files": 200
   },
   "linked_contracts": {
     "compatibility_registry": "docs/architecture/python-compatibility-shims.md",
@@ -890,6 +890,11 @@
           "owner_group": "aio"
         },
         {
+          "path": "easyuse_anima/aio/native_metadata_budget.py",
+          "role": "aio-native-metadata-budget",
+          "owner_group": "aio"
+        },
+        {
           "path": "easyuse_anima/aio/native_output_publication.py",
           "role": "aio-native-output-publication",
           "owner_group": "aio"
@@ -904,8 +909,8 @@
         "tests/test_aio_native_image_output.py"
       ],
       "compatibility_registry_key": null,
-      "task_id": "ISSUE-689-694",
-      "rollback_unit": "Revert the cohesive Issue #689 resource split and Issue #694 publication extraction.",
+      "task_id": "ISSUE-689-694-696",
+      "rollback_unit": "Revert the cohesive Issue #689 resource split, Issue #694 publication extraction, and Issue #696 metadata-budget extraction.",
       "replacement_owner": null,
       "size_exception_verdicts": []
     },

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -15,6 +15,7 @@ from PIL import ExifTags, Image
 
 from easyuse_anima.aio import native_civitai as civitai
 from easyuse_anima.aio import native_image_output as native
+from easyuse_anima.aio import native_metadata_budget as metadata_budget
 from easyuse_anima.aio import native_output_publication as publication
 from easyuse_anima.aio import native_resource_hashes as resources
 
@@ -987,6 +988,227 @@ class AIONativeImageOutputTests(unittest.TestCase):
             self.assertEqual(result["ui"]["images"][0]["filename"], "image-only.png")
             self.assertTrue((root / "image-only.png").is_file())
             self.assertFalse((root / "image-only.json").exists())
+
+    def test_metadata_byte_limits_accept_boundary_and_reject_next_byte(self):
+        with patch.object(metadata_budget, "_MAX_PARAMETERS_BYTES", 16):
+            serialized = native._serialize_metadata(
+                extension="png",
+                parameters="x" * 16,
+                prompt=None,
+                extra_pnginfo=None,
+                embed_workflow=False,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+            self.assertEqual(serialized.embedded_size_bytes, 16)
+            with self.assertRaisesRegex(
+                metadata_budget.MetadataLimitError,
+                "A1111 parameters",
+            ):
+                native._serialize_metadata(
+                    extension="png",
+                    parameters="x" * 17,
+                    prompt=None,
+                    extra_pnginfo=None,
+                    embed_workflow=False,
+                    save_workflow_as_json=False,
+                    write_metadata=True,
+                )
+
+        with patch.object(metadata_budget, "_MAX_PROMPT_JSON_BYTES", 12):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt="x" * 10,
+                extra_pnginfo=None,
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+            with self.assertRaisesRegex(
+                metadata_budget.MetadataLimitError,
+                "prompt JSON",
+            ):
+                native._serialize_metadata(
+                    extension="png",
+                    parameters="",
+                    prompt="x" * 11,
+                    extra_pnginfo=None,
+                    embed_workflow=True,
+                    save_workflow_as_json=False,
+                    write_metadata=True,
+                )
+
+        with patch.object(metadata_budget, "_MAX_WORKFLOW_JSON_BYTES", 12):
+            serialized = native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt=None,
+                extra_pnginfo={"workflow": "x" * 10},
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+            self.assertIsNone(
+                serialized.workflow_json,
+                "embedded PNG workflow must not retain an unrequested pretty sidecar copy",
+            )
+            with self.assertRaisesRegex(
+                metadata_budget.MetadataLimitError,
+                "workflow JSON",
+            ):
+                native._serialize_metadata(
+                    extension="png",
+                    parameters="",
+                    prompt=None,
+                    extra_pnginfo={"workflow": "x" * 11},
+                    embed_workflow=True,
+                    save_workflow_as_json=False,
+                    write_metadata=True,
+                )
+
+    def test_metadata_structure_limits_depth_items_and_extra_keys(self):
+        deeply_nested = {"level": {"level": {"level": True}}}
+        with (
+            patch.object(metadata_budget, "_MAX_JSON_DEPTH", 2),
+            self.assertRaisesRegex(metadata_budget.MetadataLimitError, "level"),
+        ):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt=None,
+                extra_pnginfo={"workflow": deeply_nested},
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+
+        with (
+            patch.object(metadata_budget, "_MAX_JSON_ITEMS", 5),
+            self.assertRaisesRegex(metadata_budget.MetadataLimitError, "item"),
+        ):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt=list(range(5)),
+                extra_pnginfo=None,
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+
+        with (
+            patch.object(metadata_budget, "_MAX_JSON_STRING_BYTES", 4),
+            self.assertRaisesRegex(metadata_budget.MetadataLimitError, "string"),
+        ):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt="12345",
+                extra_pnginfo=None,
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+
+        with (
+            patch.object(metadata_budget, "_MAX_EXTRA_PNGINFO_KEYS", 2),
+            self.assertRaisesRegex(metadata_budget.MetadataLimitError, "key"),
+        ):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt=None,
+                extra_pnginfo={"workflow": {}, "one": 1, "two": 2},
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+
+        with (
+            patch.object(metadata_budget, "_MAX_EXTRA_PNGINFO_JSON_BYTES", 20),
+            self.assertRaisesRegex(
+                metadata_budget.MetadataLimitError,
+                "extra_pnginfo",
+            ),
+        ):
+            native._serialize_metadata(
+                extension="png",
+                parameters="",
+                prompt=None,
+                extra_pnginfo={"one": "x" * 8, "two": "y" * 8},
+                embed_workflow=True,
+                save_workflow_as_json=False,
+                write_metadata=True,
+            )
+
+    def test_batch_metadata_budget_rejects_before_image_encoding(self):
+        metadata = native.NativeImageMetadata("x" * 10, "", {})
+        pixels = np.zeros((2, 2, 3), dtype=np.float32)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with (
+                patch.object(metadata_budget, "_MAX_SAVE_METADATA_BYTES", 19),
+                patch.object(
+                    native,
+                    "_tensor_to_pil",
+                    side_effect=AssertionError("must reject before image encoding"),
+                ) as encode,
+                self.assertRaisesRegex(
+                    metadata_budget.MetadataLimitError,
+                    "batch metadata",
+                ),
+            ):
+                native._save_native_images(
+                    [FakeTensor(pixels), FakeTensor(pixels)],
+                    output_root=root,
+                    path="",
+                    filename="batch-limit",
+                    extension="png",
+                    quality_jpeg_or_webp=80,
+                    lossless_webp=False,
+                    optimize_png=False,
+                    embed_workflow=False,
+                    save_workflow_as_json=False,
+                    metadata=metadata,
+                    prompt=None,
+                    extra_pnginfo=None,
+                )
+
+            encode.assert_not_called()
+            self.assertEqual(list(root.iterdir()), [])
+
+    def test_jpeg_fallback_rejects_oversized_pretty_sidecar_before_publication(self):
+        metadata = native.NativeImageMetadata("parameters", "", {})
+        workflow = {"nodes": list(range(20))}
+        pixels = np.zeros((2, 2, 3), dtype=np.float32)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with (
+                patch.object(native, "_JPEG_EXIF_LIMIT", 20),
+                patch.object(metadata_budget, "_MAX_WORKFLOW_JSON_BYTES", 100),
+                self.assertRaisesRegex(
+                    metadata_budget.MetadataLimitError,
+                    "workflow JSON sidecar",
+                ),
+            ):
+                native._save_native_images(
+                    [FakeTensor(pixels)],
+                    output_root=root,
+                    path="",
+                    filename="jpeg-limit",
+                    extension="jpeg",
+                    quality_jpeg_or_webp=90,
+                    lossless_webp=False,
+                    optimize_png=False,
+                    embed_workflow=True,
+                    save_workflow_as_json=False,
+                    metadata=metadata,
+                    prompt=None,
+                    extra_pnginfo={"workflow": workflow},
+                )
+
+            self.assertEqual(list(root.iterdir()), [])
 
     def test_large_jpeg_workflow_falls_back_to_json_before_image_commit(self):
         metadata = native.NativeImageMetadata("short parameters", "", {})

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
 from easyuse_anima.aio import native_civitai as civitai
+from easyuse_anima.aio import native_metadata_budget as metadata_budget
 from easyuse_anima.aio import output, output_settings
 from easyuse_anima.aio.generation_defaults import AIO_GENERATION_DEFAULT_SETTINGS
 from tests.comfy_host_fakes import patch_comfy_helper
@@ -549,6 +550,39 @@ class AIOOutputMoveTests(unittest.TestCase):
         self.assertEqual(metadata.parameters, "")
         self.assertEqual(metadata.final_hashes, "")
         self.assertEqual(metadata.hashes, {})
+
+    def test_oversized_prompt_is_rejected_before_lora_metadata_expansion(self):
+        settings = {
+            "image_saver": {
+                **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                "filename": "frame",
+                "path": "EasyUseAnima/Test",
+            }
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch.object(
+                    output,
+                    "_validate_parameter_sources",
+                    side_effect=metadata_budget.MetadataLimitError("too large"),
+                ),
+                patch.object(output, "_aio_prompt_with_lora_metadata") as expand,
+                patch.object(output, "_save_native_images") as save,
+                self.assertRaises(metadata_budget.MetadataLimitError),
+            ):
+                output._save_image_with_image_saver(
+                    images="images",
+                    save_settings=settings,
+                    positive_prompt="oversized",
+                    negative_prompt="",
+                    width=512,
+                    height=512,
+                    sampler_settings={"seed": 1},
+                )
+
+        expand.assert_not_called()
+        save.assert_not_called()
 
     def test_image_saver_rejects_expanded_output_escape_before_dependency_lookup(self):
         cases = (

--- a/tests/test_python_file_disposition_contract.py
+++ b/tests/test_python_file_disposition_contract.py
@@ -60,9 +60,9 @@ class PythonFileDispositionContractTests(unittest.TestCase):
         self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
         contract = self.validate(self.document)
         self.assertEqual(contract["expected_baseline_files"], 191)
-        self.assertEqual(contract["expected_target_files"], 199)
+        self.assertEqual(contract["expected_target_files"], 200)
         self.assertEqual(len(contract["entries"]), 191)
-        self.assertEqual(len(contract["target_paths"]), 199)
+        self.assertEqual(len(contract["target_paths"]), 200)
 
     def test_inventory_requires_every_source_exactly_once(self):
         missing = copy.deepcopy(self.document)


### PR DESCRIPTION
## 목적과 변경 경계

Closes #696.

- workflow-controlled image metadata에 구조 및 바이트 예산을 적용합니다.
- 제한 검사는 Pillow 인코딩과 출력 게시 트랜잭션 전에 수행합니다.
- PNG/WebP는 요청하지 않은 pretty workflow 복사본을 만들지 않고 compact 표현을 재사용합니다.
- JPEG EXIF fallback sidecar와 batch 반복 메타데이터에도 동일한 상한을 적용합니다.

## Base -> Head

`a37642a854d8751f1972aaf8ea9120caf7a030db` -> `beb2f6b`

## 주요 파일과 보존 계약

- `easyuse_anima/aio/native_metadata_budget.py`: depth/item/string/key/field/per-image/per-save 제한과 bounded JSON encoding 소유
- `easyuse_anima/aio/native_image_output.py`: 모든 포맷 및 JPEG sidecar fallback에 제한 적용
- `easyuse_anima/aio/output.py`: LoRA 메타데이터 확장 전 A1111 source prompt 제한 적용
- 기존 PNG/JPEG/WebP round trip, global `disable_metadata`, 정상 workflow 저장 동작은 유지합니다.

적용 상한: A1111 512 KiB, prompt 2 MiB, workflow 4 MiB, extra PNG info 6 MiB/128 keys, embedded 8 MiB/image, repeated metadata 64 MiB/save.

## 검증

- focused: native image output 35 passed
- focused: AiO output 16 passed
- focused: backend analyzer 19 passed
- focused: file disposition 7 passed
- changed-file Ruff: passed
- quick project gate: passed (frontend 121 files)
- full project gate at `beb2f6b`: Python 1,575 passed, 2 skipped; frontend 121 files; Pyright/import/size/disposition/support/diff gates passed
- runtime baseline: ComfyUI v0.34.0 (`12d5279438bfefc058a269eae805ceab6047777f`), frontend 1.49.6

## 남은 위험과 rollback

- 명시적 상한보다 큰 비정상 workflow는 이제 저장 대신 오류로 중단됩니다. 이는 메모리/디스크 증폭 차단을 위한 의도된 보안 경계입니다.
- rollback 단위는 이 PR의 단일 squash commit입니다.

## Next

- #691 JPEG workflow import/restore 경계를 구현합니다.
