### PR TITLE
docs(aio): remove stale Image Saver dependency

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -86,9 +86,11 @@ Basic wiring:
 The compact node surface exposes seed, steps, CFG, shift, denoise, sampler,
 scheduler, Highres, Detailer, Preview, and Save. Model patches and optimization
 belong in `Advanced Options`, save metadata belongs in `Save Options`, and image
-comparison/feed controls live in Preview settings. Saving is enabled by default;
-with Image Saver, workflow embedding and Civitai/LoRA metadata are handled in
-the same output path.
+comparison/feed controls live in Preview settings. Saving is enabled by default.
+EasyUse's native output backend handles PNG, JPEG, and WebP, workflow
+embedding/JSON sidecars, A1111 metadata, and Civitai-compatible model/LoRA
+hashes in the same output path. `ComfyUI-Image-Saver` is not required by AiO
+Save Options.
 
 Detailed settings: [Anima AiO Generator guide](docs/nodes/anima-aio-generator.en.md)
 
@@ -200,7 +202,6 @@ Related node packs:
 - [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes): Used for optimization options such as Torch Compile and SageAttention.
 - [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack): Required for Impact detailer and AiO SAM3 detailer flows.
 - [ComfyUI-Lora-Manager](https://github.com/willmiao/ComfyUI-Lora-Manager): Recommended for LoRA trigger-word and metadata management.
-- [ComfyUI-Image-Saver](https://github.com/alexopus/ComfyUI-Image-Saver): Used by AiO Save Options for workflow embedding and Civitai/LoRA metadata.
 - [ComfyUI-Anima-DAVE](https://github.com/sorryhyun/ComfyUI-Anima-DAVE): Optional model patch for generation diversity.
 
 Install Python dependency:

--- a/README.ko.md
+++ b/README.ko.md
@@ -85,8 +85,10 @@ Detailer, 미리보기, 이미지 저장을 한 노드에서 처리합니다. �
 기본 노드 화면에서는 seed, steps, CFG, shift, denoise, sampler, scheduler,
 Highres, Detailer, Preview, Save만 조작합니다. 모델 패치와 최적화는
 `Advanced Options`, 저장 메타데이터는 `Save Options`, 이미지 비교와 피드는
-Preview 설정에서 관리합니다. 저장은 기본 ON이며, Image Saver를 사용하면
-workflow embed와 Civitai/LoRA metadata 저장까지 한 번에 처리할 수 있습니다.
+Preview 설정에서 관리합니다. 저장은 기본 ON입니다. EasyUse 네이티브 출력
+backend가 PNG, JPEG, WebP 저장, workflow embed/JSON sidecar, A1111 metadata,
+Civitai 호환 model/LoRA hash를 같은 출력 경로에서 처리합니다. AiO Save
+Options에 `ComfyUI-Image-Saver`는 필요하지 않습니다.
 
 자세한 설정 기준: [Anima AiO Generator 문서](docs/nodes/anima-aio-generator.ko.md)
 
@@ -197,7 +199,6 @@ dependency이므로 `pyproject.toml`의 Python dependencies에는 넣지 않습�
 - [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes): Torch Compile, SageAttention 등 최적화 옵션에 사용합니다.
 - [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack): Impact detailer, AiO SAM3 detailer 흐름에 필요합니다.
 - [ComfyUI-Lora-Manager](https://github.com/willmiao/ComfyUI-Lora-Manager): LoRA trigger word와 metadata 관리에 권장합니다.
-- [ComfyUI-Image-Saver](https://github.com/alexopus/ComfyUI-Image-Saver): AiO Save Options에서 workflow embed, Civitai/LoRA metadata 저장에 사용합니다.
 - [ComfyUI-Anima-DAVE](https://github.com/sorryhyun/ComfyUI-Anima-DAVE): 생성 다양성을 위한 선택 model patch입니다.
 
 Python dependency 설치:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -32,6 +32,18 @@ AIO_NATIVE_OUTPUT_WORKFLOWS = (
     EXAMPLE_WORKFLOW_DIR / "ANIMA_Easy_Use_workflow_v1_release_ko.json",
     EXAMPLE_WORKFLOW_DIR / "ANIMA_Easy_Use_workflow_v1_release_en.json",
 )
+CURRENT_README_NATIVE_OUTPUT_CONTRACTS = (
+    (
+        ROOT / "README.en.md",
+        "EasyUse's native output backend handles PNG, JPEG, and WebP",
+        "`ComfyUI-Image-Saver` is not required by AiO Save Options.",
+    ),
+    (
+        ROOT / "README.ko.md",
+        "EasyUse 네이티브 출력 backend가 PNG, JPEG, WebP 저장",
+        "AiO Save Options에 `ComfyUI-Image-Saver`는 필요하지 않습니다.",
+    ),
+)
 MOJIBAKE_LATIN1_RE = re.compile(r"[\u0080-\u00ff]")
 PACKAGE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[.-][0-9A-Za-z]+)*$")
 
@@ -177,6 +189,20 @@ class ReleaseWorkflowTests(unittest.TestCase):
                     metadata.get("sampler_paths"),
                     ["comfy_ksampler", "spectrum_mod_guidance_advanced", "spectrum_spd_speed"],
                 )
+
+    def test_current_readmes_use_native_aio_output_contract(self):
+        image_saver_repository = "https://github.com/alexopus/ComfyUI-Image-Saver"
+        for (
+            path,
+            native_contract,
+            no_dependency_contract,
+        ) in CURRENT_README_NATIVE_OUTPUT_CONTRACTS:
+            with self.subTest(path=path.name):
+                text = path.read_text(encoding="utf-8")
+                normalized = " ".join(text.split())
+                self.assertIn(native_contract, normalized)
+                self.assertIn(no_dependency_contract, normalized)
+                self.assertNotIn(image_saver_repository, text)
 
     def test_current_aio_samples_keep_remote_civitai_enrichment_opt_in(self):
         for workflow_path in AIO_NATIVE_OUTPUT_WORKFLOWS:


### PR DESCRIPTION
## 목적과 변경 경계

현재 AiO Save Options가 외부 Image Saver를 사용한다는 영문·한글 README의 오래된 안내를 EasyUse 네이티브 출력 계약으로 바로잡습니다.

Closes #688

Base `3ba6fd8e007b47e96bd85769445fe4634aaef069` (`dev`) -> Head `79d54093158b620a5e914645cc9493b85c7078fb`

## 주요 변경

- 영문·한글 quick guide에 EasyUse 네이티브 PNG/JPEG/WebP 출력, workflow embed/JSON sidecar, A1111 metadata, Civitai-compatible model/LoRA hash 기능 명시
- 현재 AiO 관련 node-pack 목록에서 `ComfyUI-Image-Saver` 링크와 필수 의존 설명 제거
- 외부 node pack이 AiO Save Options에 필요하지 않다는 안내 유지
- 두 README의 native backend 문구와 외부 Image Saver 저장소 링크 부재를 고정하는 회귀 테스트 추가

## 보존 계약

- standalone legacy workflow와 과거 release 문서의 실제 Image Saver node 요구는 변경하지 않음
- 기존 profile/workflow의 `save.image_saver` 호환 key는 변경하지 않음
- runtime 코드는 변경하지 않음

## 검증

- focused README native-output contract 통과
- exact README Image Saver/reference search 확인
- quick profile 통과
- full profile 통과: Python 1,577 passed / 2 skipped, frontend 123 JavaScript files, TypeScript 6.0.3, `git diff --check`

## 남은 위험과 rollback

- 문서·회귀 계약만 변경하므로 runtime 위험은 없음
- rollback은 이 PR의 squash commit 하나를 revert하면 됨

## Next

- PR 리뷰 후 `dev`에 squash merge
