### PR TITLE
fix(aio): bound native resource hash work

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -100,14 +100,20 @@ but an ambiguous basename or path-like value containing traversal components is
 not hashed. ComfyUI's prompt parser supplies embedding attention weights, such
 as `0.8` in `(embedding:styles/example:0.8)`.
 
+One save performs at most 32 unique local resource lookup/hash attempts across
+the selected model, applied LoRAs, and embedding references. Missing resources
+consume the same budget as successful lookups, repeated embedding requests are
+deduplicated before lookup, and the ComfyUI embedding inventory is indexed once
+per save.
+
 SHA-256 values keep a 128-entry process cache and a bounded cross-session cache
 at `easyuse_anima/cache/resource-hashes.v1.json` under ComfyUI's user-data
 directory. Cache keys contain an opaque digest of the resolved path rather than
 the path itself. A hit must match size, modification/change timestamps, device,
 and file identity; uncached reads report byte progress through ComfyUI. Cache
 files are size/schema validated and atomically replaced. Corruption or write
-failure causes a safe recomputation, and no cache file is written beside a
-model, LoRA, or embedding.
+failure, including excessively nested JSON, causes a safe recomputation, and no
+cache file is written beside a model, LoRA, or embedding.
 
 Locally calculated SHA-256 values use the first ten characters in the
 A1111/Civitai-compatible fields. Manual hash and hash-bundle settings preserve

--- a/easyuse_anima/aio/native_resource_hashes.py
+++ b/easyuse_anima/aio/native_resource_hashes.py
@@ -23,7 +23,7 @@ _HASH_CACHE_SCHEMA = 1
 _HASH_CACHE_MAX_BYTES = 1024 * 1024
 _HASH_CACHE_MAX_ENTRIES = 128
 _HASH_CACHE_FILENAME = "resource-hashes.v1.json"
-_MAX_LOCAL_EMBEDDINGS = 32
+_MAX_LOCAL_RESOURCE_ATTEMPTS = 32
 _MAX_MANUAL_HASHES = 30
 _MAX_MANUAL_HASH_TEXT = 8_192
 _EMBEDDING_RE = re.compile(r"embedding:([^,\s():]+)", re.IGNORECASE)
@@ -47,6 +47,33 @@ class _ResourceHash:
     @property
     def metadata_hash(self) -> str:
         return self.sha256 if self.preserve_hash else self.sha256[:10]
+
+
+@dataclass(slots=True)
+class _LocalResourceAttemptBudget:
+    limit: int = _MAX_LOCAL_RESOURCE_ATTEMPTS
+    used: int = 0
+    warned: bool = False
+
+    def consume(self) -> bool:
+        if self.used >= self.limit:
+            if not self.warned:
+                logger.warning(
+                    "[EasyUseAnima] Ignoring local resource references beyond the "
+                    "%d-attempt limit.",
+                    self.limit,
+                )
+                self.warned = True
+            return False
+        self.used += 1
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class _ResourceInventoryIndex:
+    exact: Mapping[str, tuple[str, ...]]
+    stems: Mapping[str, tuple[str, ...]]
+    basenames: Mapping[str, tuple[str, ...]]
 
 
 def _supported_model_extensions() -> set[str]:
@@ -303,7 +330,13 @@ def _hash_file_revision(
         if cache_path is not None:
             try:
                 entries = _read_hash_cache(cache_path)
-            except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+            except (
+                OSError,
+                RecursionError,
+                UnicodeError,
+                ValueError,
+                json.JSONDecodeError,
+            ) as exc:
                 logger.warning(
                     "[EasyUseAnima] Ignoring invalid persistent resource hash cache (%s).",
                     type(exc).__name__,
@@ -384,10 +417,7 @@ def _without_supported_extension(value: str) -> str:
     return value
 
 
-def _inventory_resource_name(folder_name: str, requested_name: str) -> str | None:
-    requested = _safe_inventory_name(requested_name)
-    if not requested:
-        return None
+def _inventory_resource_index(folder_name: str) -> _ResourceInventoryIndex | None:
     try:
         import folder_paths  # type: ignore
     except Exception:
@@ -397,11 +427,11 @@ def _inventory_resource_name(folder_name: str, requested_name: str) -> str | Non
         return None
     try:
         values = cast(Iterable[object], get_filename_list(folder_name))
-        inventory = [
+        inventory = tuple(
             safe_name
             for value in values
             if (safe_name := _safe_inventory_name(value))
-        ]
+        )
     except Exception as exc:
         logger.warning(
             "[EasyUseAnima] Could not read the %s inventory: %s",
@@ -410,25 +440,38 @@ def _inventory_resource_name(folder_name: str, requested_name: str) -> str | Non
         )
         return None
 
+    exact: dict[str, list[str]] = {}
+    stems: dict[str, list[str]] = {}
+    basenames: dict[str, list[str]] = {}
+    for name in inventory:
+        stem = _without_supported_extension(name)
+        exact.setdefault(name.casefold(), []).append(name)
+        stems.setdefault(stem.casefold(), []).append(name)
+        basenames.setdefault(PurePosixPath(stem).name.casefold(), []).append(name)
+    return _ResourceInventoryIndex(
+        exact={key: tuple(names) for key, names in exact.items()},
+        stems={key: tuple(names) for key, names in stems.items()},
+        basenames={key: tuple(names) for key, names in basenames.items()},
+    )
+
+
+def _inventory_resource_name(
+    inventory: _ResourceInventoryIndex,
+    requested_name: str,
+) -> str | None:
+    requested = _safe_inventory_name(requested_name)
+    if not requested:
+        return None
     requested_folded = requested.casefold()
-    exact = [name for name in inventory if name.casefold() == requested_folded]
-    if len(exact) == 1:
-        return exact[0]
+    exact_matches = inventory.exact.get(requested_folded, ())
+    if len(exact_matches) == 1:
+        return exact_matches[0]
     requested_stem = _without_supported_extension(requested).casefold()
-    stem_matches = [
-        name
-        for name in inventory
-        if _without_supported_extension(name).casefold() == requested_stem
-    ]
+    stem_matches = inventory.stems.get(requested_stem, ())
     if len(stem_matches) == 1:
         return stem_matches[0]
     if "/" not in requested:
-        basename_matches = [
-            name
-            for name in inventory
-            if PurePosixPath(_without_supported_extension(name)).name.casefold()
-            == requested_stem
-        ]
+        basename_matches = inventory.basenames.get(requested_stem, ())
         if len(basename_matches) == 1:
             return basename_matches[0]
         if len(basename_matches) > 1:
@@ -464,48 +507,66 @@ def _weighted_prompt_segments(prompt: str) -> Iterable[tuple[str, float]]:
     return tuple(segments)
 
 
-def _embedding_resource_hashes(prompts: Sequence[str]) -> list[_ResourceHash]:
-    resources: list[_ResourceHash] = []
-    seen_names: set[str] = set()
+def _embedding_resource_hashes(
+    prompts: Sequence[str],
+    budget: _LocalResourceAttemptBudget,
+) -> list[_ResourceHash]:
+    requests: list[tuple[str, float]] = []
+    seen_requests: set[str] = set()
     for prompt in prompts:
         for segment, weight in _weighted_prompt_segments(prompt):
             for match in _EMBEDDING_RE.finditer(segment):
-                if len(resources) >= _MAX_LOCAL_EMBEDDINGS:
-                    logger.warning(
-                        "[EasyUseAnima] Ignoring embedding references beyond the %d-resource limit.",
-                        _MAX_LOCAL_EMBEDDINGS,
-                    )
-                    return resources
                 requested_name = match.group(1)
-                inventory_name = _inventory_resource_name("embeddings", requested_name)
-                if inventory_name is None:
+                request_key = requested_name.strip().replace("\\", "/").casefold()
+                if not request_key or request_key in seen_requests:
                     continue
-                metadata_name = _lora_metadata_name(inventory_name)
-                normalized_name = metadata_name.casefold()
-                if not metadata_name or normalized_name in seen_names:
-                    continue
-                path = _resolve_resource_path(("embeddings",), inventory_name)
-                if path is None:
-                    continue
-                try:
-                    sha256 = _hash_file(path)
-                except OSError as exc:
-                    logger.warning(
-                        "[EasyUseAnima] Could not hash embedding %r; continuing without its hash: %s",
-                        inventory_name,
-                        exc,
-                    )
-                    continue
-                seen_names.add(normalized_name)
-                resources.append(
-                    _ResourceHash(
-                        display_name=metadata_name,
-                        metadata_key=f"embed:{metadata_name}",
-                        path=path,
-                        sha256=sha256,
-                        weight=weight,
-                    )
-                )
+                seen_requests.add(request_key)
+                if not budget.consume():
+                    return _resolve_embedding_resource_hashes(requests)
+                requests.append((requested_name, weight))
+    return _resolve_embedding_resource_hashes(requests)
+
+
+def _resolve_embedding_resource_hashes(
+    requests: Sequence[tuple[str, float]],
+) -> list[_ResourceHash]:
+    resources: list[_ResourceHash] = []
+    if not requests:
+        return resources
+    inventory = _inventory_resource_index("embeddings")
+    if inventory is None:
+        return resources
+    seen_names: set[str] = set()
+    for requested_name, weight in requests:
+        inventory_name = _inventory_resource_name(inventory, requested_name)
+        if inventory_name is None:
+            continue
+        metadata_name = _lora_metadata_name(inventory_name)
+        normalized_name = metadata_name.casefold()
+        if not metadata_name or normalized_name in seen_names:
+            continue
+        path = _resolve_resource_path(("embeddings",), inventory_name)
+        if path is None:
+            continue
+        try:
+            sha256 = _hash_file(path)
+        except OSError as exc:
+            logger.warning(
+                "[EasyUseAnima] Could not hash embedding %r; continuing without its hash: %s",
+                inventory_name,
+                exc,
+            )
+            continue
+        seen_names.add(normalized_name)
+        resources.append(
+            _ResourceHash(
+                display_name=metadata_name,
+                metadata_key=f"embed:{metadata_name}",
+                path=path,
+                sha256=sha256,
+                weight=weight,
+            )
+        )
     return resources
 
 
@@ -515,7 +576,13 @@ def _local_resource_hashes(
     prompts: Sequence[str] = (),
 ) -> list[_ResourceHash]:
     resources: list[_ResourceHash] = []
-    model_path = _resolve_resource_path(("diffusion_models", "checkpoints"), modelname)
+    budget = _LocalResourceAttemptBudget()
+    model_path = None
+    if str(modelname or "").strip() and budget.consume():
+        model_path = _resolve_resource_path(
+            ("diffusion_models", "checkpoints"),
+            modelname,
+        )
     if model_path is not None:
         try:
             resources.append(
@@ -543,6 +610,8 @@ def _local_resource_hashes(
         if not metadata_name or metadata_name.casefold() in seen_names:
             continue
         seen_names.add(metadata_name.casefold())
+        if not budget.consume():
+            break
         lora_path = _resolve_resource_path(("loras",), source_name)
         if lora_path is None:
             logger.warning(
@@ -574,7 +643,7 @@ def _local_resource_hashes(
                 weight=strength,
             )
         )
-    resources.extend(_embedding_resource_hashes(prompts))
+    resources.extend(_embedding_resource_hashes(prompts, budget))
     return resources
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -10649,7 +10649,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 53
+            "line": 80
           }
         ],
         "classification": "external",
@@ -10657,7 +10657,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 54,
+        "line": 81,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10674,7 +10674,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 76
+            "line": 103
           }
         ],
         "classification": "external",
