### PR TITLE
fix(aio): make native output filenames Windows-safe

### DIFF
--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -48,6 +48,12 @@ _MAX_REMOTE_RESOURCES = 32
 _USER_COMMENT_PREFIX = b"UNICODE\0"
 _LORA_TAG_RE = re.compile(r"<lora:([^>:]+)(?::([^>]+))?>", re.IGNORECASE)
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_WINDOWS_INVALID_COMPONENT_RE = re.compile(r'[<>:"|?*\x00-\x1f\x7f]')
+_WINDOWS_RESERVED_COMPONENTS = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{index}" for index in range(1, 10)}
+    | {f"lpt{index}" for index in range(1, 10)}
+)
 _SAVE_LOCK = threading.Lock()
 
 _CIVITAI_SAMPLER_NAMES = MappingProxyType({
@@ -413,6 +419,31 @@ def _tensor_to_pil(image: object):
     return Image.fromarray(pixels)
 
 
+def _is_windows_safe_output_component(value: str) -> bool:
+    text = str(value or "")
+    if (
+        not text
+        or text in {".", ".."}
+        or text.endswith((" ", "."))
+        or _WINDOWS_INVALID_COMPONENT_RE.search(text)
+    ):
+        return False
+    device_name = text.split(".", 1)[0].rstrip(" ").casefold()
+    return device_name not in _WINDOWS_RESERVED_COMPONENTS
+
+
+def _sanitize_native_output_filename(value: str) -> str:
+    text = str(value or "").strip()
+    if "/" in text or "\\" in text:
+        raise RuntimeError(
+            "[EasyUseAnima] AiO save filename must be a single filename component."
+        )
+    text = _WINDOWS_INVALID_COMPONENT_RE.sub("", text).rstrip(" .")
+    if not _is_windows_safe_output_component(text):
+        raise RuntimeError("[EasyUseAnima] AiO save filename is invalid on Windows.")
+    return text
+
+
 def _allocate_filenames(
     output_folder: Path,
     filename: str,
@@ -472,7 +503,12 @@ def _resolve_native_output_folder(output_root: Path, path: str) -> tuple[Path, P
         posix_path.is_absolute()
         or windows_path.drive
         or windows_path.root
-        or any(part in {".", ".."} or ":" in part for part in parts)
+        or any(
+            part in {".", ".."}
+            or ":" in part
+            or not _is_windows_safe_output_component(part)
+            for part in parts
+        )
     ):
         raise RuntimeError(
             "[EasyUseAnima] AiO save path must stay within the ComfyUI output directory."
@@ -559,15 +595,8 @@ def _save_native_images(
     safe_extension = str(extension or "").casefold()
     if safe_extension not in {"png", "jpg", "jpeg", "webp"}:
         raise RuntimeError("[EasyUseAnima] AiO save extension is invalid.")
-    if (
-        not filename
-        or filename in {".", ".."}
-        or len(f"{filename}.{safe_extension}") > 255
-        or "/" in filename
-        or "\\" in filename
-        or ":" in filename
-        or _CONTROL_RE.search(filename)
-    ):
+    safe_filename = _sanitize_native_output_filename(filename)
+    if len(f"{safe_filename}.{safe_extension}") > 255:
         raise RuntimeError("[EasyUseAnima] AiO save filename is invalid.")
     resolved_folder, relative_folder = _resolve_native_output_folder(output_root, path)
 
@@ -594,7 +623,7 @@ def _save_native_images(
     with _SAVE_LOCK, OutputDirectoryBinding(resolved_folder) as directory:
         pending_names = _allocate_filenames(
             resolved_folder,
-            filename,
+            safe_filename,
             safe_extension,
             len(batch),
             sidecar_required=sidecar_required,
@@ -636,7 +665,7 @@ def _save_native_images(
                 directory.assert_current()
                 pending_names[index:] = _allocate_filenames(
                     resolved_folder,
-                    filename,
+                    safe_filename,
                     safe_extension,
                     len(batch) - index,
                     sidecar_required=sidecar_required,

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -21,6 +21,8 @@ from .native_image_output import (
     _build_native_metadata,
     _comfy_metadata_enabled,
     _fetch_civitai_autov3_hash,
+    _is_windows_safe_output_component,
+    _sanitize_native_output_filename,
     _save_native_images,
 )
 from .native_metadata_budget import _validate_parameter_sources
@@ -119,6 +121,7 @@ def _output_path_parts(value: str, *, field: str, allow_empty: bool) -> list[str
         not parts
         or any(part in {".", ".."} for part in parts)
         or any(":" in part for part in parts)
+        or any(not _is_windows_safe_output_component(part) for part in parts)
     ):
         raise RuntimeError(
             f"[EasyUseAnima] AiO save {field} must stay within the ComfyUI output directory."
@@ -289,6 +292,7 @@ def _resolve_image_saver_runtime(
     )
     if not rendered_filename:
         rendered_filename = _image_saver_timestamp(now, time_format)
+    rendered_filename = _sanitize_native_output_filename(rendered_filename)
     output_root = _comfy_output_directory()
     safe_path = _validated_output_subpath(
         rendered_path,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9699,7 +9699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 292
+            "line": 298
           }
         ],
         "classification": "external",
@@ -9707,7 +9707,7 @@
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 293,
+        "line": 299,
         "name": "args",
         "optional": true,
         "requested": "comfy.cli_args",
@@ -9724,7 +9724,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 309,
+        "line": 315,
         "name": "ExifTags",
         "optional": false,
         "requested": "PIL",
@@ -9741,7 +9741,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 309,
+        "line": 315,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -9756,7 +9756,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 345,
+            "line": 351,
             "type_checking": false
           }
         ],
@@ -9765,7 +9765,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 346,
+        "line": 352,
         "name": "PngInfo",
         "optional": false,
         "requested": "PIL.PngImagePlugin",
@@ -9782,7 +9782,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 395,
+        "line": 401,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -9799,7 +9799,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 396,
+        "line": 402,
         "name": "Image",
         "optional": false,
         "requested": "PIL",
@@ -11489,6 +11489,42 @@
       },
       {
         "alias": null,
+        "bound_name": "_is_windows_safe_output_component",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_image_output:_is_windows_safe_output_component",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_is_windows_safe_output_component",
+        "optional": false,
+        "requested": ".native_image_output",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_sanitize_native_output_filename",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".native_image_output:_sanitize_native_output_filename",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_sanitize_native_output_filename",
+        "optional": false,
+        "requested": ".native_image_output",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/native_image_output.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_save_native_images",
         "branch_context": [],
         "classification": "internal",
@@ -11514,7 +11550,7 @@
         "conditional": false,
         "imported": ".native_metadata_budget:_validate_parameter_sources",
         "kind": "static_from",
-        "line": 26,
+        "line": 28,
         "name": "_validate_parameter_sources",
         "optional": false,
         "requested": ".native_metadata_budget",
@@ -11532,7 +11568,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 27,
+        "line": 29,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".output_settings",
@@ -11550,7 +11586,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 30,
+        "line": 32,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -11568,7 +11604,7 @@
         "conditional": false,
         "imported": ".sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 33,
+        "line": 35,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".sampling",
@@ -11586,7 +11622,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 81
+            "line": 83
           }
         ],
         "classification": "external",
@@ -11594,7 +11630,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 82,
+        "line": 84,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11611,7 +11647,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 159
+            "line": 162
           }
         ],
         "classification": "external",
@@ -11619,7 +11655,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 160,
+        "line": 163,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11636,7 +11672,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 437
+            "line": 441
           }
         ],
         "classification": "external",
@@ -11644,7 +11680,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 438,
+        "line": 442,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -50232,150 +50268,166 @@
         "functions": [
           {
             "async": false,
-            "end_line": 88,
+            "end_line": 94,
             "kind": "function",
-            "line": 82,
+            "line": 88,
             "loc": 7,
             "qualified_name": "_compact_json"
           },
           {
             "async": false,
-            "end_line": 98,
+            "end_line": 104,
             "kind": "function",
-            "line": 91,
+            "line": 97,
             "loc": 8,
             "qualified_name": "_clean_prompt_for_remix"
           },
           {
             "async": false,
-            "end_line": 96,
+            "end_line": 102,
             "kind": "function",
-            "line": 94,
+            "line": 100,
             "loc": 3,
             "qualified_name": "_clean_prompt_for_remix.simplify_embedding"
           },
           {
             "async": false,
-            "end_line": 111,
+            "end_line": 117,
             "kind": "function",
-            "line": 101,
+            "line": 107,
             "loc": 11,
             "qualified_name": "_civitai_sampler_name"
           },
           {
             "async": false,
-            "end_line": 169,
+            "end_line": 175,
             "kind": "function",
-            "line": 114,
+            "line": 120,
             "loc": 56,
             "qualified_name": "_civitai_resource_entries"
           },
           {
             "async": false,
-            "end_line": 288,
+            "end_line": 294,
             "kind": "function",
-            "line": 172,
+            "line": 178,
             "loc": 117,
             "qualified_name": "_build_native_metadata"
           },
           {
             "async": false,
-            "end_line": 297,
+            "end_line": 303,
             "kind": "function",
-            "line": 291,
+            "line": 297,
             "loc": 7,
             "qualified_name": "_comfy_metadata_enabled"
           },
           {
             "async": false,
-            "end_line": 301,
+            "end_line": 307,
             "kind": "function",
-            "line": 300,
+            "line": 306,
             "loc": 2,
             "qualified_name": "_encode_user_comment"
           },
           {
             "async": false,
-            "end_line": 321,
+            "end_line": 327,
             "kind": "function",
-            "line": 304,
+            "line": 310,
             "loc": 18,
             "qualified_name": "_build_exif_bytes"
           },
           {
             "async": false,
-            "end_line": 391,
+            "end_line": 397,
             "kind": "function",
-            "line": 324,
+            "line": 330,
             "loc": 68,
             "qualified_name": "_serialize_metadata"
           },
           {
             "async": false,
-            "end_line": 413,
+            "end_line": 419,
             "kind": "function",
-            "line": 394,
+            "line": 400,
             "loc": 20,
             "qualified_name": "_tensor_to_pil"
           },
           {
             "async": false,
-            "end_line": 461,
+            "end_line": 432,
             "kind": "function",
-            "line": 416,
+            "line": 422,
+            "loc": 11,
+            "qualified_name": "_is_windows_safe_output_component"
+          },
+          {
+            "async": false,
+            "end_line": 444,
+            "kind": "function",
+            "line": 435,
+            "loc": 10,
+            "qualified_name": "_sanitize_native_output_filename"
+          },
+          {
+            "async": false,
+            "end_line": 492,
+            "kind": "function",
+            "line": 447,
             "loc": 46,
             "qualified_name": "_allocate_filenames"
           },
           {
             "async": false,
-            "end_line": 429,
+            "end_line": 460,
             "kind": "function",
-            "line": 425,
+            "line": 456,
             "loc": 5,
             "qualified_name": "_allocate_filenames.occupied"
           },
           {
             "async": false,
-            "end_line": 498,
+            "end_line": 534,
             "kind": "function",
-            "line": 464,
-            "loc": 35,
+            "line": 495,
+            "loc": 40,
             "qualified_name": "_resolve_native_output_folder"
           },
           {
             "async": false,
-            "end_line": 521,
+            "end_line": 557,
             "kind": "function",
-            "line": 501,
+            "line": 537,
             "loc": 21,
             "qualified_name": "_image_save_options"
           },
           {
             "async": false,
-            "end_line": 536,
+            "end_line": 572,
             "kind": "function",
-            "line": 524,
+            "line": 560,
             "loc": 13,
             "qualified_name": "_validated_sidecar_requirement"
           },
           {
             "async": false,
-            "end_line": 658,
+            "end_line": 687,
             "kind": "function",
-            "line": 539,
-            "loc": 120,
+            "line": 575,
+            "loc": 113,
             "qualified_name": "_save_native_images"
           }
         ],
         "is_package": false,
-        "loc": 661,
+        "loc": 690,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "db5dc7a0f962848f35bfd68ad830847b91d03eb2",
+        "normalized_git_blob_sha1": "def9e3abde59a6803c710f45bd376a35fdb70ae0",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 15,
-          "global_count": 9
+          "function_count": 17,
+          "global_count": 11
         }
       },
       {
@@ -51142,153 +51194,153 @@
         "functions": [
           {
             "async": false,
-            "end_line": 69,
+            "end_line": 71,
             "kind": "function",
-            "line": 66,
+            "line": 68,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 77,
+            "end_line": 79,
             "kind": "function",
-            "line": 72,
+            "line": 74,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 98,
+            "end_line": 100,
             "kind": "function",
-            "line": 80,
+            "line": 82,
             "loc": 19,
             "qualified_name": "_comfy_output_directory"
           },
           {
             "async": false,
-            "end_line": 126,
+            "end_line": 129,
             "kind": "function",
-            "line": 101,
-            "loc": 26,
+            "line": 103,
+            "loc": 27,
             "qualified_name": "_output_path_parts"
           },
           {
             "async": false,
-            "end_line": 153,
+            "end_line": 156,
             "kind": "function",
-            "line": 129,
+            "line": 132,
             "loc": 25,
             "qualified_name": "_validated_output_subpath"
           },
           {
             "async": false,
-            "end_line": 166,
+            "end_line": 169,
             "kind": "function",
-            "line": 156,
+            "line": 159,
             "loc": 11,
             "qualified_name": "_image_saver_model_names"
           },
           {
             "async": false,
-            "end_line": 173,
+            "end_line": 176,
             "kind": "function",
-            "line": 169,
+            "line": 172,
             "loc": 5,
             "qualified_name": "_image_saver_timestamp"
           },
           {
             "async": false,
-            "end_line": 237,
+            "end_line": 240,
             "kind": "function",
-            "line": 176,
+            "line": 179,
             "loc": 62,
             "qualified_name": "_render_image_saver_template"
           },
           {
             "async": false,
-            "end_line": 199,
+            "end_line": 202,
             "kind": "function",
-            "line": 198,
+            "line": 201,
             "loc": 2,
             "qualified_name": "_render_image_saver_template.replace_time"
           },
           {
             "async": false,
-            "end_line": 207,
+            "end_line": 210,
             "kind": "function",
-            "line": 201,
+            "line": 204,
             "loc": 7,
             "qualified_name": "_render_image_saver_template.replace_counter"
           },
           {
             "async": false,
-            "end_line": 327,
+            "end_line": 331,
             "kind": "function",
-            "line": 240,
-            "loc": 88,
+            "line": 243,
+            "loc": 89,
             "qualified_name": "_resolve_image_saver_runtime"
           },
           {
             "async": false,
-            "end_line": 405,
+            "end_line": 409,
             "kind": "function",
-            "line": 330,
+            "line": 334,
             "loc": 76,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 429,
+            "end_line": 433,
             "kind": "function",
-            "line": 408,
+            "line": 412,
             "loc": 22,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 445,
+            "end_line": 449,
             "kind": "function",
-            "line": 432,
+            "line": 436,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 463,
+            "end_line": 467,
             "kind": "function",
-            "line": 448,
+            "line": 452,
             "loc": 16,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 488,
+            "end_line": 492,
             "kind": "function",
-            "line": 466,
+            "line": 470,
             "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 500,
+            "end_line": 504,
             "kind": "function",
-            "line": 491,
+            "line": 495,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 609,
+            "end_line": 613,
             "kind": "function",
-            "line": 503,
+            "line": 507,
             "loc": 107,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 612,
+        "loc": 616,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "f159e7c3460e3839beec04c65bfe94a93fa49b54",
+        "normalized_git_blob_sha1": "f84d2a924da6effd590c466f0272f2d46429064a",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,
@@ -64138,14 +64190,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 292
+            "line": 298
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 293,
+        "line": 299,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64156,7 +64208,7 @@
         "conditional": false,
         "imported": "PIL:ExifTags",
         "kind": "static_from",
-        "line": 309,
+        "line": 315,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64167,7 +64219,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 309,
+        "line": 315,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64177,7 +64229,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 345,
+            "line": 351,
             "type_checking": false
           }
         ],
@@ -64185,7 +64237,7 @@
         "conditional": true,
         "imported": "PIL.PngImagePlugin:PngInfo",
         "kind": "static_from",
-        "line": 346,
+        "line": 352,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64196,7 +64248,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 395,
+        "line": 401,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -64207,7 +64259,7 @@
         "conditional": false,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 396,
+        "line": 402,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -65119,14 +65171,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 81
+            "line": 83
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 82,
+        "line": 84,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65138,14 +65190,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 159
+            "line": 162
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 160,
+        "line": 163,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65157,14 +65209,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 437
+            "line": 441
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 438,
+        "line": 442,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -71853,14 +71905,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 292
+            "line": 298
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.cli_args:args",
         "kind": "static_from",
-        "line": 293,
+        "line": 299,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_image_output.py"
@@ -72024,14 +72076,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 81
+            "line": 83
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 82,
+        "line": 84,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72043,14 +72095,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 159
+            "line": 162
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 160,
+        "line": 163,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72062,14 +72114,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 437
+            "line": 441
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 438,
+        "line": 442,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -74585,11 +74637,47 @@
         "scope": "<module>"
       },
       {
+        "callee": "re.compile",
+        "column": 32,
+        "context": "assign:_WINDOWS_INVALID_COMPONENT_RE",
+        "kind": "import_time_call",
+        "line": 51,
+        "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 31,
+        "context": "assign:_WINDOWS_RESERVED_COMPONENTS",
+        "kind": "import_time_call",
+        "line": 52,
+        "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "range",
+        "column": 34,
+        "context": "assign:_WINDOWS_RESERVED_COMPONENTS",
+        "kind": "import_time_call",
+        "line": 54,
+        "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "range",
+        "column": 34,
+        "context": "assign:_WINDOWS_RESERVED_COMPONENTS",
+        "kind": "import_time_call",
+        "line": 55,
+        "module": "easyuse_anima/aio/native_image_output.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "threading.Lock",
         "column": 13,
         "context": "assign:_SAVE_LOCK",
         "kind": "import_time_call",
-        "line": 51,
+        "line": 57,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74598,7 +74686,7 @@
         "column": 25,
         "context": "assign:_CIVITAI_SAMPLER_NAMES",
         "kind": "import_time_call",
-        "line": 53,
+        "line": 59,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74607,7 +74695,7 @@
         "column": 1,
         "context": "decorator:NativeImageMetadata",
         "kind": "import_time_call",
-        "line": 65,
+        "line": 71,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74616,7 +74704,7 @@
         "column": 1,
         "context": "decorator:_SerializedMetadata",
         "kind": "import_time_call",
-        "line": 72,
+        "line": 78,
         "module": "easyuse_anima/aio/native_image_output.py",
         "scope": "<module>"
       },
