### PR TITLE
chore(registry): reconcile unpublished 0.6.1 metadata

### DIFF
--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -17,6 +17,12 @@
       "workflow"
     ]
   },
+  "omitted_versions": [
+    {
+      "version": "0.6.1",
+      "reason": "GitHub-only historical release with no Comfy Registry row; do not backfill without a separate security review."
+    }
+  ],
   "versions": [
     {
       "version": "1.2.0",
@@ -82,11 +88,6 @@
       "version": "0.6.2",
       "deprecated": true,
       "changelog_file": "changelogs/0.6.2.txt"
-    },
-    {
-      "version": "0.6.1",
-      "deprecated": true,
-      "changelog_file": "changelogs/0.6.1.txt"
     },
     {
       "version": "0.6.0",

--- a/tests/test_registry_release_copy.py
+++ b/tests/test_registry_release_copy.py
@@ -13,6 +13,21 @@ RELEASE_PATH = ROOT / "RELEASE.md"
 
 
 class RegistryReleaseCopyTests(unittest.TestCase):
+    def test_historical_registry_omissions_are_explicit_and_not_synced(self) -> None:
+        metadata = json.loads(METADATA_PATH.read_text(encoding="utf-8"))
+        synced_versions = {item["version"] for item in metadata["versions"]}
+        omissions = metadata.get("omitted_versions", [])
+
+        self.assertIn("0.6.1", {item["version"] for item in omissions})
+        for item in omissions:
+            with self.subTest(version=item.get("version")):
+                self.assertEqual(set(item), {"version", "reason"})
+                self.assertNotIn(item["version"], synced_versions)
+                self.assertTrue(item["reason"].strip())
+                self.assertTrue(
+                    (METADATA_PATH.parent / "changelogs" / f"{item['version']}.txt").is_file()
+                )
+
     def test_only_current_registry_version_is_not_deprecated(self) -> None:
         project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         current_version = project["project"]["version"]


### PR DESCRIPTION
## Purpose

Resolve #748 by reconciling the checked-in Registry metadata with the versions that actually exist in Comfy Registry.

## Base -> Head

`dev` -> `codex/reconcile-registry-061`

## Changes and preserved contracts

- Remove historical GitHub-only `0.6.1` from the Registry synchronization target.
- Record it under `omitted_versions` with the explicit rule that it must not be backfilled without a separate security review.
- Keep its historical changelog in the repository.
- Add focused coverage that omissions have a reason, remain disjoint from synchronized versions, and retain their changelog.
- No runtime, package, workflow, node, or public API behavior changes.

## Validation

- `RegistryReleaseCopyTests`: 4 passed.
- Live Registry metadata dry-run: every declared version matches; no missing-version skips.
- `git diff --check`: passed.
- Existing 1.2.0 full/package/live validation remains valid because this PR changes only Registry bookkeeping and its focused test.

## Risk and rollback

Low risk. Roll back this commit to restore the previous repeated skip. Do not publish the obsolete 0.6.1 archive as a substitute.

Closes #748