### PR TITLE
fix(aio): prevent EXIF key shadowing

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -25,7 +25,9 @@ at `save.image_saver`. The UI presents that compatibility ID as
 The writer owns the `parameters` and `prompt` metadata keys. Matching keys in
 `extra_pnginfo` are compared case-insensitively and ignored so caller-provided
 aliases cannot replace the A1111 block, serialized ComfyUI prompt, or canonical
-lowercase `workflow`. Unrelated extra metadata is preserved.
+lowercase `workflow`. Keys beginning with an owned name plus `:` are reserved
+too because EXIF serializes the key and JSON value with that delimiter.
+Unrelated extra metadata is preserved.
 
 `Save workflow JSON` writes the workflow as a same-stem UTF-8 JSON sidecar for
 all formats. If JPEG EXIF would exceed its safe size, serialization first drops
@@ -50,7 +52,9 @@ metadata-free JPEGs, and every non-JPEG input delegate to the exact previous
 handler with the original receiver and arguments. PNG and WebP therefore stay
 on ComfyUI's native parser path. Exact lowercase `workflow:` and `prompt:` EXIF
 fields take priority over case-insensitive compatibility aliases regardless of
-directory order. Installation is idempotent and is skipped when
+directory order. Malformed exact candidates do not hide a later valid exact
+field, but the presence of any exact candidate disables alias fallback for that
+field. Installation is idempotent and is skipped when
 the host exposes a native `getJpegMetadata` capability or declares JPEG in its
 handler metadata MIME types; the same capability is checked again for each
 file so a later host upgrade also wins.

--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -23,8 +23,9 @@ at `save.image_saver`. The UI presents that compatibility ID as
 | WebP | EXIF `UserComment` | EXIF `Model`/`Make` fields | quality 1-100 or lossless |
 
 The writer owns the `parameters` and `prompt` metadata keys. Matching keys in
-`extra_pnginfo` are ignored so caller-provided extras cannot replace the A1111
-block or the serialized ComfyUI prompt.
+`extra_pnginfo` are compared case-insensitively and ignored so caller-provided
+aliases cannot replace the A1111 block, serialized ComfyUI prompt, or canonical
+lowercase `workflow`. Unrelated extra metadata is preserved.
 
 `Save workflow JSON` writes the workflow as a same-stem UTF-8 JSON sidecar for
 all formats. If JPEG EXIF would exceed its safe size, serialization first drops
@@ -47,7 +48,9 @@ EXIF segment, and rejects TIFF directories above 256 entries or field values
 above 65,535 bytes. Invalid offsets, truncated segments, malformed JSON,
 metadata-free JPEGs, and every non-JPEG input delegate to the exact previous
 handler with the original receiver and arguments. PNG and WebP therefore stay
-on ComfyUI's native parser path. Installation is idempotent and is skipped when
+on ComfyUI's native parser path. Exact lowercase `workflow:` and `prompt:` EXIF
+fields take priority over case-insensitive compatibility aliases regardless of
+directory order. Installation is idempotent and is skipped when
 the host exposes a native `getJpegMetadata` capability or declares JPEG in its
 handler metadata MIME types; the same capability is checked again for each
 file so a later host upgrade also wins.