@@ -74796,7 +74884,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 35,
+        "line": 37,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74805,7 +74893,7 @@
         "column": 30,
         "context": "assign:_IMAGE_SAVER_CUSTOM_TIME_RE",
         "kind": "import_time_call",
-        "line": 38,
+        "line": 40,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74814,7 +74902,7 @@
         "column": 33,
         "context": "assign:_IMAGE_SAVER_CUSTOM_COUNTER_RE",
         "kind": "import_time_call",
-        "line": 39,
+        "line": 41,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74823,7 +74911,7 @@
         "column": 21,
         "context": "assign:_OUTPUT_CONTROL_RE",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 42,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -74832,7 +74920,7 @@
         "column": 1,
         "context": "decorator:_ImageSaverRuntime",
         "kind": "import_time_call",
-        "line": 44,
+        "line": 46,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },
@@ -76533,7 +76621,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 51,
+        "line": 57,
         "module": "easyuse_anima/aio/native_image_output.py",
         "name": "_SAVE_LOCK"
       },

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -841,6 +841,60 @@ class AIONativeImageOutputTests(unittest.TestCase):
                                 workflow,
                             )
 
+    def test_png_jpeg_and_webp_publish_sanitized_windows_filenames(self):
+        metadata = native.NativeImageMetadata("parameters", "", {})
+        pixels = np.zeros((2, 2, 3), dtype=np.float32)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for extension in ("png", "jpeg", "webp"):
+                with self.subTest(extension=extension):
+                    result = native._save_native_images(
+                        [FakeTensor(pixels)],
+                        output_root=root,
+                        path=extension,
+                        filename='bad<>:"|?*name. ',
+                        extension=extension,
+                        quality_jpeg_or_webp=80,
+                        lossless_webp=False,
+                        optimize_png=False,
+                        embed_workflow=False,
+                        save_workflow_as_json=False,
+                        metadata=metadata,
+                        prompt=None,
+                        extra_pnginfo=None,
+                    )
+
+                    image_record = result["ui"]["images"][0]
+                    self.assertEqual(image_record["filename"], f"badname.{extension}")
+                    self.assertTrue((root / extension / f"badname.{extension}").is_file())
+
+    def test_native_writer_rejects_windows_reserved_filename_before_publication(self):
+        metadata = native.NativeImageMetadata("parameters", "", {})
+        pixels = np.zeros((2, 2, 3), dtype=np.float32)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for filename in ("NUL.txt", "con", "aux.log", "CON?"):
+                with self.subTest(filename=filename), self.assertRaisesRegex(
+                    RuntimeError, "invalid on Windows"
+                ):
+                    native._save_native_images(
+                        [FakeTensor(pixels)],
+                        output_root=root,
+                        path="",
+                        filename=filename,
+                        extension="png",
+                        quality_jpeg_or_webp=80,
+                        lossless_webp=False,
+                        optimize_png=False,
+                        embed_workflow=False,
+                        save_workflow_as_json=False,
+                        metadata=metadata,
+                        prompt=None,
+                        extra_pnginfo=None,
+                    )
+
+            self.assertEqual(list(root.iterdir()), [])
+
     def test_png_extra_metadata_cannot_override_owned_parameters_or_prompt(self):
         metadata = native.NativeImageMetadata("owned parameters", "", {})
         pixels = np.zeros((2, 2, 3), dtype=np.float32)
