### PR TITLE
fix(aio): snapshot metadata privacy setting

### DIFF
--- a/docs/architecture/native-image-output.md
+++ b/docs/architecture/native-image-output.md
@@ -90,7 +90,10 @@ workflow representation is reused for embedded metadata.
 
 ComfyUI's global `disable_metadata` flag suppresses A1111, prompt, workflow,
 and sidecar metadata. It also skips local hashing and Civitai requests; the
-image encoder still writes the selected format.
+image encoder still writes the selected format. EasyUse Anima snapshots this
+flag once at the start of each save transaction and reuses that decision for
+metadata preparation and image/sidecar serialization. If the ComfyUI setting
+cannot be imported or read, metadata is treated as disabled.
 
 ## A1111 and Civitai metadata
 

--- a/easyuse_anima/aio/native_image_output.py
+++ b/easyuse_anima/aio/native_image_output.py
@@ -298,9 +298,9 @@ def _comfy_metadata_enabled() -> bool:
     try:
         from comfy.cli_args import args  # type: ignore
 
-        return not bool(getattr(args, "disable_metadata", False))
+        return not bool(getattr(args, "disable_metadata"))
     except Exception:
-        return True
+        return False
 
 
 def _encode_user_comment(value: str) -> bytes:
@@ -587,6 +587,7 @@ def _save_native_images(
     metadata: NativeImageMetadata,
     prompt: object | None,
     extra_pnginfo: Mapping[str, object] | None,
+    metadata_enabled: bool | None = None,
 ) -> dict[str, object]:
     batch = list(images)
     if not batch:
@@ -600,6 +601,11 @@ def _save_native_images(
         raise RuntimeError("[EasyUseAnima] AiO save filename is invalid.")
     resolved_folder, relative_folder = _resolve_native_output_folder(output_root, path)
 
+    write_metadata = (
+        _comfy_metadata_enabled()
+        if metadata_enabled is None
+        else bool(metadata_enabled)
+    )
     serialized = _serialize_metadata(
         extension=safe_extension,
         parameters=metadata.parameters,
@@ -607,7 +613,7 @@ def _save_native_images(
         extra_pnginfo=extra_pnginfo,
         embed_workflow=embed_workflow,
         save_workflow_as_json=save_workflow_as_json,
-        write_metadata=_comfy_metadata_enabled(),
+        write_metadata=write_metadata,
     )
     quality = max(1, min(100, int(quality_jpeg_or_webp)))
     image_format = {

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -706,7 +706,8 @@ def _save_image_with_image_saver(
         resource_info=resource_info,
     )
 
-    if _comfy_metadata_enabled():
+    metadata_enabled = _comfy_metadata_enabled()
+    if metadata_enabled:
         _validate_parameter_sources(
             positive_prompt,
             negative_prompt,
@@ -791,6 +792,7 @@ def _save_image_with_image_saver(
         metadata=metadata,
         prompt=workflow_prompt,
         extra_pnginfo=extra_pnginfo,
+        metadata_enabled=metadata_enabled,
     )
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -50516,17 +50516,17 @@
           },
           {
             "async": false,
-            "end_line": 687,
+            "end_line": 693,
             "kind": "function",
             "line": 575,
-            "loc": 113,
+            "loc": 119,
             "qualified_name": "_save_native_images"
           }
         ],
         "is_package": false,
-        "loc": 690,
+        "loc": 696,
         "module": "easyuse_anima.aio.native_image_output",
-        "normalized_git_blob_sha1": "14a5cfb66c8fe87f85cf03fd9a8b5fb5dadd9f60",
+        "normalized_git_blob_sha1": "116e960254ee5ffecf61c8b74b0d3b6b931c1a2e",
         "path": "easyuse_anima/aio/native_image_output.py",
         "top_level": {
           "class_count": 2,
@@ -51522,17 +51522,17 @@
           },
           {
             "async": false,
-            "end_line": 794,
+            "end_line": 796,
             "kind": "function",
             "line": 688,
-            "loc": 107,
+            "loc": 109,
             "qualified_name": "_save_image_with_image_saver"
           }
         ],
         "is_package": false,
-        "loc": 797,
+        "loc": 799,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "eace1458be47f30e547470d0678f51f30e303abd",
+        "normalized_git_blob_sha1": "bc32a08be80dacafd65ff38baddc1d22eb1d0fa4",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 1,

--- a/tests/test_aio_native_image_output.py
+++ b/tests/test_aio_native_image_output.py
@@ -69,6 +69,84 @@ class AIONativeImageOutputTests(unittest.TestCase):
         resources._hash_file_revision.cache_clear()
         civitai._fetch_civitai_autov3_hash.cache_clear()
         civitai._cached_civitai_resource_by_hash.cache_clear()
+        comfy_module = types.ModuleType("comfy")
+        comfy_module.__path__ = []
+        cli_args_module = types.ModuleType("comfy.cli_args")
+        cli_args_module.args = types.SimpleNamespace(disable_metadata=False)
+        comfy_module.cli_args = cli_args_module
+        cli_args_patch = patch.dict(
+            sys.modules,
+            {
+                "comfy": comfy_module,
+                "comfy.cli_args": cli_args_module,
+            },
+        )
+        cli_args_patch.start()
+        self.addCleanup(cli_args_patch.stop)
+
+    def test_comfy_metadata_setting_fails_closed_on_import_or_access_error(self):
+        for disable_metadata, expected in ((False, True), (True, False)):
+            cli_args_module = types.ModuleType("comfy.cli_args")
+            cli_args_module.args = types.SimpleNamespace(
+                disable_metadata=disable_metadata
+            )
+            with patch.dict(sys.modules, {"comfy.cli_args": cli_args_module}):
+                self.assertIs(native._comfy_metadata_enabled(), expected)
+
+        missing_attribute_module = types.ModuleType("comfy.cli_args")
+        missing_attribute_module.args = object()
+        with patch.dict(
+            sys.modules,
+            {"comfy.cli_args": missing_attribute_module},
+        ):
+            self.assertFalse(native._comfy_metadata_enabled())
+
+        class RaisingArgs:
+            @property
+            def disable_metadata(self):
+                raise RuntimeError("setting access failed")
+
+        raising_module = types.ModuleType("comfy.cli_args")
+        raising_module.args = RaisingArgs()
+        with patch.dict(sys.modules, {"comfy.cli_args": raising_module}):
+            self.assertFalse(native._comfy_metadata_enabled())
+
+        with patch.dict(sys.modules, {"comfy.cli_args": None}):
+            self.assertFalse(native._comfy_metadata_enabled())
+
+    def test_disabled_metadata_snapshot_writes_image_only_without_rereading_flag(self):
+        metadata = native.NativeImageMetadata("parameters", "hashes", {"model": "abc"})
+        pixels = np.zeros((2, 2, 3), dtype=np.float32)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with patch.object(
+                native,
+                "_comfy_metadata_enabled",
+                side_effect=AssertionError("explicit snapshot must not be reread"),
+            ):
+                result = native._save_native_images(
+                    [FakeTensor(pixels)],
+                    output_root=root,
+                    path="",
+                    filename="private",
+                    extension="png",
+                    quality_jpeg_or_webp=80,
+                    lossless_webp=False,
+                    optimize_png=False,
+                    embed_workflow=True,
+                    save_workflow_as_json=True,
+                    metadata=metadata,
+                    prompt={"1": {"class_type": "Test"}},
+                    extra_pnginfo={"workflow": {"nodes": []}},
+                    metadata_enabled=False,
+                )
+
+            image_path = root / result["ui"]["images"][0]["filename"]
+            with Image.open(image_path) as saved:
+                self.assertNotIn("parameters", saved.info)
+                self.assertNotIn("prompt", saved.info)
+                self.assertNotIn("workflow", saved.info)
+            self.assertFalse(image_path.with_suffix(".json").exists())
 
     def test_a1111_metadata_contains_local_model_lora_and_manual_civitai_hashes(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -988,6 +989,21 @@ class AIOSettingsStorageTests(unittest.TestCase):
 
 class AIONativeImageSaverTests(unittest.TestCase):
     def setUp(self):
+        comfy_module = types.ModuleType("comfy")
+        comfy_module.__path__ = []
+        cli_args_module = types.ModuleType("comfy.cli_args")
+        cli_args_module.args = types.SimpleNamespace(disable_metadata=False)
+        comfy_module.cli_args = cli_args_module
+        cli_args_patch = patch.dict(
+            sys.modules,
+            {
+                "comfy": comfy_module,
+                "comfy.cli_args": cli_args_module,
+            },
+        )
+        cli_args_patch.start()
+        self.addCleanup(cli_args_patch.stop)
+
         output_directory_patch = patch.object(
             output,
             "_comfy_output_directory",

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -58,6 +58,22 @@ def render_output_template(
 
 
 class AIOOutputMoveTests(unittest.TestCase):
+    def setUp(self):
+        comfy_module = types.ModuleType("comfy")
+        comfy_module.__path__ = []
+        cli_args_module = types.ModuleType("comfy.cli_args")
+        cli_args_module.args = types.SimpleNamespace(disable_metadata=False)
+        comfy_module.cli_args = cli_args_module
+        cli_args_patch = patch.dict(
+            sys.modules,
+            {
+                "comfy": comfy_module,
+                "comfy.cli_args": cli_args_module,
+            },
+        )
+        cli_args_patch.start()
+        self.addCleanup(cli_args_patch.stop)
+
     def test_output_functions_are_owned_by_canonical_modules(self):
         for name in (
             "_normalize_aio_hash_text",
@@ -665,6 +681,7 @@ class AIOOutputMoveTests(unittest.TestCase):
             metadata=metadata,
             prompt={"1": {}},
             extra_pnginfo={"workflow": {}},
+            metadata_enabled=True,
         )
 
     def test_image_saver_renders_templates_before_forwarding_safe_values(self):
@@ -848,7 +865,11 @@ class AIOOutputMoveTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             with (
                 patch.dict(sys.modules, {"folder_paths": fake_folder_paths(temp)}),
-                patch.object(output, "_comfy_metadata_enabled", return_value=False),
+                patch.object(
+                    output,
+                    "_comfy_metadata_enabled",
+                    side_effect=[False, True],
+                ) as metadata_flag,
                 patch.object(output, "_resolve_aio_runtime_seed", return_value=11),
                 patch.object(output, "_build_native_metadata") as build,
                 patch.object(output, "_aio_image_saver_additional_hashes") as hashes,
@@ -877,6 +898,8 @@ class AIOOutputMoveTests(unittest.TestCase):
         self.assertEqual(metadata.parameters, "")
         self.assertEqual(metadata.final_hashes, "")
         self.assertEqual(metadata.hashes, {})
+        self.assertEqual(metadata_flag.call_count, 1)
+        self.assertIs(save.call_args.kwargs["metadata_enabled"], False)
 
     def test_oversized_prompt_is_rejected_before_lora_metadata_expansion(self):
         settings = {


### PR DESCRIPTION
## 목적과 변경 경계

ComfyUI의 전역 메타데이터 비활성화 설정을 저장 트랜잭션 시작 시 한 번만 읽고, 읽기 실패 시 메타데이터 저장을 안전하게 비활성화합니다.

## Base -> Head

`dev` -> `codex/snapshot-disable-metadata`

## 주요 변경

- `disable_metadata` import/access 실패를 fail-closed로 처리
- 한 번 스냅샷한 결정을 해시, Civitai, 이미지 메타데이터와 JSON sidecar 전체에 전달
- 비활성화 상태에서는 이미지 인코딩만 수행
- 정상 호스트, 설정 오류, 서로 반대인 연속 읽기, 비활성화 출력에 대한 회귀 테스트 추가

## 검증

- native image output focused class: 43 passed
- AiO output focused class: 24 passed
- backend analyzer fixture: passed
- quick project validation: passed; 기존 report-only Ruff 25건 유지, frontend 123개 통과

## 위험과 rollback

- ComfyUI 설정 모듈을 읽을 수 없는 비정상 환경에서는 기존과 달리 메타데이터가 저장되지 않습니다. 이는 프라이버시 우선 동작입니다.
- 단일 커밋 revert로 복구할 수 있습니다.

Closes #712