@@ -10682,7 +10682,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 77,
+        "line": 104,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10699,7 +10699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 104
+            "line": 131
           }
         ],
         "classification": "external",
@@ -10707,7 +10707,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 105,
+        "line": 132,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10724,7 +10724,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 224
+            "line": 251
           }
         ],
         "classification": "external",
@@ -10732,7 +10732,7 @@
         "conditional": true,
         "imported": "comfy.utils:ProgressBar",
         "kind": "static_from",
-        "line": 225,
+        "line": 252,
         "name": "ProgressBar",
         "optional": true,
         "requested": "comfy.utils",
@@ -10749,7 +10749,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 391
+            "line": 421
           }
         ],
         "classification": "external",
@@ -10757,12 +10757,12 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 392,
+        "line": 422,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
         "role": "optional_dependency",
-        "scope": "_inventory_resource_name",
+        "scope": "_inventory_resource_index",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
       },
       {
@@ -10774,7 +10774,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
@@ -10782,7 +10782,7 @@
         "conditional": true,
         "imported": "comfy.sd1_clip:escape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "name": "escape_important",
         "optional": true,
         "requested": "comfy.sd1_clip",
@@ -10799,7 +10799,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
@@ -10807,7 +10807,7 @@
         "conditional": true,
         "imported": "comfy.sd1_clip:token_weights",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "name": "token_weights",
         "optional": true,
         "requested": "comfy.sd1_clip",
@@ -10824,7 +10824,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
@@ -10832,7 +10832,7 @@
         "conditional": true,
         "imported": "comfy.sd1_clip:unescape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "name": "unescape_important",
         "optional": true,
         "requested": "comfy.sd1_clip",
@@ -50806,173 +50806,197 @@
           },
           {
             "async": false,
-            "end_line": 58,
+            "end_line": 69,
+            "kind": "method",
+            "line": 58,
+            "loc": 12,
+            "qualified_name": "_LocalResourceAttemptBudget.consume"
+          },
+          {
+            "async": false,
+            "end_line": 85,
             "kind": "function",
-            "line": 52,
+            "line": 79,
             "loc": 7,
             "qualified_name": "_supported_model_extensions"
           },
           {
             "async": false,
-            "end_line": 64,
+            "end_line": 91,
             "kind": "function",
-            "line": 61,
+            "line": 88,
             "loc": 4,
             "qualified_name": "_resource_name"
           },
           {
             "async": false,
-            "end_line": 70,
+            "end_line": 97,
             "kind": "function",
-            "line": 67,
+            "line": 94,
             "loc": 4,
             "qualified_name": "_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 100,
+            "end_line": 127,
             "kind": "function",
-            "line": 73,
+            "line": 100,
             "loc": 28,
             "qualified_name": "_resolve_resource_path"
           },
           {
             "async": false,
-            "end_line": 122,
+            "end_line": 149,
             "kind": "function",
-            "line": 103,
+            "line": 130,
             "loc": 20,
             "qualified_name": "_hash_cache_path"
           },
           {
             "async": false,
-            "end_line": 178,
+            "end_line": 205,
             "kind": "function",
-            "line": 125,
+            "line": 152,
             "loc": 54,
             "qualified_name": "_read_hash_cache"
           },
           {
             "async": false,
-            "end_line": 215,
+            "end_line": 242,
             "kind": "function",
-            "line": 181,
+            "line": 208,
             "loc": 35,
             "qualified_name": "_atomic_write_hash_cache"
           },
           {
             "async": false,
-            "end_line": 220,
+            "end_line": 247,
             "kind": "function",
-            "line": 218,
+            "line": 245,
             "loc": 3,
             "qualified_name": "_hash_cache_key"
           },
           {
             "async": false,
-            "end_line": 229,
+            "end_line": 256,
             "kind": "function",
-            "line": 223,
+            "line": 250,
             "loc": 7,
             "qualified_name": "_new_hash_progress"
           },
           {
             "async": false,
-            "end_line": 239,
+            "end_line": 266,
             "kind": "function",
-            "line": 232,
+            "line": 259,
             "loc": 8,
             "qualified_name": "_stat_revision"
           },
           {
             "async": false,
-            "end_line": 286,
+            "end_line": 313,
             "kind": "function",
-            "line": 242,
+            "line": 269,
             "loc": 45,
             "qualified_name": "_calculate_file_sha256"
           },
           {
             "async": false,
-            "end_line": 352,
+            "end_line": 385,
             "kind": "function",
-            "line": 289,
-            "loc": 64,
+            "line": 316,
+            "loc": 70,
             "qualified_name": "_hash_file_revision"
           },
           {
             "async": false,
-            "end_line": 358,
+            "end_line": 391,
             "kind": "function",
-            "line": 355,
+            "line": 388,
             "loc": 4,
             "qualified_name": "_hash_file"
           },
           {
             "async": false,
-            "end_line": 377,
+            "end_line": 410,
             "kind": "function",
-            "line": 361,
+            "line": 394,
             "loc": 17,
             "qualified_name": "_safe_inventory_name"
           },
           {
             "async": false,
-            "end_line": 384,
+            "end_line": 417,
             "kind": "function",
-            "line": 380,
+            "line": 413,
             "loc": 5,
             "qualified_name": "_without_supported_extension"
           },
           {
             "async": false,
-            "end_line": 439,
+            "end_line": 455,
             "kind": "function",
-            "line": 387,
-            "loc": 53,
+            "line": 420,
+            "loc": 36,
+            "qualified_name": "_inventory_resource_index"
+          },
+          {
+            "async": false,
+            "end_line": 482,
+            "kind": "function",
+            "line": 458,
+            "loc": 25,
             "qualified_name": "_inventory_resource_name"
           },
           {
             "async": false,
-            "end_line": 464,
+            "end_line": 507,
             "kind": "function",
-            "line": 442,
+            "line": 485,
             "loc": 23,
             "qualified_name": "_weighted_prompt_segments"
           },
           {
             "async": false,
-            "end_line": 509,
+            "end_line": 527,
             "kind": "function",
-            "line": 467,
-            "loc": 43,
+            "line": 510,
+            "loc": 18,
             "qualified_name": "_embedding_resource_hashes"
           },
           {
             "async": false,
-            "end_line": 578,
+            "end_line": 570,
             "kind": "function",
-            "line": 512,
-            "loc": 67,
+            "line": 530,
+            "loc": 41,
+            "qualified_name": "_resolve_embedding_resource_hashes"
+          },
+          {
+            "async": false,
+            "end_line": 647,
+            "kind": "function",
+            "line": 573,
+            "loc": 75,
             "qualified_name": "_local_resource_hashes"
           },
           {
             "async": false,
-            "end_line": 653,
+            "end_line": 722,
             "kind": "function",
-            "line": 581,
+            "line": 650,
             "loc": 73,
             "qualified_name": "_manual_resource_hashes"
           }
         ],
         "is_package": false,
