### PR TITLE
fix(aio): bound output template expansion

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -156,8 +156,11 @@ rechecks the created folder's resolved path before use.
 Template inputs and rendered results are limited to 1,024 characters, and the
 time-format setting is limited to 256 characters. Every custom time, padded
 counter, and fixed placeholder substitution checks its projected result length
-before constructing that intermediate string, so repeated large replacement
-values cannot amplify beyond the accepted template budget.
+before constructing that intermediate string. Time formats are rendered in
+bounded segments after rejecting excessive numeric field widths, and integer
+placeholders verify their decimal digit count before string formatting. Repeated
+large replacement values therefore cannot amplify beyond the accepted template
+budget.
 
 Batch and collision suffixes are allocated while holding a process lock. When
 a workflow sidecar is required, both the image and JSON names participate in

--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -153,6 +153,12 @@ Templates are expanded before output-path validation. Both the output subfolder
 and filename must remain relative to the active ComfyUI output root. The writer
 rechecks the created folder's resolved path before use.
 
+Template inputs and rendered results are limited to 1,024 characters, and the
+time-format setting is limited to 256 characters. Every custom time, padded
+counter, and fixed placeholder substitution checks its projected result length
+before constructing that intermediate string, so repeated large replacement
+values cannot amplify beyond the accepted template budget.
+
 Batch and collision suffixes are allocated while holding a process lock. When
 a workflow sidecar is required, both the image and JSON names participate in
 collision checks. A late image or sidecar target is never overwritten: the

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -40,6 +40,8 @@ _IMAGE_SAVER_SAFE_TIME_FORMAT = "%Y-%m-%d-%H%M%S"
 _IMAGE_SAVER_CUSTOM_TIME_RE = re.compile(r"%time_format<([^>]*)>")
 _IMAGE_SAVER_CUSTOM_COUNTER_RE = re.compile(r"%counter<([0-9]+)>")
 _OUTPUT_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_MAX_OUTPUT_TEMPLATE_LENGTH = 1024
+_MAX_OUTPUT_TIME_FORMAT_LENGTH = 256
 _MAX_CIVITAI_HASH_FETCHERS = 32
 
 
@@ -176,6 +178,43 @@ def _image_saver_timestamp(now: datetime, time_format: str) -> str:
         return now.strftime(_IMAGE_SAVER_SAFE_TIME_FORMAT)
 
 
