### PR TITLE
chore(release): prepare EasyUse Anima 1.2.0

### DIFF
--- a/.github/registry/changelogs/1.2.0.txt
+++ b/.github/registry/changelogs/1.2.0.txt
@@ -1,0 +1,12 @@
+EasyUse Anima 1.2.0 adds native AiO image saving without requiring ComfyUI-Image-Saver.
+
+Changes:
+1. Anima AiO Generator can save PNG, JPEG/JPG, lossy WebP, and lossless WebP images directly.
+2. Native saves can include A1111-style generation parameters, embedded ComfyUI prompt and workflow data, and matching JSON workflow sidecars.
+3. Saved metadata can include local model, LoRA, and embedding hashes, manually supplied hashes, and optional bounded Civitai hash enrichment.
+4. EasyUse-generated JPEG images can restore their embedded ComfyUI workflows when opened in ComfyUI.
+5. Output names and folders are kept inside the active ComfyUI output directory, including Windows-specific unsafe-name protection.
+6. Existing AiO workflows and profiles keep their saved image_saver compatibility key and require no migration.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser. Workflows that explicitly contain standalone ComfyUI-Image-Saver nodes still require that node pack.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,8 +19,13 @@
   },
   "versions": [
     {
-      "version": "1.1.6",
+      "version": "1.2.0",
       "deprecated": false,
+      "changelog_file": "changelogs/1.2.0.txt"
+    },
+    {
+      "version": "1.1.6",
+      "deprecated": true,
       "changelog_file": "changelogs/1.1.6.txt"
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,8 +17,9 @@
 
 - Native output filenames, templates, and subdirectories are validated for the
   active ComfyUI output folder, including Windows-specific unsafe names.
-- Image and workflow-sidecar publication now avoids exposing incomplete output
-  pairs, while metadata, hash, and optional Civitai work have explicit limits.
+- When a JSON workflow sidecar is requested, it is published before the image
+  so an image is not exposed while its sidecar is still missing. Metadata,
+  hash, and optional Civitai work also have explicit limits.
 - Reserved EXIF fields and the selected metadata privacy setting remain stable
   throughout each save operation.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,42 @@
 # Release Notes
 
+## 1.2.0
+
+### Added
+
+- Anima AiO Generator can now save PNG, JPEG/JPG, lossy WebP, and lossless
+  WebP images directly without requiring ComfyUI-Image-Saver.
+- Native saves can include A1111-style generation parameters, embedded ComfyUI
+  prompt and workflow data, and optional matching JSON workflow sidecars.
+- Saved metadata can include local model, LoRA, and embedding hashes, manually
+  supplied hashes, and optional bounded Civitai hash enrichment.
+- EasyUse-generated JPEG images can restore their embedded ComfyUI workflows
+  when opened in ComfyUI.
+
+### Fixed
+
+- Native output filenames, templates, and subdirectories are validated for the
+  active ComfyUI output folder, including Windows-specific unsafe names.
+- Image and workflow-sidecar publication now avoids exposing incomplete output
+  pairs, while metadata, hash, and optional Civitai work have explicit limits.
+- Reserved EXIF fields and the selected metadata privacy setting remain stable
+  throughout each save operation.
+
+### Compatibility
+
+- Existing AiO workflows and profiles keep their saved `image_saver`
+  compatibility key, which is now presented as EasyUse Native. No migration is
+  required.
+- AiO native saving no longer imports or looks up ComfyUI-Image-Saver. A
+  workflow that explicitly contains standalone nodes from that project still
+  requires it.
+- Remote Civitai enrichment remains opt-in. Local and manually supplied hashes
+  do not require a remote request.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+
 ## 1.1.6
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "1.1.6"
+version = "1.2.0"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose and boundary

Prepare the dependency-free native AiO image output release as EasyUse Anima 1.2.0. This PR changes release metadata and user-facing release copy only; it does not alter production behavior.

Tracks #707.

## Base -> head

- dev 52902dd8a812b64c283ddf3722685c2437a537f9
- codex/release-1.2.0 9419045

## Files and preserved contracts

- pyproject.toml: version 1.2.0
- RELEASE.md: GitHub user-facing notes
- .github/registry/changelogs/1.2.0.txt: exact Registry publish copy
- .github/registry/metadata.json: 1.2.0 current and 1.1.6 deprecated after promotion
- Existing image_saver serialization key, workflow/profile compatibility, and explicit standalone Image Saver workflow behavior remain documented.

## Validation

- Focused Registry release-copy contract: 3 passed
- comfy-cli 1.20.0 node validate: passed, including security checks
- comfy-cli 1.20.0 node pack: 346 files; required runtime/native-output/frontend files present; docs, tests, CI, caches, generated archives, and sensitive filename patterns absent
- Registry changelog extraction: exact content match after newline normalization
- Registry metadata dry-run: node metadata already matches; 1.2.0 is not yet registered; 1.1.6 deprecation is the only existing-version change
- git diff --check: passed
- Reused production full validation from ece21a4 because its tree equals merged 983fffc; the only later changes are MAINTAINING.md and these four release files. That run used ComfyUI 0.34.0/frontend 1.49.6 and passed 1,609 Python tests with 3 skipped plus all 123 frontend files, Pyright, import, size, disposition, support, and diff gates.
- Reused dev live queue evidence from 52902dd: external Image Saver nodes absent; native PNG/JPEG/WebP, A1111 metadata, embedded workflows, JSON sidecars, and hash metadata passed.

## Remaining risk and rollback

- Registry scanner status is external; 1.1.6 remains flagged and 1.2.0 must be read back after publication.
- Rollback before publication is a simple revert of this metadata-only commit.

## Next

After merge: promote dev to main through a separate PR, create the rooted v1.2.0 manual-install ZIP and GitHub Release, publish through the pinned Registry workflow, then verify Registry read-back before closing #707.