-        "loc": 656,
+        "loc": 725,
         "module": "easyuse_anima.aio.native_resource_hashes",
-        "normalized_git_blob_sha1": "7bbc99cc120dcb1ead20d12d1cf69f6aa8a527b6",
+        "normalized_git_blob_sha1": "a35f7fb2873d419f5f40781b75de9b230464eb9b",
         "path": "easyuse_anima/aio/native_resource_hashes.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 20,
+          "class_count": 3,
+          "function_count": 22,
           "global_count": 17
         }
       },
@@ -64810,14 +64834,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 53
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 54,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64829,14 +64853,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 76
+            "line": 103
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 77,
+        "line": 104,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64848,14 +64872,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 104
+            "line": 131
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 105,
+        "line": 132,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64867,14 +64891,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 224
+            "line": 251
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.utils:ProgressBar",
         "kind": "static_from",
-        "line": 225,
+        "line": 252,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64886,14 +64910,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 391
+            "line": 421
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 392,
+        "line": 422,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64905,14 +64929,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:escape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64924,14 +64948,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:token_weights",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -64943,14 +64967,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:unescape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -71924,14 +71948,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 53
+            "line": 80
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 54,
+        "line": 81,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -71943,14 +71967,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 76
+            "line": 103
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 77,
+        "line": 104,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -71962,14 +71986,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 104
+            "line": 131
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 105,
+        "line": 132,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -71981,14 +72005,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 224
+            "line": 251
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.utils:ProgressBar",
         "kind": "static_from",