+def _bounded_template_replace(value: str, token: str, replacement: str) -> str:
+    count = value.count(token)
+    if not count:
+        return value
+    result_length = len(value) + count * (len(replacement) - len(token))
+    if result_length > _MAX_OUTPUT_TEMPLATE_LENGTH:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    return value.replace(token, replacement)
+
+
+def _bounded_template_sub(
+    pattern: re.Pattern[str],
+    replacement: Callable[[re.Match[str]], str],
+    value: str,
+) -> str:
+    pieces: list[str] = []
+    cursor = 0
+    result_length = 0
+    matched = False
+    for match in pattern.finditer(value):
+        matched = True
+        literal = value[cursor : match.start()]
+        rendered = replacement(match)
+        result_length += len(literal) + len(rendered)
+        if result_length > _MAX_OUTPUT_TEMPLATE_LENGTH:
+            raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+        pieces.extend((literal, rendered))
+        cursor = match.end()
+    if not matched:
+        return value
+    tail = value[cursor:]
+    if result_length + len(tail) > _MAX_OUTPUT_TEMPLATE_LENGTH:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    pieces.append(tail)
+    return "".join(pieces)
+
+
 def _render_image_saver_template(
     pattern: str,
     *,
@@ -195,7 +234,10 @@ def _render_image_saver_template(
     custom: str,
 ) -> str:
     value = str(pattern or "")
-    if len(value) > 1024 or len(str(time_format or "")) > 256:
+    if (
+        len(value) > _MAX_OUTPUT_TEMPLATE_LENGTH
+        or len(str(time_format or "")) > _MAX_OUTPUT_TIME_FORMAT_LENGTH
+    ):
         raise RuntimeError("[EasyUseAnima] AiO save template is too long.")
 
     def replace_time(match: re.Match[str]) -> str:
@@ -210,8 +252,8 @@ def _render_image_saver_template(
         return f"{counter:0{padding}d}"
 
     model_filename, base_model_name = _image_saver_model_names(modelname)
-    value = _IMAGE_SAVER_CUSTOM_TIME_RE.sub(replace_time, value)
-    value = _IMAGE_SAVER_CUSTOM_COUNTER_RE.sub(replace_counter, value)
+    value = _bounded_template_sub(_IMAGE_SAVER_CUSTOM_TIME_RE, replace_time, value)
+    value = _bounded_template_sub(_IMAGE_SAVER_CUSTOM_COUNTER_RE, replace_counter, value)
     replacements = (
         ("%date", _image_saver_timestamp(now, "%Y-%m-%d")),
         ("%time", _image_saver_timestamp(now, time_format)),
@@ -230,12 +272,12 @@ def _render_image_saver_template(
         ("%custom", custom),
     )
     for token, replacement in replacements:
-        value = value.replace(token, replacement)
+        value = _bounded_template_replace(value, token, replacement)
     if "%" in value:
         raise RuntimeError(
             "[EasyUseAnima] AiO save template contains an unsupported placeholder."
         )
-    if len(value) > 1024:
+    if len(value) > _MAX_OUTPUT_TEMPLATE_LENGTH:
         raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
     return value
 

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -42,6 +42,7 @@ _IMAGE_SAVER_CUSTOM_COUNTER_RE = re.compile(r"%counter<([0-9]+)>")
 _OUTPUT_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _MAX_OUTPUT_TEMPLATE_LENGTH = 1024
 _MAX_OUTPUT_TIME_FORMAT_LENGTH = 256
+_STRFTIME_DIRECTIVE_PREFIX_CHARS = frozenset("-_0^#:EO0123456789")
 _MAX_CIVITAI_HASH_FETCHERS = 32
 
 
@@ -171,26 +172,115 @@ def _image_saver_model_names(modelname: str) -> tuple[str, str]:
     return filename, basename
 
 
-def _image_saver_timestamp(now: datetime, time_format: str) -> str:
+def _iter_strftime_segments(time_format: str) -> Iterator[tuple[str, bool]]:
+    cursor = 0
+    while cursor < len(time_format):
+        percent = time_format.find("%", cursor)
+        if percent < 0:
+            yield time_format[cursor:], False
+            return
+        if percent > cursor:
+            yield time_format[cursor:percent], False
+
+        end = percent + 1
+        if end < len(time_format) and time_format[end] == "%":
+            end += 1
+        else:
+            while (
+                end < len(time_format)
+                and time_format[end] in _STRFTIME_DIRECTIVE_PREFIX_CHARS
+            ):
+                end += 1
+            if end < len(time_format):
+                end += 1
+        yield time_format[percent:end], True
+        cursor = end
+
+
+def _render_strftime_bounded(
+    now: datetime,
+    time_format: str,
+    max_length: int,
+) -> str:
+    pieces: list[str] = []
+    result_length = 0
+    for segment, is_directive in _iter_strftime_segments(time_format):
+        remaining = max_length - result_length
+        if remaining < 0:
+            raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+        if is_directive:
+            if any(
+                int(width) > remaining
+                for width in re.findall(r"[0-9]+", segment[1:])
+            ):
+                raise RuntimeError(
+                    "[EasyUseAnima] AiO save template result is too long."
+                )
+            rendered = now.strftime(segment)
+        else:
+            rendered = segment
+        if len(rendered) > remaining:
+            raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+        pieces.append(rendered)
+        result_length += len(rendered)
+    return "".join(pieces)
+
+
+def _bounded_image_saver_timestamp(
+    now: datetime,
+    time_format: str,
+    max_length: int,
+) -> str:
     try:
-        return now.strftime(time_format)
+        return _render_strftime_bounded(now, time_format, max_length)
     except (OSError, ValueError):
-        return now.strftime(_IMAGE_SAVER_SAFE_TIME_FORMAT)
+        return _render_strftime_bounded(
+            now,
+            _IMAGE_SAVER_SAFE_TIME_FORMAT,
+            max_length,
+        )
 
 
-def _bounded_template_replace(value: str, token: str, replacement: str) -> str:
+def _bounded_integer_text(value: int, max_length: int, *, padding: int = 0) -> str:
+    sign_length = int(value < 0)
+    digit_limit = max_length - sign_length
+    if digit_limit < 1 or padding > max_length or abs(value) >= 10**digit_limit:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    rendered = f"{value:0{padding}d}" if padding else str(value)
+    if len(rendered) > max_length:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    return rendered
+
+
+def _bounded_template_replace_with(
+    value: str,
+    token: str,
+    replacement: Callable[[int], str],
+) -> str:
     count = value.count(token)
     if not count:
         return value
-    result_length = len(value) + count * (len(replacement) - len(token))
-    if result_length > _MAX_OUTPUT_TEMPLATE_LENGTH:
+    fixed_length = len(value) - count * len(token)
+    if fixed_length > _MAX_OUTPUT_TEMPLATE_LENGTH:
         raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
-    return value.replace(token, replacement)
+    replacement_limit = (_MAX_OUTPUT_TEMPLATE_LENGTH - fixed_length) // count
+    rendered = replacement(replacement_limit)
+    if len(rendered) > replacement_limit:
+        raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+    return value.replace(token, rendered)
+
+
+def _bounded_template_replace(value: str, token: str, replacement: str) -> str:
+    return _bounded_template_replace_with(
+        value,
+        token,
+        lambda _max_length: replacement,
+    )
 
 
 def _bounded_template_sub(
     pattern: re.Pattern[str],
-    replacement: Callable[[re.Match[str]], str],
+    replacement: Callable[[re.Match[str], int], str],
     value: str,
 ) -> str:
     pieces: list[str] = []
@@ -200,11 +290,14 @@ def _bounded_template_sub(
     for match in pattern.finditer(value):
         matched = True
         literal = value[cursor : match.start()]
-        rendered = replacement(match)
-        result_length += len(literal) + len(rendered)
-        if result_length > _MAX_OUTPUT_TEMPLATE_LENGTH:
+        replacement_limit = _MAX_OUTPUT_TEMPLATE_LENGTH - result_length - len(literal)
+        if replacement_limit < 0:
+            raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
+        rendered = replacement(match, replacement_limit)
+        if len(rendered) > replacement_limit:
             raise RuntimeError("[EasyUseAnima] AiO save template result is too long.")
         pieces.extend((literal, rendered))
+        result_length += len(literal) + len(rendered)
         cursor = match.end()
     if not matched:
         return value
@@ -240,39 +333,39 @@ def _render_image_saver_template(
     ):
         raise RuntimeError("[EasyUseAnima] AiO save template is too long.")
 
-    def replace_time(match: re.Match[str]) -> str:
-        return _image_saver_timestamp(now, match.group(1))
+    def replace_time(match: re.Match[str], max_length: int) -> str:
+        return _bounded_image_saver_timestamp(now, match.group(1), max_length)
 
-    def replace_counter(match: re.Match[str]) -> str:
+    def replace_counter(match: re.Match[str], max_length: int) -> str:
         padding = int(match.group(1))
         if padding > 32:
             raise RuntimeError(
                 "[EasyUseAnima] AiO save counter padding must be 32 or less."
             )
-        return f"{counter:0{padding}d}"
+        return _bounded_integer_text(counter, max_length, padding=padding)
 
     model_filename, base_model_name = _image_saver_model_names(modelname)
     value = _bounded_template_sub(_IMAGE_SAVER_CUSTOM_TIME_RE, replace_time, value)
     value = _bounded_template_sub(_IMAGE_SAVER_CUSTOM_COUNTER_RE, replace_counter, value)
     replacements = (
-        ("%date", _image_saver_timestamp(now, "%Y-%m-%d")),
-        ("%time", _image_saver_timestamp(now, time_format)),
-        ("%model", model_filename),
-        ("%width", str(width)),
-        ("%height", str(height)),
-        ("%seed", str(seed)),
-        ("%counter", str(counter)),
-        ("%sampler_name", sampler_name),
-        ("%steps", str(steps)),
-        ("%cfg", str(cfg)),
-        ("%scheduler_name", scheduler_name),
-        ("%basemodelname", base_model_name),
-        ("%denoise", str(denoise)),
-        ("%clip_skip", str(clip_skip)),
-        ("%custom", custom),
+        ("%date", lambda limit: _bounded_image_saver_timestamp(now, "%Y-%m-%d", limit)),
+        ("%time", lambda limit: _bounded_image_saver_timestamp(now, time_format, limit)),
+        ("%model", lambda _limit: model_filename),
+        ("%width", lambda limit: _bounded_integer_text(width, limit)),
+        ("%height", lambda limit: _bounded_integer_text(height, limit)),
+        ("%seed", lambda limit: _bounded_integer_text(seed, limit)),
+        ("%counter", lambda limit: _bounded_integer_text(counter, limit)),
+        ("%sampler_name", lambda _limit: sampler_name),
+        ("%steps", lambda limit: _bounded_integer_text(steps, limit)),
+        ("%cfg", lambda _limit: str(cfg)),
+        ("%scheduler_name", lambda _limit: scheduler_name),
+        ("%basemodelname", lambda _limit: base_model_name),
+        ("%denoise", lambda _limit: str(denoise)),
+        ("%clip_skip", lambda limit: _bounded_integer_text(clip_skip, limit)),
+        ("%custom", lambda _limit: custom),
     )
     for token, replacement in replacements:
-        value = _bounded_template_replace(value, token, replacement)
+        value = _bounded_template_replace_with(value, token, replacement)
     if "%" in value:
         raise RuntimeError(
             "[EasyUseAnima] AiO save template contains an unsupported placeholder."
@@ -333,7 +426,11 @@ def _resolve_image_saver_runtime(
         **template_values,
     )
     if not rendered_filename:
-        rendered_filename = _image_saver_timestamp(now, time_format)
+        rendered_filename = _bounded_image_saver_timestamp(
+            now,
+            time_format,
+            _MAX_OUTPUT_TEMPLATE_LENGTH,
+        )
     rendered_filename = _sanitize_native_output_filename(rendered_filename)
     output_root = _comfy_output_directory()
     safe_path = _validated_output_subpath(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -11171,6 +11171,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Iterator",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Iterator",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Iterator",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Mapping",
         "branch_context": [],
         "classification": "external",
@@ -11639,7 +11656,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 85
+            "line": 86
           }
         ],
         "classification": "external",
@@ -11647,7 +11664,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 86,
+        "line": 87,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11664,7 +11681,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 164
+            "line": 165
           }
         ],
         "classification": "external",
@@ -11672,7 +11689,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 165,
+        "line": 166,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11689,7 +11706,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 483
+            "line": 580
           }
         ],
         "classification": "external",
