### PR TITLE
chore(registry): reconcile unpublished 0.6.1 metadata

### DIFF
--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -17,6 +17,12 @@
       "workflow"
     ]
   },
+  "omitted_versions": [
+    {
+      "version": "0.6.1",
+      "reason": "GitHub-only historical release with no Comfy Registry row; do not backfill without a separate security review."
+    }
+  ],
   "versions": [
     {
       "version": "1.2.0",
@@ -82,11 +88,6 @@
       "version": "0.6.2",
       "deprecated": true,
       "changelog_file": "changelogs/0.6.2.txt"
-    },
-    {
-      "version": "0.6.1",
-      "deprecated": true,
-      "changelog_file": "changelogs/0.6.1.txt"
     },
     {
       "version": "0.6.0",

--- a/tests/test_registry_release_copy.py
+++ b/tests/test_registry_release_copy.py
@@ -13,6 +13,21 @@ RELEASE_PATH = ROOT / "RELEASE.md"
 
 
 class RegistryReleaseCopyTests(unittest.TestCase):
+    def test_historical_registry_omissions_are_explicit_and_not_synced(self) -> None:
+        metadata = json.loads(METADATA_PATH.read_text(encoding="utf-8"))
+        synced_versions = {item["version"] for item in metadata["versions"]}
+        omissions = metadata.get("omitted_versions", [])
+
+        self.assertIn("0.6.1", {item["version"] for item in omissions})
+        for item in omissions:
+            with self.subTest(version=item.get("version")):
+                self.assertEqual(set(item), {"version", "reason"})
+                self.assertNotIn(item["version"], synced_versions)
+                self.assertTrue(item["reason"].strip())
+                self.assertTrue(
+                    (METADATA_PATH.parent / "changelogs" / f"{item['version']}.txt").is_file()
+                )
+
     def test_only_current_registry_version_is_not_deprecated(self) -> None:
         project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         current_version = project["project"]["version"]


### PR DESCRIPTION
## Purpose

Promote the resolved Registry metadata drift from dev to main. This is the main-branch counterpart of #749 and completes #748.

## Base -> Head

`main` -> `codex/promote-registry-061`

## Changes and preserved contracts

- Record historical GitHub-only `0.6.1` as intentionally omitted from Registry synchronization.
- Remove the nonexistent Registry version from the synchronization target.
- Keep its changelog and require a separate security review before any backfill publication.
- Add focused metadata-contract coverage.
- No runtime, package, workflow, node, or public API behavior changes.

## Validation

- Head tree is byte-for-byte identical to current `origin/dev`.
- Reused from #749 on that exact tree: `RegistryReleaseCopyTests` 4 passed, live Registry metadata dry-run fully converged with no missing-version skip, and `git diff --check` passed.

## Risk and rollback

Low risk and Registry-bookkeeping-only. Revert this commit to restore the previous declaration and repeated skip; do not publish obsolete 0.6.1 as a workaround.

Closes #748