-        "line": 225,
+        "line": 252,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -72000,14 +72024,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 391
+            "line": 421
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 392,
+        "line": 422,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -72019,14 +72043,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:escape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -72038,14 +72062,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:token_weights",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -72057,14 +72081,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 444
+            "line": 487
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.sd1_clip:unescape_important",
         "kind": "static_from",
-        "line": 445,
+        "line": 488,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/native_resource_hashes.py"
@@ -74844,11 +74868,29 @@
         "scope": "<module>"
       },
       {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_LocalResourceAttemptBudget",
+        "kind": "import_time_call",
+        "line": 52,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_ResourceInventoryIndex",
+        "kind": "import_time_call",
+        "line": 72,
+        "module": "easyuse_anima/aio/native_resource_hashes.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "lru_cache",
         "column": 1,
         "context": "decorator:_hash_file_revision",
         "kind": "import_time_call",
-        "line": 289,
+        "line": 316,
         "module": "easyuse_anima/aio/native_resource_hashes.py",
         "scope": "<module>"
       },

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -232,31 +232,40 @@ class AIONativeImageOutputTests(unittest.TestCase):
         self.assertNotIn("embed:duplicate", metadata.hashes)
 
     def test_embedding_lookup_attempts_are_deduplicated_bounded_and_indexed_once(self):