@@ -11697,7 +11714,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 484,
+        "line": 581,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -51235,174 +51252,206 @@
         "functions": [
           {
             "async": false,
-            "end_line": 73,
+            "end_line": 74,
             "kind": "function",
-            "line": 70,
+            "line": 71,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 81,
+            "end_line": 82,
             "kind": "function",
-            "line": 76,
+            "line": 77,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 102,
+            "end_line": 103,
             "kind": "function",
-            "line": 84,
+            "line": 85,
             "loc": 19,
             "qualified_name": "_comfy_output_directory"
           },
           {
             "async": false,
-            "end_line": 131,
+            "end_line": 132,
             "kind": "function",
-            "line": 105,
+            "line": 106,
             "loc": 27,
             "qualified_name": "_output_path_parts"
           },
           {
             "async": false,
-            "end_line": 158,
+            "end_line": 159,
             "kind": "function",
-            "line": 134,
+            "line": 135,
             "loc": 25,
             "qualified_name": "_validated_output_subpath"
           },
           {
             "async": false,
-            "end_line": 171,
+            "end_line": 172,
             "kind": "function",
-            "line": 161,
+            "line": 162,
             "loc": 11,
             "qualified_name": "_image_saver_model_names"
           },
           {
             "async": false,
-            "end_line": 178,
+            "end_line": 197,
             "kind": "function",
-            "line": 174,
-            "loc": 5,
-            "qualified_name": "_image_saver_timestamp"
+            "line": 175,
+            "loc": 23,
+            "qualified_name": "_iter_strftime_segments"
           },
           {
             "async": false,
-            "end_line": 188,
+            "end_line": 226,
             "kind": "function",
-            "line": 181,
-            "loc": 8,
-            "qualified_name": "_bounded_template_replace"
+            "line": 200,
+            "loc": 27,
+            "qualified_name": "_render_strftime_bounded"
           },
           {
             "async": false,
-            "end_line": 215,
+            "end_line": 241,
             "kind": "function",
-            "line": 191,
-            "loc": 25,
-            "qualified_name": "_bounded_template_sub"
-          },
-          {
-            "async": false,
-            "end_line": 282,
-            "kind": "function",
-            "line": 218,
-            "loc": 65,
-            "qualified_name": "_render_image_saver_template"
-          },
-          {
-            "async": false,
-            "end_line": 244,
-            "kind": "function",
-            "line": 243,
-            "loc": 2,
-            "qualified_name": "_render_image_saver_template.replace_time"
+            "line": 229,
+            "loc": 13,
+            "qualified_name": "_bounded_image_saver_timestamp"
           },
           {
             "async": false,
             "end_line": 252,
             "kind": "function",
-            "line": 246,
+            "line": 244,
+            "loc": 9,
+            "qualified_name": "_bounded_integer_text"
+          },
+          {
+            "async": false,
+            "end_line": 270,
+            "kind": "function",
+            "line": 255,
+            "loc": 16,
+            "qualified_name": "_bounded_template_replace_with"
+          },
+          {
+            "async": false,
+            "end_line": 278,
+            "kind": "function",
+            "line": 273,
+            "loc": 6,
+            "qualified_name": "_bounded_template_replace"
+          },
+          {
+            "async": false,
+            "end_line": 308,
+            "kind": "function",
+            "line": 281,
+            "loc": 28,
+            "qualified_name": "_bounded_template_sub"
+          },
+          {
+            "async": false,
+            "end_line": 375,
+            "kind": "function",
+            "line": 311,
+            "loc": 65,
+            "qualified_name": "_render_image_saver_template"
+          },
+          {
+            "async": false,
+            "end_line": 337,
+            "kind": "function",
+            "line": 336,
+            "loc": 2,
+            "qualified_name": "_render_image_saver_template.replace_time"
+          },
+          {
+            "async": false,
+            "end_line": 345,
+            "kind": "function",
+            "line": 339,
             "loc": 7,
             "qualified_name": "_render_image_saver_template.replace_counter"
           },
           {
             "async": false,
-            "end_line": 373,
+            "end_line": 470,
             "kind": "function",
-            "line": 285,
-            "loc": 89,
+            "line": 378,
+            "loc": 93,
             "qualified_name": "_resolve_image_saver_runtime"
           },
           {
             "async": false,
-            "end_line": 451,
+            "end_line": 548,
             "kind": "function",
-            "line": 376,
+            "line": 473,
             "loc": 76,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 475,
+            "end_line": 572,
             "kind": "function",
-            "line": 454,
+            "line": 551,
             "loc": 22,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 491,
+            "end_line": 588,
             "kind": "function",
-            "line": 478,
+            "line": 575,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 509,
+            "end_line": 606,
             "kind": "function",
-            "line": 494,
+            "line": 591,
             "loc": 16,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 534,
+            "end_line": 631,
             "kind": "function",
-            "line": 512,
+            "line": 609,
             "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 546,
+            "end_line": 643,
             "kind": "function",
-            "line": 537,
+            "line": 634,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 655,
+            "end_line": 752,
             "kind": "function",
-            "line": 549,
+            "line": 646,
             "loc": 107,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 658,
+        "loc": 755,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "e5e06a809307187807061db498e9888314065d52",
+        "normalized_git_blob_sha1": "1b1a13c31948d82ab56c64494a211dee3acd5b8b",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 18,
-          "global_count": 9
+          "function_count": 22,
+          "global_count": 10
         }
       },
       {
@@ -65159,6 +65208,17 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "collections.abc:Iterator",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "collections.abc:Mapping",
         "kind": "static_from",
         "line": 8,
@@ -65239,14 +65299,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 85
+            "line": 86
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 86,
+        "line": 87,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65258,14 +65318,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 164
+            "line": 165
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 165,
+        "line": 166,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65277,14 +65337,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 483
+            "line": 580
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 484,
+        "line": 581,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72144,14 +72204,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 85
+            "line": 86
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 86,
+        "line": 87,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72163,14 +72223,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 164
+            "line": 165
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 165,
+        "line": 166,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72182,14 +72242,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 483
+            "line": 580
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 484,
+        "line": 581,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -75002,11 +75062,20 @@
         "scope": "<module>"
       },
       {
+        "callee": "frozenset",
+        "column": 35,
+        "context": "assign:_STRFTIME_DIRECTIVE_PREFIX_CHARS",
+        "kind": "import_time_call",
+        "line": 45,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "dataclass",
         "column": 1,
         "context": "decorator:_ImageSaverRuntime",
         "kind": "import_time_call",
-        "line": 48,
+        "line": 49,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -11154,6 +11154,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Mapping",
         "branch_context": [],
         "classification": "external",
@@ -11622,7 +11639,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 83
+            "line": 85
           }
         ],
         "classification": "external",