--- a/easyuse_anima/aio/native_metadata_budget.py
+++ b/easyuse_anima/aio/native_metadata_budget.py
@@ -292,7 +292,11 @@ def _prepare_metadata_payload(
         for key, value in extra_values.items():
             key_text = _extra_pnginfo_key(key)
             canonical_key = key_text.casefold()
-            if canonical_key in _RESERVED_EXTRA_PNGINFO_KEYS and key_text != "workflow":
+            is_reserved = any(
+                canonical_key == reserved or canonical_key.startswith(f"{reserved}:")
+                for reserved in _RESERVED_EXTRA_PNGINFO_KEYS
+            )
+            if is_reserved and key_text != "workflow":
                 logger.warning(
                     "[EasyUseAnima] Ignoring reserved extra_pnginfo key %r.",
                     key_text,

--- a/easyuse_anima/aio/native_metadata_budget.py
+++ b/easyuse_anima/aio/native_metadata_budget.py
@@ -26,6 +26,7 @@ _MAX_SAVE_METADATA_BYTES = 64 * 1024 * 1024
 
 _TEXT_CHUNK_CHARACTERS = 64 * 1024
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_RESERVED_EXTRA_PNGINFO_KEYS = frozenset({"parameters", "prompt", "workflow"})
 
 
 class MetadataLimitError(RuntimeError):
@@ -290,7 +291,8 @@ def _prepare_metadata_payload(
         _validate_extra_pnginfo_count(extra_values)
         for key, value in extra_values.items():
             key_text = _extra_pnginfo_key(key)
-            if key_text in {"parameters", "prompt"}:
+            canonical_key = key_text.casefold()
+            if canonical_key in _RESERVED_EXTRA_PNGINFO_KEYS and key_text != "workflow":
                 logger.warning(
                     "[EasyUseAnima] Ignoring reserved extra_pnginfo key %r.",
                     key_text,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -50468,126 +50468,126 @@
         "functions": [
           {
             "async": false,
-            "end_line": 45,
+            "end_line": 46,
             "kind": "function",
-            "line": 35,
+            "line": 36,
             "loc": 11,
             "qualified_name": "_utf8_size"
           },
           {
             "async": false,
-            "end_line": 61,
+            "end_line": 62,
             "kind": "function",
-            "line": 48,
+            "line": 49,
             "loc": 14,
             "qualified_name": "_scalar_size"
           },
           {
             "async": false,
-            "end_line": 149,
+            "end_line": 150,
             "kind": "function",
-            "line": 64,
+            "line": 65,
             "loc": 86,
             "qualified_name": "_validate_json_structure"
           },
           {
             "async": false,
-            "end_line": 81,
+            "end_line": 82,
             "kind": "function",
-            "line": 75,
+            "line": 76,
             "loc": 7,
             "qualified_name": "_validate_json_structure.add_bytes"
           },
           {
             "async": false,
-            "end_line": 187,
+            "end_line": 188,
             "kind": "function",
-            "line": 152,
+            "line": 153,
             "loc": 36,
             "qualified_name": "_json_dumps_limited"
           },
           {
             "async": false,
-            "end_line": 191,
+            "end_line": 192,
             "kind": "function",
-            "line": 190,
+            "line": 191,
             "loc": 2,
             "qualified_name": "_metadata_text_size"
           },
           {
             "async": false,
-            "end_line": 207,
+            "end_line": 208,
             "kind": "function",
-            "line": 194,
+            "line": 195,
             "loc": 14,
             "qualified_name": "_validate_parameter_sources"
           },
           {
             "async": false,
-            "end_line": 217,
+            "end_line": 218,
             "kind": "function",
-            "line": 210,
+            "line": 211,
             "loc": 8,
             "qualified_name": "_extra_pnginfo_key"
           },
           {
             "async": false,
-            "end_line": 224,
+            "end_line": 225,
             "kind": "function",
-            "line": 220,
+            "line": 221,
             "loc": 5,
             "qualified_name": "_validate_extra_pnginfo_count"
           },
           {
             "async": false,
-            "end_line": 245,
+            "end_line": 246,
             "kind": "method",
-            "line": 236,
+            "line": 237,
             "loc": 10,
             "qualified_name": "_PreparedMetadataPayload.ensure_workflow_sidecar"
           },
           {
             "async": false,
-            "end_line": 336,
+            "end_line": 338,
             "kind": "function",
-            "line": 248,
-            "loc": 89,
+            "line": 249,
+            "loc": 90,
             "qualified_name": "_prepare_metadata_payload"
           },
           {
             "async": false,
-            "end_line": 344,
+            "end_line": 346,
             "kind": "function",
-            "line": 339,
+            "line": 341,
             "loc": 6,
             "qualified_name": "_validate_embedded_metadata_size"
           },
           {
             "async": false,
-            "end_line": 352,
+            "end_line": 354,
             "kind": "function",
-            "line": 347,
+            "line": 349,
             "loc": 6,
             "qualified_name": "_validate_save_metadata_size"
           },
           {
             "async": false,
-            "end_line": 371,
+            "end_line": 373,
             "kind": "function",
-            "line": 355,
+            "line": 357,
             "loc": 17,
             "qualified_name": "_sidecar_required_and_validate_batch"
           }
         ],
         "is_package": false,
-        "loc": 374,
+        "loc": 376,
         "module": "easyuse_anima.aio.native_metadata_budget",
-        "normalized_git_blob_sha1": "6f901c4ecd75af20318a224d58b7a1a15d32b3b0",
+        "normalized_git_blob_sha1": "3aa5b9f2eca5e46a414d4b3c1dcbe4ce63d11c5f",
         "path": "easyuse_anima/aio/native_metadata_budget.py",
         "top_level": {
           "class_count": 2,
           "function_count": 12,
-          "global_count": 15
+          "global_count": 16
         }
       },
       {
@@ -74855,11 +74855,20 @@
         "scope": "<module>"
       },
       {
+        "callee": "frozenset",
+        "column": 31,
+        "context": "assign:_RESERVED_EXTRA_PNGINFO_KEYS",
+        "kind": "import_time_call",
+        "line": 29,
+        "module": "easyuse_anima/aio/native_metadata_budget.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "dataclass",
         "column": 1,
         "context": "decorator:_PreparedMetadataPayload",
         "kind": "import_time_call",
-        "line": 227,
+        "line": 228,
         "module": "easyuse_anima/aio/native_metadata_budget.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -50548,41 +50548,41 @@
           },
           {
             "async": false,
-            "end_line": 338,
+            "end_line": 342,
             "kind": "function",
             "line": 249,
-            "loc": 90,
+            "loc": 94,
             "qualified_name": "_prepare_metadata_payload"
           },
           {
             "async": false,
-            "end_line": 346,
+            "end_line": 350,
             "kind": "function",
-            "line": 341,
+            "line": 345,
             "loc": 6,
             "qualified_name": "_validate_embedded_metadata_size"
           },
           {
             "async": false,
-            "end_line": 354,
+            "end_line": 358,
             "kind": "function",
-            "line": 349,
+            "line": 353,
             "loc": 6,
             "qualified_name": "_validate_save_metadata_size"
           },
           {
             "async": false,
-            "end_line": 373,
+            "end_line": 377,
             "kind": "function",
-            "line": 357,
+            "line": 361,
             "loc": 17,
             "qualified_name": "_sidecar_required_and_validate_batch"
           }
         ],
         "is_package": false,
-        "loc": 376,
+        "loc": 380,
         "module": "easyuse_anima.aio.native_metadata_budget",
-        "normalized_git_blob_sha1": "3aa5b9f2eca5e46a414d4b3c1dcbe4ce63d11c5f",
+        "normalized_git_blob_sha1": "985165bfd0a9c88672bb9d82e2ab499d91984947",
         "path": "easyuse_anima/aio/native_metadata_budget.py",
         "top_level": {
           "class_count": 2,

--- a/tests/frontend_aio_jpeg_workflow_import_smoke.mjs
+++ b/tests/frontend_aio_jpeg_workflow_import_smoke.mjs
@@ -110,6 +110,8 @@ const forgedPrompt = { forged: { class_type: "Forged", inputs: {} } };
 const shadowedJpeg = jpegWithExifTextFields([
   `Workflow:${JSON.stringify(forgedWorkflow)}`,
   `Prompt:${JSON.stringify(forgedPrompt)}`,
+  `workflow::${JSON.stringify(forgedWorkflow)}`,
+  `prompt::${JSON.stringify(forgedPrompt)}`,
   `workflow:${JSON.stringify(expectedWorkflow)}`,
   `prompt:${JSON.stringify(expectedPrompt)}`,
 ]);
@@ -127,6 +129,18 @@ assert.deepEqual(
   metadataModule.aioParseNativeJpegMetadata(aliasOnlyJpeg),
   { workflow: forgedWorkflow, prompt: forgedPrompt },
   "alias-only legacy metadata must remain readable",
+);
+
+const malformedCanonicalJpeg = jpegWithExifTextFields([
+  `Workflow:${JSON.stringify(forgedWorkflow)}`,
+  `Prompt:${JSON.stringify(forgedPrompt)}`,
+  "workflow:not-json",
+  "prompt:not-json",
+]);
+assert.equal(
+  metadataModule.aioParseNativeJpegMetadata(malformedCanonicalJpeg),
+  undefined,
+  "malformed exact metadata must block fallback to case-variant aliases",
 );
 
 const malformedWorkflow = Buffer.from(WORKFLOW_JPEG);

--- a/tests/frontend_aio_jpeg_workflow_import_smoke.mjs
+++ b/tests/frontend_aio_jpeg_workflow_import_smoke.mjs
@@ -44,6 +44,47 @@ function exactArrayBuffer(bytes) {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
 }
 
+function jpegWithExifTextFields(fields) {
+  const values = fields.map((field) => {
+    const encoded = new TextEncoder().encode(field);
+    const terminated = new Uint8Array(encoded.byteLength + 1);
+    terminated.set(encoded);
+    return terminated;
+  });
+  const ifdOffset = 8;
+  const entriesOffset = ifdOffset + 2;
+  const valuesOffset = entriesOffset + values.length * 12 + 4;
+  const valuesLength = values.reduce((total, value) => total + value.byteLength, 0);
+  const tiff = new Uint8Array(valuesOffset + valuesLength);
+  const view = new DataView(tiff.buffer);
+  tiff.set([0x4d, 0x4d], 0);
+  view.setUint16(2, 42, false);
+  view.setUint32(4, ifdOffset, false);
+  view.setUint16(ifdOffset, values.length, false);
+
+  let valueOffset = valuesOffset;
+  values.forEach((value, index) => {
+    const entryOffset = entriesOffset + index * 12;
+    view.setUint16(entryOffset, 0x0100 + index, false);
+    view.setUint16(entryOffset + 2, 2, false);
+    view.setUint32(entryOffset + 4, value.byteLength, false);
+    view.setUint32(entryOffset + 8, valueOffset, false);
+    tiff.set(value, valueOffset);
+    valueOffset += value.byteLength;
+  });
+  view.setUint32(entriesOffset + values.length * 12, 0, false);
+
+  const exif = new Uint8Array(6 + tiff.byteLength);
+  exif.set([0x45, 0x78, 0x69, 0x66, 0x00, 0x00]);
+  exif.set(tiff, 6);
+  const segmentLength = exif.byteLength + 2;
+  const jpeg = new Uint8Array(8 + exif.byteLength);
+  jpeg.set([0xff, 0xd8, 0xff, 0xe1, segmentLength >> 8, segmentLength & 0xff]);
+  jpeg.set(exif, 6);
+  jpeg.set([0xff, 0xd9], 6 + exif.byteLength);
+  return jpeg;
+}
+
 function jpegFile(bytes, { name = "native-output.jpeg", type = "image/jpeg" } = {}) {
   const slices = [];
   return {
@@ -63,6 +104,30 @@ const expectedWorkflow = { last_node_id: 1, nodes: [], links: [] };
 const expectedPrompt = { 1: { class_type: "KSampler", inputs: {} } };
 const parsed = metadataModule.aioParseNativeJpegMetadata(WORKFLOW_JPEG);
 assert.deepEqual(parsed, { workflow: expectedWorkflow, prompt: expectedPrompt });
+
+const forgedWorkflow = { last_node_id: 999, nodes: [{ id: "forged" }], links: [] };
+const forgedPrompt = { forged: { class_type: "Forged", inputs: {} } };
+const shadowedJpeg = jpegWithExifTextFields([
+  `Workflow:${JSON.stringify(forgedWorkflow)}`,
+  `Prompt:${JSON.stringify(forgedPrompt)}`,
+  `workflow:${JSON.stringify(expectedWorkflow)}`,
+  `prompt:${JSON.stringify(expectedPrompt)}`,
+]);
+assert.deepEqual(
+  metadataModule.aioParseNativeJpegMetadata(shadowedJpeg),
+  { workflow: expectedWorkflow, prompt: expectedPrompt },
+  "exact canonical metadata must win even when aliases appear first",
+);
+
+const aliasOnlyJpeg = jpegWithExifTextFields([
+  `WORKFLOW:${JSON.stringify(forgedWorkflow)}`,
+  `PROMPT:${JSON.stringify(forgedPrompt)}`,
+]);
+assert.deepEqual(
+  metadataModule.aioParseNativeJpegMetadata(aliasOnlyJpeg),
+  { workflow: forgedWorkflow, prompt: forgedPrompt },
+  "alias-only legacy metadata must remain readable",
+);
 
 const malformedWorkflow = Buffer.from(WORKFLOW_JPEG);
 const workflowPrefix = Buffer.from("workflow:{", "utf8");

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -1040,37 +1040,47 @@ class AIONativeImageOutputTests(unittest.TestCase):
             with self.subTest(component=component):
                 self.assertTrue(native._is_windows_safe_output_component(component))
 
-    def test_png_extra_metadata_cannot_override_owned_parameters_or_prompt(self):
+    def test_png_extra_metadata_case_variants_cannot_override_owned_keys(self):
         metadata = native.NativeImageMetadata("owned parameters", "", {})
         pixels = np.zeros((2, 2, 3), dtype=np.float32)
         prompt = {"owned": True}
         workflow = {"nodes": []}
+        forged_workflow = {"nodes": [{"id": "forged"}]}
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            native._save_native_images(
-                [FakeTensor(pixels)],
-                output_root=root,
-                path="",
-                filename="reserved-keys",
-                extension="png",
-                quality_jpeg_or_webp=80,
-                lossless_webp=False,
-                optimize_png=False,
-                embed_workflow=True,
-                save_workflow_as_json=False,
-                metadata=metadata,
-                prompt=prompt,
-                extra_pnginfo={
-                    "workflow": workflow,
-                    "parameters": "forged parameters",
-                    "prompt": {"forged": True},
-                },
-            )
+            with self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING"):
+                native._save_native_images(
+                    [FakeTensor(pixels)],
+                    output_root=root,
+                    path="",
+                    filename="reserved-keys",
+                    extension="png",
+                    quality_jpeg_or_webp=80,
+                    lossless_webp=False,
+                    optimize_png=False,
+                    embed_workflow=True,
+                    save_workflow_as_json=False,
+                    metadata=metadata,
+                    prompt=prompt,
+                    extra_pnginfo={
+                        "Workflow": forged_workflow,
+                        "WORKFLOW": forged_workflow,
+                        "Prompt": {"forged": True},
+                        "PARAMETERS": "forged parameters",
+                        "workflow": workflow,
+                        "parameters": "forged parameters",
+                        "prompt": {"forged": True},
+                        "unrelated": {"kept": True},
+                    },
+                )
 
             with Image.open(root / "reserved-keys.png") as saved:
                 self.assertEqual(saved.info["parameters"], metadata.parameters)
                 self.assertEqual(json.loads(saved.info["prompt"]), prompt)
                 self.assertEqual(json.loads(saved.info["workflow"]), workflow)
+                self.assertEqual(json.loads(saved.info["unrelated"]), {"kept": True})
+                for alias in ("Workflow", "WORKFLOW", "Prompt", "PARAMETERS"):
+                    self.assertNotIn(alias, saved.info)
 
     def test_lossy_webp_uses_quality_while_lossless_webp_preserves_pixels(self):
         rng = np.random.default_rng(7)

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -1067,6 +1067,9 @@ class AIONativeImageOutputTests(unittest.TestCase):
                         "WORKFLOW": forged_workflow,
                         "Prompt": {"forged": True},
                         "PARAMETERS": "forged parameters",
+                        "workflow:": forged_workflow,
+                        "Prompt:alias": {"forged": True},
+                        "PARAMETERS:alias": "forged parameters",
                         "workflow": workflow,
                         "parameters": "forged parameters",
                         "prompt": {"forged": True},
@@ -1079,7 +1082,15 @@ class AIONativeImageOutputTests(unittest.TestCase):
                 self.assertEqual(json.loads(saved.info["prompt"]), prompt)
                 self.assertEqual(json.loads(saved.info["workflow"]), workflow)
                 self.assertEqual(json.loads(saved.info["unrelated"]), {"kept": True})
-                for alias in ("Workflow", "WORKFLOW", "Prompt", "PARAMETERS"):
+                for alias in (
+                    "Workflow",
+                    "WORKFLOW",
+                    "Prompt",
+                    "PARAMETERS",
+                    "workflow:",
+                    "Prompt:alias",
+                    "PARAMETERS:alias",
+                ):
                     self.assertNotIn(alias, saved.info)
 
     def test_lossy_webp_uses_quality_while_lossless_webp_preserves_pixels(self):

--- a/web/js/aio/jpeg_workflow_metadata.js
+++ b/web/js/aio/jpeg_workflow_metadata.js
@@ -114,8 +114,10 @@ function parseExifPayload(payload) {
     return undefined;
   }
 
-  let workflowText;
-  let promptText;
+  let canonicalWorkflowText;
+  let canonicalPromptText;
+  let workflowAliasText;
+  let promptAliasText;
   for (let index = 0; index < entryCount; index += 1) {
     const entryOffset = entriesOffset + index * 12;
     const type = view.getUint16(entryOffset + 2, littleEndian);
@@ -131,14 +133,28 @@ function parseExifPayload(payload) {
     );
     if (!field) continue;
     const text = decodeAscii(field);
+    if (canonicalWorkflowText === undefined && text.startsWith("workflow:")) {
+      canonicalWorkflowText = text.slice("workflow:".length);
+      continue;
+    }
+    if (canonicalPromptText === undefined && text.startsWith("prompt:")) {
+      canonicalPromptText = text.slice("prompt:".length);
+      continue;
+    }
     const lower = text.toLowerCase();
-    if (workflowText === undefined && lower.startsWith("workflow:")) {
-      workflowText = text.slice("workflow:".length);
-    } else if (promptText === undefined && lower.startsWith("prompt:")) {
-      promptText = text.slice("prompt:".length);
+    if (workflowAliasText === undefined && lower.startsWith("workflow:")) {
+      workflowAliasText = text.slice("workflow:".length);
+    } else if (promptAliasText === undefined && lower.startsWith("prompt:")) {
+      promptAliasText = text.slice("prompt:".length);
     }
   }
 
+  const workflowText = canonicalWorkflowText === undefined
+    ? workflowAliasText
+    : canonicalWorkflowText;
+  const promptText = canonicalPromptText === undefined
+    ? promptAliasText
+    : canonicalPromptText;
   const workflow = parseMetadataObject(workflowText);
   const prompt = parseMetadataObject(promptText);
   if (workflow === undefined && prompt === undefined) return undefined;

--- a/web/js/aio/jpeg_workflow_metadata.js
+++ b/web/js/aio/jpeg_workflow_metadata.js
@@ -114,8 +114,10 @@ function parseExifPayload(payload) {
     return undefined;
   }
 
-  let canonicalWorkflowText;
-  let canonicalPromptText;
+  let canonicalWorkflow;
+  let canonicalPrompt;
+  let sawCanonicalWorkflow = false;
+  let sawCanonicalPrompt = false;
   let workflowAliasText;
   let promptAliasText;
   for (let index = 0; index < entryCount; index += 1) {
@@ -133,12 +135,18 @@ function parseExifPayload(payload) {
     );
     if (!field) continue;
     const text = decodeAscii(field);
-    if (canonicalWorkflowText === undefined && text.startsWith("workflow:")) {
-      canonicalWorkflowText = text.slice("workflow:".length);
+    if (text.startsWith("workflow:")) {
+      sawCanonicalWorkflow = true;
+      if (canonicalWorkflow === undefined) {
+        canonicalWorkflow = parseMetadataObject(text.slice("workflow:".length));
+      }
       continue;
     }
-    if (canonicalPromptText === undefined && text.startsWith("prompt:")) {
-      canonicalPromptText = text.slice("prompt:".length);
+    if (text.startsWith("prompt:")) {
+      sawCanonicalPrompt = true;
+      if (canonicalPrompt === undefined) {
+        canonicalPrompt = parseMetadataObject(text.slice("prompt:".length));
+      }
       continue;
     }
     const lower = text.toLowerCase();
@@ -149,14 +157,12 @@ function parseExifPayload(payload) {
     }
   }
 
-  const workflowText = canonicalWorkflowText === undefined
-    ? workflowAliasText
-    : canonicalWorkflowText;
-  const promptText = canonicalPromptText === undefined
-    ? promptAliasText
-    : canonicalPromptText;
-  const workflow = parseMetadataObject(workflowText);
-  const prompt = parseMetadataObject(promptText);
+  const workflow = sawCanonicalWorkflow
+    ? canonicalWorkflow
+    : parseMetadataObject(workflowAliasText);
+  const prompt = sawCanonicalPrompt
+    ? canonicalPrompt
+    : parseMetadataObject(promptAliasText);
   if (workflow === undefined && prompt === undefined) return undefined;
   return { workflow, prompt };
 }


### PR DESCRIPTION
목적과 변경 경계: caller-controlled Workflow/Prompt 같은 case-variant EXIF metadata가 canonical workflow/prompt보다 먼저 복원되는 모호성을 제거합니다. Base -> Head: dev@2fde0b7 -> codex/exif-key-shadowing@7d3b31a. 주요 파일과 보존 계약: backend metadata 준비기는 parameters/prompt/workflow를 casefold로 예약 처리하되 exact lowercase workflow만 canonical 값으로 유지합니다. JPEG reader는 exact lowercase workflow:/prompt:를 입력 순서와 무관하게 alias보다 우선하고, alias-only 구형 JPEG 호환과 unrelated extras를 유지합니다. PNG/WebP canonical roundtrip은 변경하지 않습니다. 검증: backend case variants 제거와 unrelated 보존, synthetic hostile JPEG alias-first/exact-later, alias-only compatibility, canonical PNG/JPEG/WebP roundtrip, frontend JPEG smoke, Python/Node syntax, Ruff 0.15.22, analyzer fixture, quick 프로필(frontend 123 files) 통과. Ruff 25건은 기존 report-only 기준선입니다. 남은 gate: 독립 보안 검토와 최종 full. 위험과 rollback: canonical exact가 존재하면 malformed canonical도 alias로 fallback하지 않는 fail-closed 선택입니다. 커밋 revert로 복구 가능합니다. Refs #710. Next: 보안 검토와 full 통과 후 dev에 squash 병합하고 #710을 닫습니다.