-        folder_paths = fake_folder_paths(
-            {},
-            filenames={
-                "embeddings": [f"known/{index}.pt" for index in range(1_000)]
-            },
-        )
-        get_filename_list = Mock(wraps=folder_paths.get_filename_list)
-        folder_paths.get_filename_list = get_filename_list
-        prompt = ", ".join(
-            ["embedding:missing"] * 10
-            + [f"embedding:missing-{index}" for index in range(40)]
-        )
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "target.pt"
+            target.write_bytes(b"target embedding")
+            folder_paths = fake_folder_paths(
+                {("embeddings", "known/target.pt"): target},
+                filenames={
+                    "embeddings": [f"known/{index}.pt" for index in range(1_000)]
+                    + ["known/target.pt"]
+                },
+            )
+            get_filename_list = Mock(wraps=folder_paths.get_filename_list)
+            folder_paths.get_filename_list = get_filename_list
+            prompt = ", ".join(
+                ["embedding:missing"] * 40
+                + [f"embedding:missing-{index}" for index in range(30)]
+                + ["embedding:known/target"]
+            )
 
-        with (
-            patch.dict(sys.modules, {"folder_paths": folder_paths}),
-            patch.object(
-                resources,
-                "_inventory_resource_name",
-                wraps=resources._inventory_resource_name,
-            ) as match_inventory,
-            self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
-        ):
-            result = resources._local_resource_hashes("", [], (prompt,))
+            with (
+                patch.dict(sys.modules, {"folder_paths": folder_paths}),
+                patch.object(
+                    resources,
+                    "_inventory_resource_name",
+                    wraps=resources._inventory_resource_name,
+                ) as match_inventory,
+            ):
+                result = resources._local_resource_hashes("", [], (prompt,))
 
-        self.assertEqual(result, [])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].metadata_key, "embed:known/target")
+        self.assertEqual(
+            result[0].sha256,
+            hashlib.sha256(b"target embedding").hexdigest(),
+        )
         get_filename_list.assert_called_once_with("embeddings")
         self.assertEqual(
             match_inventory.call_count,

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -231,6 +231,77 @@ class AIONativeImageOutputTests(unittest.TestCase):
         self.assertIn("embedding:easy", metadata.parameters)
         self.assertNotIn("embed:duplicate", metadata.hashes)
 
+    def test_embedding_lookup_attempts_are_deduplicated_bounded_and_indexed_once(self):
+        folder_paths = fake_folder_paths(
+            {},
+            filenames={
+                "embeddings": [f"known/{index}.pt" for index in range(1_000)]
+            },
+        )
+        get_filename_list = Mock(wraps=folder_paths.get_filename_list)
+        folder_paths.get_filename_list = get_filename_list
+        prompt = ", ".join(
+            ["embedding:missing"] * 10
+            + [f"embedding:missing-{index}" for index in range(40)]
+        )
+
+        with (
+            patch.dict(sys.modules, {"folder_paths": folder_paths}),
+            patch.object(
+                resources,
+                "_inventory_resource_name",
+                wraps=resources._inventory_resource_name,
+            ) as match_inventory,
+            self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+        ):
+            result = resources._local_resource_hashes("", [], (prompt,))
+
+        self.assertEqual(result, [])
+        get_filename_list.assert_called_once_with("embeddings")
+        self.assertEqual(
+            match_inventory.call_count,
+            resources._MAX_LOCAL_RESOURCE_ATTEMPTS,
+        )
+
+    def test_local_resource_attempt_budget_includes_model_loras_before_embeddings(self):
+        folder_paths = fake_folder_paths({}, filenames={"embeddings": ["unused.pt"]})
+        get_filename_list = Mock(wraps=folder_paths.get_filename_list)
+        folder_paths.get_filename_list = get_filename_list
+        applied_loras = [
+            {
+                "name": f"style-{index}.safetensors",
+                "strength_model": 1.0,
+            }
+            for index in range(40)
+        ]
+        resolved_path = Path("resource.safetensors")
+
+        with (
+            patch.dict(sys.modules, {"folder_paths": folder_paths}),
+            patch.object(
+                resources,
+                "_resolve_resource_path",
+                return_value=resolved_path,
+            ) as resolve_resource,
+            patch.object(resources, "_hash_file", return_value="a" * 64) as hash_file,
+            self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"),
+        ):
+            result = resources._local_resource_hashes(
+                "model.safetensors",
+                applied_loras,
+                ("embedding:unused",),
+            )
+
+        self.assertEqual(len(result), resources._MAX_LOCAL_RESOURCE_ATTEMPTS)
+        self.assertEqual(result[0].metadata_key, "model")
+        self.assertEqual(result[-1].metadata_key, "LORA:style-30")
+        self.assertEqual(
+            resolve_resource.call_count,
+            resources._MAX_LOCAL_RESOURCE_ATTEMPTS,
+        )
+        self.assertEqual(hash_file.call_count, resources._MAX_LOCAL_RESOURCE_ATTEMPTS)
+        get_filename_list.assert_not_called()
+
     def test_manual_hashes_preserve_values_and_cannot_replace_local_model_hash(self):
         first = "ABCDEF1234AAAAAA"
         second = "ABCDEF1234BBBBBB"
@@ -787,6 +858,43 @@ class AIONativeImageOutputTests(unittest.TestCase):
                     result,
                     hashlib.sha256(b"still returns a hash").hexdigest(),
                 )