@@ -11630,7 +11647,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 84,
+        "line": 86,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11647,7 +11664,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 162
+            "line": 164
           }
         ],
         "classification": "external",
@@ -11655,7 +11672,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 163,
+        "line": 165,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11672,7 +11689,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 483
           }
         ],
         "classification": "external",
@@ -11680,7 +11697,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 442,
+        "line": 484,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -51218,158 +51235,174 @@
         "functions": [
           {
             "async": false,
-            "end_line": 71,
+            "end_line": 73,
             "kind": "function",
-            "line": 68,
+            "line": 70,
             "loc": 4,
             "qualified_name": "_missing_host_helper"
           },
           {
             "async": false,
-            "end_line": 79,
+            "end_line": 81,
             "kind": "function",
-            "line": 74,
+            "line": 76,
             "loc": 6,
             "qualified_name": "_find_comfy_node_class"
           },
           {
             "async": false,
-            "end_line": 100,
+            "end_line": 102,
             "kind": "function",
-            "line": 82,
+            "line": 84,
             "loc": 19,
             "qualified_name": "_comfy_output_directory"
           },
           {
             "async": false,
-            "end_line": 129,
+            "end_line": 131,
             "kind": "function",
-            "line": 103,
+            "line": 105,
             "loc": 27,
             "qualified_name": "_output_path_parts"
           },
           {
             "async": false,
-            "end_line": 156,
+            "end_line": 158,
             "kind": "function",
-            "line": 132,
+            "line": 134,
             "loc": 25,
             "qualified_name": "_validated_output_subpath"
           },
           {
             "async": false,
-            "end_line": 169,
+            "end_line": 171,
             "kind": "function",
-            "line": 159,
+            "line": 161,
             "loc": 11,
             "qualified_name": "_image_saver_model_names"
           },
           {
             "async": false,
-            "end_line": 176,
+            "end_line": 178,
             "kind": "function",
-            "line": 172,
+            "line": 174,
             "loc": 5,
             "qualified_name": "_image_saver_timestamp"
           },
           {
             "async": false,
-            "end_line": 240,
+            "end_line": 188,
             "kind": "function",
-            "line": 179,
-            "loc": 62,
+            "line": 181,
+            "loc": 8,
+            "qualified_name": "_bounded_template_replace"
+          },
+          {
+            "async": false,
+            "end_line": 215,
+            "kind": "function",
+            "line": 191,
+            "loc": 25,
+            "qualified_name": "_bounded_template_sub"
+          },
+          {
+            "async": false,
+            "end_line": 282,
+            "kind": "function",
+            "line": 218,
+            "loc": 65,
             "qualified_name": "_render_image_saver_template"
           },
           {
             "async": false,
-            "end_line": 202,
+            "end_line": 244,
             "kind": "function",
-            "line": 201,
+            "line": 243,
             "loc": 2,
             "qualified_name": "_render_image_saver_template.replace_time"
           },
           {
             "async": false,
-            "end_line": 210,
+            "end_line": 252,
             "kind": "function",
-            "line": 204,
+            "line": 246,
             "loc": 7,
             "qualified_name": "_render_image_saver_template.replace_counter"
           },
           {
             "async": false,
-            "end_line": 331,
+            "end_line": 373,
             "kind": "function",
-            "line": 243,
+            "line": 285,
             "loc": 89,
             "qualified_name": "_resolve_image_saver_runtime"
           },
           {
             "async": false,
-            "end_line": 409,
+            "end_line": 451,
             "kind": "function",
-            "line": 334,
+            "line": 376,
             "loc": 76,
             "qualified_name": "_aio_image_saver_civitai_hash_fetcher_entries"
           },
           {
             "async": false,
-            "end_line": 433,
+            "end_line": 475,
             "kind": "function",
-            "line": 412,
+            "line": 454,
             "loc": 22,
             "qualified_name": "_aio_image_saver_additional_hashes"
           },
           {
             "async": false,
-            "end_line": 449,
+            "end_line": 491,
             "kind": "function",
-            "line": 436,
+            "line": 478,
             "loc": 14,
             "qualified_name": "_aio_lora_metadata_name"
           },
           {
             "async": false,
-            "end_line": 467,
+            "end_line": 509,
             "kind": "function",
-            "line": 452,
+            "line": 494,
             "loc": 16,
             "qualified_name": "_aio_prompt_with_lora_metadata"
           },
           {
             "async": false,
-            "end_line": 492,
+            "end_line": 534,
             "kind": "function",
-            "line": 470,
+            "line": 512,
             "loc": 23,
             "qualified_name": "_save_image_with_comfy"
           },
           {
             "async": false,
-            "end_line": 504,
+            "end_line": 546,
             "kind": "function",
-            "line": 495,
+            "line": 537,
             "loc": 10,
             "qualified_name": "_aio_save_filename_prefix"
           },
           {
             "async": false,
-            "end_line": 613,
+            "end_line": 655,
             "kind": "function",
-            "line": 507,
+            "line": 549,
             "loc": 107,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 616,
+        "loc": 658,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "f84d2a924da6effd590c466f0272f2d46429064a",
+        "normalized_git_blob_sha1": "e5e06a809307187807061db498e9888314065d52",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 16,
-          "global_count": 7
+          "function_count": 18,
+          "global_count": 9
         }
       },
       {
@@ -65115,6 +65148,17 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "collections.abc:Mapping",
         "kind": "static_from",
         "line": 8,
@@ -65195,14 +65239,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 83
+            "line": 85
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 84,
+        "line": 86,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65214,14 +65258,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 162
+            "line": 164
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 163,
+        "line": 165,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -65233,14 +65277,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 483
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 442,
+        "line": 484,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72100,14 +72144,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 83
+            "line": 85
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 84,
+        "line": 86,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72119,14 +72163,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 162
+            "line": 164
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 163,
+        "line": 165,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -72138,14 +72182,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 483
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 442,
+        "line": 484,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -74962,7 +75006,7 @@
         "column": 1,
         "context": "decorator:_ImageSaverRuntime",
         "kind": "import_time_call",
-        "line": 46,
+        "line": 48,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
       },

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -30,16 +30,23 @@ def fake_folder_paths(output_root: str) -> types.ModuleType:
     return module
 
 
