### PR TITLE
fix(aio): reject Windows device aliases

### DIFF
--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -50,9 +50,9 @@ _LORA_TAG_RE = re.compile(r"<lora:([^>:]+)(?::([^>]+))?>", re.IGNORECASE)
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _WINDOWS_INVALID_COMPONENT_RE = re.compile(r'[<>:"|?*\x00-\x1f\x7f]')
 _WINDOWS_RESERVED_COMPONENTS = frozenset(
-    {"con", "prn", "aux", "nul"}
-    | {f"com{index}" for index in range(1, 10)}
-    | {f"lpt{index}" for index in range(1, 10)}
+    {"con", "prn", "aux", "nul", "conin$", "conout$"}
+    | {f"com{index}" for index in (*range(1, 10), "¹", "²", "³")}
+    | {f"lpt{index}" for index in (*range(1, 10), "¹", "²", "³")}
 )
 _SAVE_LOCK = threading.Lock()
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -50422,7 +50422,7 @@
         "is_package": false,
         "loc": 690,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "def9e3abde59a6803c710f45bd376a35fdb70ae0",
+        "normalized_git_blob_sha1": "14a5cfb66c8fe87f85cf03fd9a8b5fb5dadd9f60",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
           "class_count": 2,
@@ -74680,7 +74680,7 @@
       },
       {
         "callee": "range",
-        "column": 34,
+        "column": 36,
         "context": "assign:_WINDOWS_RESERVED_COMPONENTS",
         "kind": "import_time_call",
         "line": 54,
@@ -74689,7 +74689,7 @@
       },
       {
         "callee": "range",
-        "column": 34,
+        "column": 36,
         "context": "assign:_WINDOWS_RESERVED_COMPONENTS",
         "kind": "import_time_call",
         "line": 55,

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -990,7 +990,16 @@ class AIONativeImageOutputTests(unittest.TestCase):
         pixels = np.zeros((2, 2, 3), dtype=np.float32)
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            for filename in ("NUL.txt", "con", "aux.log", "CON?"):
+            for filename in (
+                "NUL.txt",
+                "con",
+                "aux.log",
+                "CON?",
+                "Com¹.txt",
+                "lPT³.bin",
+                "CONIN$.png",
+                "conout$",
+            ):
                 with self.subTest(filename=filename), self.assertRaisesRegex(
                     RuntimeError, "invalid on Windows"
                 ):
@@ -1011,6 +1020,25 @@ class AIONativeImageOutputTests(unittest.TestCase):
                     )
 
             self.assertEqual(list(root.iterdir()), [])
+
+    def test_windows_output_component_recognizes_exact_dos_device_aliases(self):
+        for device_name in (
+            "COM¹",
+            "COM²",
+            "COM³",
+            "LPT¹",
+            "LPT²",
+            "LPT³",
+            "CONIN$",
+            "CONOUT$",
+        ):
+            for component in (device_name, f"{device_name.lower()}.txt"):
+                with self.subTest(component=component):
+                    self.assertFalse(native._is_windows_safe_output_component(component))
+
+        for component in ("COM⁴", "LPT⁹", "CONIN-data", "résumé"):
+            with self.subTest(component=component):
+                self.assertTrue(native._is_windows_safe_output_component(component))
 
     def test_png_extra_metadata_cannot_override_owned_parameters_or_prompt(self):
         metadata = native.NativeImageMetadata("owned parameters", "", {})
@@ -1429,6 +1457,10 @@ class AIONativeImageOutputTests(unittest.TestCase):
                 "nested/bad?folder",
                 "nested/CON",
                 "nested/aux.txt",
+                "nested/COM²",
+                "nested/LPT¹.log",
+                "nested/conin$",
+                "nested/CONOUT$.txt",
                 "nested/trailing./child",
             ):
                 with self.subTest(path=unsafe_path), self.assertRaisesRegex(


### PR DESCRIPTION
목적과 변경 경계: Windows가 모든 디렉터리에서 예약하는 COM¹/²/³, LPT¹/²/³ 및 DOS 장치명 CONIN$/CONOUT AiO 네이티브 출력 파일명과 중첩 경로에서 거부합니다. Base -> Head: dev@7c6651e -> codex/windows-device-aliases@b0a5e11. 주요 파일과 보존 계약: native_image_output.py의 기존 예약명 집합만 확장하며 정상 Unicode 이름, 기존 정리 규칙, 충돌 회피와 출력 루트 containment는 유지합니다. 생성형 backend baseline은 모듈 해시와 두 AST 열 위치만 갱신했습니다. 검증: 직접 predicate, 실제 파일명 publication 전 거부, 중첩 경로 거부, analyzer fixture 테스트 통과; 변경 파일 Ruff 0.15.22 통과; quick 프로필 통과(frontend 123 files, 기존 report-only Ruff 25건). 남은 gate: 독립 보안 검토 후 최종 full. 위험과 rollback: 좁은 예약명 집합 확장이므로 해당 커밋 revert로 복구 가능합니다. 근거: Microsoft Windows 파일 명명 문서 및 RtlIsDosDeviceName_U 문서. Refs #705. Next: 검토와 full 통과 후 dev에 squash 병합하고 #705를 닫습니다.