+
+    def test_deeply_nested_persistent_hash_cache_is_recomputed_and_replaced(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            user_directory = root / "user"
+            user_directory.mkdir()
+            model_path = root / "model.safetensors"
+            model_path.write_bytes(b"verified model")
+            cache_path = (
+                user_directory
+                / "easyuse_anima"
+                / "cache"
+                / resources._HASH_CACHE_FILENAME
+            )
+            cache_path.parent.mkdir(parents=True)
+            depth = sys.getrecursionlimit() * 4
+            cache_path.write_text("[" * depth + "0" + "]" * depth, encoding="utf-8")
+            folder_paths = fake_folder_paths({}, user_directory=user_directory)
+            calculate = resources._calculate_file_sha256
+
+            with (
+                patch.dict(sys.modules, {"folder_paths": folder_paths}),
+                patch.object(
+                    resources,
+                    "_calculate_file_sha256",
+                    wraps=calculate,
+                ) as recomputed,
+                self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING") as logs,
+            ):
+                result = resources._hash_file(model_path)
+
+            self.assertEqual(result, hashlib.sha256(b"verified model").hexdigest())
+            recomputed.assert_called_once()
+            self.assertTrue(any("RecursionError" in entry for entry in logs.output))
+            replacement = json.loads(cache_path.read_text(encoding="utf-8"))
+            self.assertEqual(replacement["version"], resources._HASH_CACHE_SCHEMA)
+            self.assertEqual(len(replacement["entries"]), 1)
 
     def test_png_jpeg_and_webp_round_trip_a1111_and_comfy_workflow_metadata(self):
         metadata = native.NativeImageMetadata(


### PR DESCRIPTION
## Purpose

Resolve #708 and #713 in one owner-aligned security patch.

## Base -> Head

- dev at 6ddb805 -> codex/native-resource-budget at c6f1d30

## Changes

- Share a 32-attempt budget across model, LoRA, and embedding resolution/hashing, counting missing resources as work.
- Deduplicate embedding requests before lookup and build one indexed ComfyUI embedding inventory per save.
- Treat RecursionError from an excessively nested persistent hash cache as corruption, then recompute and atomically replace it.
- Preserve resource precedence, metadata keys, cache schema/location, manual hashes, and valid profile/workflow behavior.

## Validation

- New focused tests for duplicate/missing embedding attempts, one inventory read, shared model/LoRA/embedding budget, and nested-cache recovery: PASS.
- Existing embedding matching and persistent-cache reuse tests: PASS.
- Changed-file Ruff 0.15.22: PASS.
- Repository quick profile and generated analyzer fixture contract: PASS.
- Full profile: pending after independent security-focused PR review.

## Risk and rollback

- Valid workflows with more than 32 local resource attempts now intentionally omit later hashes while image saving continues.
- Metadata order remains model, LoRA, then embedding.
- Rollback is a single commit revert.

## Next

Independent non-duplicative subagent review, any required corrections, then one full profile run on the reviewed candidate SHA.