-def render_output_template(pattern: str, *, custom: str) -> str:
+def render_output_template(
+    pattern: str,
+    *,
+    custom: str,
+    now=None,
+    counter: int = 7,
+    time_format: str = "%Y-%m-%d-%H%M%S",
+) -> str:
     return output._render_image_saver_template(
         pattern,
-        now=datetime(2026, 9, 4, 12, 34, 56),
+        now=now or datetime(2026, 9, 4, 12, 34, 56),
         width=1024,
         height=1024,
         seed=11,
         modelname="anima.safetensors",
-        counter=7,
-        time_format="%Y-%m-%d-%H%M%S",
+        counter=counter,
+        time_format=time_format,
         sampler_name="euler",
         steps=28,
         cfg=5.0,
@@ -541,18 +548,87 @@ class AIOOutputMoveTests(unittest.TestCase):
 
         with patch.object(
             output,
-            "_bounded_template_replace",
-            wraps=output._bounded_template_replace,
+            "_bounded_template_replace_with",
+            wraps=output._bounded_template_replace_with,
         ) as bounded_replace:
             with self.assertRaisesRegex(RuntimeError, "template result is too long"):
                 render_output_template("%custom" * 128, custom="abcdefghi")
-        bounded_replace.assert_any_call(ANY, "%custom", "abcdefghi")
+        self.assertTrue(
+            any(call.args[1] == "%custom" for call in bounded_replace.call_args_list)
+        )
 
     def test_template_expansion_accepts_exact_result_budget(self):
         rendered = render_output_template("%custom" * 128, custom="abcdefgh")
 
         self.assertEqual(rendered, "abcdefgh" * 128)
         self.assertEqual(len(rendered), 1024)
+
+    def test_template_time_width_is_rejected_before_strftime(self):
+        class StrftimeTrap:
+            def __init__(self):
+                self.calls = []
+
+            def strftime(self, time_format):
+                self.calls.append(time_format)
+                raise AssertionError("oversized field width must not reach strftime")
+
+        for pattern, time_format in (
+            ("%time_format<%9999Y>", "%Y-%m-%d"),
+            ("%time", "%9999Y"),
+        ):
+            now = StrftimeTrap()
+            with self.subTest(pattern=pattern), self.assertRaisesRegex(
+                RuntimeError, "template result is too long"
+            ):
+                render_output_template(
+                    pattern,
+                    custom="",
+                    now=now,
+                    time_format=time_format,
+                )
+            self.assertEqual(now.calls, [])
+
+        fallback_now = StrftimeTrap()
+
+        class FixedDateTime:
+            @staticmethod
+            def now():
+                return fallback_now
+
+        settings = {
+            "image_saver": {
+                **AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"],
+                "filename": "%custom",
+                "custom": "",
+                "time_format": "%9999Y",
+            }
+        }
+        with patch.object(output, "datetime", FixedDateTime), self.assertRaisesRegex(
+            RuntimeError, "template result is too long"
+        ):
+            output._resolve_image_saver_runtime(
+                settings,
+                width=1024,
+                height=1024,
+                sampler_settings={"seed": 11},
+                resource_info=None,
+            )
+        self.assertEqual(fallback_now.calls, [])
+
+    def test_template_counter_is_rejected_before_decimal_formatting(self):
+        class FormatTrap(int):
+            def __str__(self):
+                raise AssertionError("oversized counter must not be stringified")
+
+            def __format__(self, _format_spec):
+                raise AssertionError("oversized counter must not be formatted")
+
+        counter = FormatTrap(10**1024)
+        for pattern in ("%counter", "%counter<03>"):
+            with self.subTest(pattern=pattern), self.assertRaisesRegex(
+                RuntimeError, "template result is too long"
+            ):
+                render_output_template(pattern, custom="", counter=counter)
 
     def test_image_saver_sanitizes_windows_filename_before_native_writer(self):
         settings = {

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -30,6 +30,26 @@ def fake_folder_paths(output_root: str) -> types.ModuleType:
     return module
 
 
+def render_output_template(pattern: str, *, custom: str) -> str:
+    return output._render_image_saver_template(
+        pattern,
+        now=datetime(2026, 9, 4, 12, 34, 56),
+        width=1024,
+        height=1024,
+        seed=11,
+        modelname="anima.safetensors",
+        counter=7,
+        time_format="%Y-%m-%d-%H%M%S",
+        sampler_name="euler",
+        steps=28,
+        cfg=5.0,
+        scheduler_name="normal",
+        denoise=1.0,
+        clip_skip=-2,
+        custom=custom,
+    )
+
+
 class AIOOutputMoveTests(unittest.TestCase):
     def test_output_functions_are_owned_by_canonical_modules(self):
         for name in (
@@ -509,6 +529,30 @@ class AIOOutputMoveTests(unittest.TestCase):
         self.assertEqual(result, "saved")
         self.assertEqual(save.call_args.kwargs["path"], "renders/2026/09")
         self.assertEqual(save.call_args.kwargs["filename"], "safe_007_anima")
+
+    def test_template_expansion_rejects_before_oversized_literal_replace(self):
+        class ReplaceTrap(str):
+            def replace(self, *_args, **_kwargs):
+                raise AssertionError("oversized replacement must not be materialized")
+
+        pattern = ReplaceTrap("%custom" * 128)
+        with self.assertRaisesRegex(RuntimeError, "template result is too long"):
+            output._bounded_template_replace(pattern, "%custom", "abcdefghi")
+
+        with patch.object(
+            output,
+            "_bounded_template_replace",
+            wraps=output._bounded_template_replace,
+        ) as bounded_replace:
+            with self.assertRaisesRegex(RuntimeError, "template result is too long"):
+                render_output_template("%custom" * 128, custom="abcdefghi")
+        bounded_replace.assert_any_call(ANY, "%custom", "abcdefghi")
+
+    def test_template_expansion_accepts_exact_result_budget(self):
+        rendered = render_output_template("%custom" * 128, custom="abcdefgh")
+
+        self.assertEqual(rendered, "abcdefgh" * 128)
+        self.assertEqual(len(rendered), 1024)
 
     def test_image_saver_sanitizes_windows_filename_before_native_writer(self):
         settings = {


### PR DESCRIPTION
목적과 변경 경계: 직렬화된 워크플로우의 반복 placeholder가 큰 치환값을 증폭해 queue-time 메모리·CPU를 소비하지 못하도록 모든 template 치환 단계에 1,024자 hard budget을 적용합니다. Base -> Head: dev@ef88dd1 -> codex/output-template-budget@8ca15a0. 주요 파일과 보존 계약: output.py의 기존 custom time/counter 및 고정 placeholder 순서와 값은 유지하며, 각 정규식 join 또는 str.replace 전에 예상 결과 길이를 검사합니다. 정상 1,024자 결과와 기존 path containment, Windows 파일명 검증은 유지합니다. 생성 backend baseline은 구현 변화에 맞춰 저장소 analyzer로 재생성했습니다. 검증: 대형 반복 %custom이 str.replace 전 거부되는 직접·통합 회귀, 정확히 1,024자 결과, 기존 time/counter/model template 및 expanded escape 테스트, analyzer fixture, 변경 파일 Ruff 0.15.22, quick 프로필(frontend 123 files) 통과. Ruff 25건은 기존 report-only 기준선입니다. 남은 gate: 독립 보안 검토와 최종 full. 위험과 rollback: 이상한 replacement 내 placeholder 조합도 기존 순차 순서를 유지하되 중간 결과가 예산을 넘으면 이제 fail-closed 합니다. 커밋 revert로 복구 가능합니다. Refs #709. Next: 보안 검토와 full 통과 후 dev에 squash 병합하고 #709를 닫습니다.