@@ -1250,7 +1304,16 @@ class AIONativeImageOutputTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp) / "output"
             outside = Path(temp) / "outside"
-            for unsafe_path in ("../outside", "nested/../outside", "/absolute", "C:\\absolute"):
+            for unsafe_path in (
+                "../outside",
+                "nested/../outside",
+                "/absolute",
+                "C:\\absolute",
+                "nested/bad?folder",
+                "nested/CON",
+                "nested/aux.txt",
+                "nested/trailing./child",
+            ):
                 with self.subTest(path=unsafe_path), self.assertRaisesRegex(
                     RuntimeError, "output directory"
                 ):

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -510,6 +510,39 @@ class AIOOutputMoveTests(unittest.TestCase):
         self.assertEqual(save.call_args.kwargs["path"], "renders/2026/09")
         self.assertEqual(save.call_args.kwargs["filename"], "safe_007_anima")
 
+    def test_image_saver_sanitizes_windows_filename_before_native_writer(self):
+        settings = {
+            "image_saver": {
+                **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                "path": "EasyUseAnima/Test",
+                "filename": 'bad<>:"|?*name. ',
+            }
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            with (
+                patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
+                patch.object(output, "_resolve_aio_runtime_seed", return_value=11),
+                patch.object(output, "_build_native_metadata", return_value=object()),
+                patch.object(
+                    output,
+                    "_save_native_images",
+                    return_value="saved",
+                ) as save,
+            ):
+                result = output._save_image_with_image_saver(
+                    images="images",
+                    save_settings=settings,
+                    positive_prompt="positive",
+                    negative_prompt="negative",
+                    width=768,
+                    height=1024,
+                    sampler_settings={"seed": 11},
+                    resource_info={"unet_name": "anima.safetensors"},
+                )
+
+        self.assertEqual(result, "saved")
+        self.assertEqual(save.call_args.kwargs["filename"], "badname")
+
     def test_metadata_disabled_skips_hashing_and_civitai_work(self):
         settings = {
             "image_saver": {
@@ -590,9 +623,14 @@ class AIOOutputMoveTests(unittest.TestCase):
             {"path": "..\\..\\outside"},
             {"path": "C:\\outside"},
             {"path": "/outside"},
+            {"path": "safe/bad?folder"},
+            {"path": "safe/CON"},
+            {"path": "safe/aux.txt"},
+            {"path": "safe/trailing./child"},
             {"path": "%custom", "custom": "../../outside"},
             {"path": "%time", "time_format": "../outside"},
             {"filename": "%custom", "custom": "../outside"},
+            {"filename": "NUL.txt"},
         )
         save = Mock(side_effect=AssertionError("must reject before native writer"))
         with tempfile.TemporaryDirectory() as temp:
@@ -609,7 +647,10 @@ class AIOOutputMoveTests(unittest.TestCase):
                         patch.object(output, "_save_native_images", save),
                         patch.object(output, "_resolve_aio_runtime_seed", return_value=11),
                     ):
-                        with self.assertRaisesRegex(RuntimeError, "output directory|single filename"):
+                        with self.assertRaisesRegex(
+                            RuntimeError,
+                            "output directory|single filename|invalid on Windows",
+                        ):
                             output._save_image_with_image_saver(
                                 images="images",
                                 save_settings=settings,


### PR DESCRIPTION
Purpose and boundary

Close the remaining native Image Saver parity gap tracked in #705: rendered basenames could contain Windows-invalid characters or reserved device names.

Base -> Head

- dev -> codex/native-output-windows-paths

Changes and preserved contracts

- Sanitize Windows-invalid basename characters before native publication.
- Reject reserved device names and unsafe output-directory components at both adapter and native-writer boundaries.
- Preserve path-containment rejection, collision allocation, batch naming, sidecars, and existing workflow settings.

Validation

- Focused adapter, native publication, reserved-name, traversal, metadata round-trip, and batch/sidecar allocation tests: PASS.
- Changed-file Ruff 0.15.22: PASS.
- Repository quick profile: PASS; existing report-only baseline findings unchanged.
- git diff --check: PASS.
- Full profile: pending on the PR candidate SHA.

Risk and rollback

- User-visible filenames containing Windows-invalid characters are normalized by removing those characters; names that become empty or reserved are rejected.
- Output subdirectories remain reject-only and are never silently rewritten.
- Rollback is a single commit revert.

Next

Run the full validation profile, review the final diff and independent security-audit findings, then promote to dev.