### PR TITLE
fix(prompt-studio): reduce redraw work and fix scroll layout errors

### DIFF
--- a/tests/fixtures/python_support_ownership_contract.v1.json
+++ b/tests/fixtures/python_support_ownership_contract.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "baseline_commit": "a0b0dc1f599fcf01ec0f25fc75a23f7524f165ab",
   "inventory": {
-    "expected_files": 217,
+    "expected_files": 218,
     "manual_matrix_source": "tests/fixtures/python_test_ownership_contract.v1.json",
     "patterns": [
       "tests/**/*.json",
@@ -1012,6 +1012,17 @@
         "prompt"
       ],
       "purpose": "Deterministic Node smoke contract for frontend prompt studio resolution orientation smoke."
+    },
+    {
+      "execution_mode": "node-smoke",
+      "generated": false,
+      "kind": "test",
+      "owner": "tests/frontend_prompt_studio_scroll_refresh_smoke.mjs",
+      "path": "tests/frontend_prompt_studio_scroll_refresh_smoke.mjs",
+      "production_groups": [
+        "prompt"
+      ],
+      "purpose": "Deterministic canvas wheel refresh coalescing and final stabilization contract."
     },
     {
       "execution_mode": "node-smoke",

--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -839,4 +839,149 @@ function replacementBinding(input, state, owner, registry, controller) {
   assert.equal(focusedHooks[0].options.scope, "easyuse");
 }
 
+{
+  const geometryModule = await import(dataModule("../web/js/autocomplete/popup_geometry.js"));
+  const sourceBetween = (start, end) => {
+    const startIndex = entrySource.indexOf(start);
+    const endIndex = entrySource.indexOf(end, startIndex);
+    assert.ok(startIndex >= 0 && endIndex > startIndex);
+    return entrySource.slice(startIndex, endIndex);
+  };
+  const schedulerSource = sourceBetween("function refreshActiveAutocomplete", "\nfunction inputTypeName");
+  const scrollSource = sourceBetween("function handleAutocompleteScroll", "\nfunction hookNode");
+  const positionSource = sourceBetween("function positionPopup", "\nfunction scrollActiveAutocompleteItemIntoView");
+  const settingsSource = sourceBetween("function handleAutocompleteSettingsUpdated", "\nfunction disposeAutocompleteEntryInputs");
+  const disposeSource = sourceBetween("function disposeAutocompleteEntryUi", "\nautocompleteEntryLifecycle =");
+  const schedulerDeclarations = entrySource.match(/^let activeRefresh\w* = .*;$/gm).join("\n");
+
+  function createScrollRuntime() {
+    const calls = { caret: 0, refresh: 0, preview: 0, hide: 0, invalidations: 0 };
+    const frames = new Map();
+    let nextFrame = 0;
+    const input = new FakeInput();
+    input.getBoundingClientRect = () => ({ left: 100, top: 100, width: 400, height: 120, right: 500, bottom: 220 });
+    const document = { activeElement: input, getElementById: () => null };
+    const popup = {
+      style: {},
+      hidden: false,
+      contains: (target) => target === popup,
+      remove() {},
+    };
+    const preview = { value: "blue hair" };
+    input.__easyuseAnimaAutocompletePreview = preview;
+    const state = { input, index: 3, suggestions: [{ tag: "blue hair" }], enabled: true };
+    const autocompleteData = { invalidated: false, syncSourceSettings() { return this.invalidated; } };
+    const runtime = new Function(
+      "dependencies",
+      `"use strict";
+      const { document, window, state, popupFixture, calls, frames, requestAnimationFrame,
+        cancelAnimationFrame, caretClientRect, calculateAutocompletePopupGeometry,
+        autocompleteData } = dependencies;
+      let activeState = state;
+      let popup = popupFixture;
+      let middlePanForwardCleanup = null;
+      ${schedulerDeclarations}
+      const pruneDisconnectedAutocompleteInputs = () => {};
+      const autocompleteEnabledForState = (current) => current.enabled;
+      const ensurePopup = () => popup;
+      const hidePopup = () => { calls.hide += 1; activeState = null; popupFixture.hidden = true; };
+      const invalidateAutocompleteDataRequests = () => { calls.invalidations += 1; hidePopup(); };
+      ${positionSource}
+      ${schedulerSource}
+      ${scrollSource}
+      ${settingsSource}
+      ${disposeSource}
+      state.reposition = () => positionPopup(state.input);
+      state.refresh = () => { calls.refresh += 1; positionPopup(state.input); calls.preview += 1; };
+      return {
+        scroll: handleAutocompleteScroll,
+        wheel: handleAutocompleteWheel,
+        settings: handleAutocompleteSettingsUpdated,
+        refresh: scheduleActiveRefresh,
+        dismiss: hidePopup,
+        dispose: disposeAutocompleteEntryUi,
+      };`,
+    )({
+      document,
+      window: { innerWidth: 1200, innerHeight: 900 },
+      state,
+      popupFixture: popup,
+      calls,
+      frames,
+      requestAnimationFrame(callback) { frames.set(++nextFrame, callback); return nextFrame; },
+      cancelAnimationFrame(handle) { frames.delete(handle); },
+      caretClientRect() { calls.caret += 1; return { left: 140, top: 130, width: 1, height: 20, right: 141, bottom: 150 }; },
+      calculateAutocompletePopupGeometry: geometryModule.calculateAutocompletePopupGeometry,
+      autocompleteData,
+    });
+    return {
+      runtime, calls, document, input, state, popup, preview, frames, autocompleteData,
+      flushFrame() {
+        const callbacks = [...frames.values()];
+        frames.clear();
+        for (const callback of callbacks) callback();
+      },
+    };
+  }
+
+  const scroll = createScrollRuntime();
+  const originalSuggestions = scroll.state.suggestions;
+  for (let index = 0; index < 30; index += 1) {
+    scroll.runtime.wheel({ target: scroll.input });
+    scroll.runtime.scroll({ target: scroll.input });
+  }
+  assert.equal(scroll.frames.size, 1, "wheel and scroll bursts must share one frame");
+  scroll.flushFrame();
+  assert.equal(scroll.calls.caret, 1, "scrolling an unchanged query must measure caret geometry only once");
+  assert.equal(scroll.calls.refresh, 0, "scrolling must not refresh searches or cancel pending controller work");
+  assert.equal(scroll.calls.preview, 0, "scrolling must not regenerate autocomplete preview");
+  assert.equal(scroll.state.index, 3, "scrolling must preserve the selected suggestion");
+  assert.equal(scroll.state.suggestions, originalSuggestions);
+  assert.equal(scroll.input.__easyuseAnimaAutocompletePreview, scroll.preview);
+  assert.ok(scroll.popup.style.top, "the popup must still follow the caret");
+
+  scroll.runtime.scroll({ target: scroll.popup });
+  scroll.runtime.wheel({ target: scroll.popup });
+  assert.equal(scroll.frames.size, 0, "scrolling inside the suggestion menu must not reposition it");
+
+  for (const order of [["settings", "scroll"], ["scroll", "settings"]]) {
+    const mixed = createScrollRuntime();
+    for (const event of order) mixed.runtime[event]({ target: mixed.input, detail: {} });
+    mixed.flushFrame();
+    assert.equal(mixed.calls.refresh, 1, "settings refresh must survive coalescing with a scroll event");
+    assert.equal(mixed.calls.caret, 1, "a full refresh must let its controller own popup positioning");
+    assert.equal(mixed.calls.preview, 1, "non-data settings refresh must retain preview updates");
+  }
+
+  for (const deactivate of [
+    (fixture) => fixture.runtime.dismiss(),
+    (fixture) => { fixture.document.activeElement = null; },
+    (fixture) => { fixture.state.enabled = false; },
+  ]) {
+    const hidden = createScrollRuntime();
+    hidden.runtime.scroll({ target: hidden.input });
+    deactivate(hidden);
+    hidden.flushFrame();
+    assert.equal(hidden.calls.caret, 0, "a queued scroll must not position a dismissed or inactive popup");
+    assert.equal(hidden.calls.refresh, 0, "a queued scroll must not reopen a dismissed or inactive popup");
+    assert.equal(hidden.popup.hidden, true);
+  }
+
+  const invalidated = createScrollRuntime();
+  invalidated.runtime.scroll({ target: invalidated.input });
+  invalidated.autocompleteData.invalidated = true;
+  invalidated.runtime.settings({ detail: {} });
+  invalidated.flushFrame();
+  assert.equal(invalidated.calls.invalidations, 1, "source changes must retain data invalidation routing");
+  assert.equal(invalidated.calls.caret, 0, "queued scrolling must not restore invalidated suggestions");
+
+  const disposed = createScrollRuntime();
+  disposed.runtime.refresh();
+  disposed.runtime.scroll({ target: disposed.input });
+  disposed.runtime.dispose();
+  assert.equal(disposed.frames.size, 0, "entry disposal must cancel the shared refresh frame");
+  disposed.flushFrame();
+  assert.equal(disposed.calls.caret, 0);
+}
+
 console.log("Autocomplete input binding smoke passed.");

--- a/tests/frontend_autocomplete_popup_geometry_smoke.mjs
+++ b/tests/frontend_autocomplete_popup_geometry_smoke.mjs
@@ -83,10 +83,49 @@ assert.deepEqual(
   ),
   {
     left: 760,
-    top: 792,
+    top: 704,
     width: 260,
     maxHeight: 56,
   },
 );
+
+for (const fixture of [
+  {
+    name: "caret below the clipped editor viewport",
+    input: rect(100, 200, 420, 1800),
+    caret: rect(240, 1137.61, 1, 14),
+    top: 656,
+    maxHeight: 56,
+  },
+  {
+    name: "caret above the viewport after scrolling",
+    input: rect(100, -400, 420, 600),
+    caret: rect(240, -300, 1, 20),
+    top: 4,
+    maxHeight: 280,
+  },
+  {
+    name: "lower edge with enough room for normal placement",
+    input: rect(100, 500, 420, 160),
+    caret: rect(240, 590, 1, 24),
+    top: 650,
+    maxHeight: 62,
+  },
+  {
+    name: "lower edge requiring the minimum menu budget",
+    input: rect(100, 500, 420, 160),
+    caret: rect(240, 630, 1, 24),
+    top: 656,
+    maxHeight: 56,
+  },
+]) {
+  const viewport = { width: 1280, height: 720 };
+  const popup = calculateAutocompletePopupGeometry(fixture.input, fixture.caret, viewport, 18);
+  assert.equal(popup.top, fixture.top, fixture.name);
+  assert.equal(popup.maxHeight, fixture.maxHeight, fixture.name);
+  assert.ok(popup.top >= 4, `${fixture.name}: popup must remain below the top margin`);
+  assert.ok(popup.maxHeight >= 56, `${fixture.name}: popup must retain its minimum height budget`);
+  assert.ok(popup.top + popup.maxHeight <= viewport.height - 8, `${fixture.name}: popup must fit above the bottom margin`);
+}
 
 console.log("frontend autocomplete popup geometry smoke passed");

--- a/tests/frontend_highlight_overlay_core_smoke.mjs
+++ b/tests/frontend_highlight_overlay_core_smoke.mjs
@@ -11,6 +11,7 @@ const {
   createHighlightOverlayRenderer,
   overlayBounds,
   overlayScrollbarPadding,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 } = await import(coreUrl);
 
@@ -149,3 +150,66 @@ assert(
 );
 
 console.log("Highlight overlay core smoke passed.");
+
+// Repeated caret/geometry changes reuse HTML; every presentation input still
+// invalidates it, including mutable preview objects and settings/locale changes.
+let renderCalls = 0;
+let language = "en";
+let settingsRevision = 0;
+let color = "red";
+const cachedRender = createHighlightOverlayRenderer({
+  escapeHtml,
+  renderHighlightedText(text, tokens) {
+    renderCalls += 1;
+    return `<mark lang="${language}" style="color:${color}">${escapeHtml(text)}:${tokens?.[0]?.section || ""}</mark>`;
+  },
+  getRenderKey: () => `${language}:${settingsRevision}`,
+});
+const cachedInput = {};
+const classifiedTokens = [{ section: "general" }];
+const firstHtml = cachedRender("cat", classifiedTokens, "", cachedInput);
+for (let i = 0; i < 30; i++) {
+  assert(cachedRender("cat", classifiedTokens, "", cachedInput) === firstHtml, "Unchanged rendering differed");
+}
+assert(renderCalls === 1, "Unchanged caret events must not repeat token rendering");
+cachedRender("cat", [], "", cachedInput);
+const emptyCalls = renderCalls;
+cachedRender("cat", [], "", cachedInput);
+assert(renderCalls === emptyCalls, "Fresh empty token arrays must share the unclassified cache");
+assert(cachedRender("dog", [], "", cachedInput).includes("dog"), "Edits must invalidate cached text immediately");
+assert(cachedRender("dog", [{ section: "artist" }], "", cachedInput).includes("artist"), "Classification changes must repaint");
+language = "ko";
+assert(cachedRender("dog", [], "", cachedInput).includes('lang="ko"'), "Locale changes must repaint unchanged text");
+color = "blue";
+settingsRevision += 1;
+assert(cachedRender("dog", [], "", cachedInput).includes("color:blue"), "Settings refresh must repaint");
+assert(cachedRender("", [], "first", cachedInput).includes("first"), "Placeholder missing");
+assert(cachedRender("", [], "second", cachedInput).includes("second"), "Placeholder changes must repaint");
+cachedInput.__easyuseAnimaAutocompletePreview = {
+  sourceValue: "cat", value: "cathedral", candidateStart: 0, candidateEnd: 9,
+  ghostStart: 3, ghostEnd: 9, color: "red",
+};
+const firstPreview = cachedRender("cat", [], "", cachedInput);
+cachedInput.__easyuseAnimaAutocompletePreview.color = "green";
+assert(cachedRender("cat", [], "", cachedInput) !== firstPreview, "In-place preview mutation must invalidate");
+cachedInput.__easyuseAnimaAutocompletePreview.sourceValue = "old text";
+assert(!cachedRender("cat", [], "", cachedInput).includes("hedral"), "Stale preview must disappear");
+delete cachedInput.__easyuseAnimaAutocompletePreview;
+const beforeNewInput = renderCalls;
+cachedRender("cat", [], "", {});
+assert(renderCalls === beforeNewInput + 1, "Replacement inputs must get their own render");
+
+let writes = 0;
+const ownedOverlay = {
+  get innerHTML() { throw new Error("Unchanged content must not serialize the DOM"); },
+  set innerHTML(value) { writes += 1; this.content = value; },
+};
+setHighlightOverlayHtml(ownedOverlay, firstHtml);
+for (let i = 0; i < 30; i++) setHighlightOverlayHtml(ownedOverlay, firstHtml);
+assert(writes === 1, "Unchanged HTML must preserve existing child nodes");
+setHighlightOverlayHtml(ownedOverlay, "changed");
+assert(writes === 2 && ownedOverlay.content === "changed", "Changed HTML must replace old content");
+const replacementOverlay = { set innerHTML(value) { writes += 1; } };
+setHighlightOverlayHtml(replacementOverlay, "changed");
+assert(writes === 3, "A reconnected overlay must receive content even when text is unchanged");
+console.log("Highlight overlay render cache and DOM identity smoke passed.");

--- a/tests/frontend_highlight_overlay_core_smoke.mjs
+++ b/tests/frontend_highlight_overlay_core_smoke.mjs
@@ -83,6 +83,20 @@ assert(
   overlayScrollbarPadding(noScrollbarInput, style).right === "4px",
   "Auto overflow without content overflow must not reserve a scrollbar gutter",
 );
+for (const overflowY of ["auto", "hidden"]) {
+  const stableStyle = { ...style, overflowY, scrollbarGutter: "stable" };
+  const stablePadding = overlayScrollbarPadding(noScrollbarInput, stableStyle);
+  assert(stablePadding.right === "22px", "A stable gutter must survive autosizing without overflow");
+  const inputContentWidth = noScrollbarInput.clientWidth
+    - Number.parseFloat(stableStyle.paddingLeft)
+    - Number.parseFloat(stableStyle.paddingRight);
+  const overlayContentWidth = noScrollbarInput.offsetWidth
+    - Number.parseFloat(stableStyle.borderLeftWidth)
+    - Number.parseFloat(stableStyle.borderRightWidth)
+    - Number.parseFloat(stableStyle.paddingLeft)
+    - Number.parseFloat(stablePadding.right);
+  assert(inputContentWidth === overlayContentWidth, "Node 2.0 stable gutter must preserve wrap width");
+}
 assert(
   JSON.stringify(overlayBounds(input)) === JSON.stringify({
     left: "8px",

--- a/tests/frontend_prompt_studio_classic_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_classic_values_smoke.mjs
@@ -29,6 +29,7 @@ const highlightUrl = inlineModule(`
   export function copyInputTextMetrics() {}
   export function ensureHighlightOverlay() { return null; }
   export function highlightOverlayHtml() { return ""; }
+  export function setHighlightOverlayHtml(overlay, html) { overlay.innerHTML = html; }
   export function syncOverlayBounds() {}
 `);
 const settingsUrl = inlineModule(`

--- a/tests/frontend_prompt_studio_highlight_revision_smoke.mjs
+++ b/tests/frontend_prompt_studio_highlight_revision_smoke.mjs
@@ -58,27 +58,40 @@ assert(
   "Rapid A to B to C input must leave only C as the publishing owner",
 );
 
+const overlayCoreSource = readFileSync(
+  new URL("../web/js/prompt_studio/highlight_overlay_core.js", import.meta.url),
+  "utf8",
+);
+const overlayCoreUrl = `data:text/javascript;base64,${Buffer.from(overlayCoreSource).toString("base64")}`;
 const highlightFixtureSource = `
+  import { createHighlightOverlayRenderer } from ${JSON.stringify(overlayCoreUrl)};
   export const requests = [];
+  export const renders = [];
+  export const metricCopies = [];
   export function classifyPrompt(text) {
     return new Promise((resolve) => requests.push({ text, resolve }));
   }
   export function ensureHighlightOverlay(input) { return input.overlay; }
-  export function highlightOverlayHtml(value, tokens) {
-    return JSON.stringify({ value, tokens });
-  }
-  export function copyInputTextMetrics() {}
+  export const highlightOverlayHtml = createHighlightOverlayRenderer({
+    escapeHtml: String,
+    renderHighlightedText(value, tokens) {
+      renders.push({ value, tokens });
+      return JSON.stringify({ value, tokens });
+    },
+  });
+  export function copyInputTextMetrics(input) { metricCopies.push(input); }
+  export function setHighlightOverlayHtml(overlay, html) { overlay.innerHTML = html; }
   export function overlayBounds() { return {}; }
   export function overlayScrollbarPadding() { return {}; }
   export function syncOverlayBounds() {}
   export function applyPromptStudioTextStyle() {}
   export function parseAdvancedFields() { return []; }
-  export function getAdvancedEditorElement() { return null; }
-  export function getAdvancedFields() { return []; }
+  export function getAdvancedEditorElement(node) { return node.editor || null; }
+  export function getAdvancedFields(node) { return node.fields || []; }
   export function registerExternalAutocompleteInput() {}
 `;
 const highlightFixtureUrl = `data:text/javascript;base64,${Buffer.from(highlightFixtureSource).toString("base64")}`;
-const { requests } = await import(highlightFixtureUrl);
+const { requests, renders, metricCopies } = await import(highlightFixtureUrl);
 let advancedSource = readFileSync(
   new URL("../web/js/prompt_studio/advanced_highlights.js", import.meta.url),
   "utf8",
@@ -93,7 +106,7 @@ for (const dependency of [
   advancedSource = advancedSource.replace(JSON.stringify(dependency), JSON.stringify(highlightFixtureUrl));
 }
 const advancedUrl = `data:text/javascript;base64,${Buffer.from(advancedSource).toString("base64")}`;
-const { advancedHighlightState, scheduleAdvancedFieldHighlight } = await import(advancedUrl);
+const { advancedHighlightState, scheduleAdvancedFieldHighlight, scheduleAdvancedHighlights } = await import(advancedUrl);
 
 const previousTextareaClass = globalThis.HTMLTextAreaElement;
 class MockTextarea {
@@ -101,7 +114,8 @@ class MockTextarea {
     this.value = value;
     this.placeholder = "";
     this.isConnected = true;
-    this.overlay = { innerHTML: "" };
+    this.overlay = { innerHTML: "", style: {} };
+    this.dataset = {};
   }
 }
 globalThis.HTMLTextAreaElement = MockTextarea;
@@ -171,6 +185,47 @@ try {
   assert(advancedHighlightState(cachedNode, { id: "positive_general_1" }) === cachedState, "Existing ordinary field state must keep its identity");
   assert(requests.length === requestCount, "Existing ordinary field caches must not be reclassified");
   assertPrototypesUnchanged();
+
+  const previousRequestFrame = globalThis.requestAnimationFrame;
+  const frames = [];
+  globalThis.requestAnimationFrame = (callback) => frames.push(callback);
+  const flushFrame = () => {
+    for (const callback of frames.splice(0)) callback();
+  };
+  try {
+    const field = { id: "settings_refresh" };
+    const textarea = new MockTextarea("cached prompt");
+    textarea.dataset.easyuseAnimaAdvancedFieldId = field.id;
+    const node = {
+      fields: [field],
+      editor: { querySelectorAll: () => [textarea] },
+    };
+    const state = advancedHighlightState(node, field);
+    state.lastText = textarea.value;
+    state.tokens = [{ token: textarea.value, section: "general" }];
+    const beforeSettings = { renders: renders.length, metrics: metricCopies.length, requests: requests.length };
+    scheduleAdvancedHighlights(node, { classify: false, forceCopyMetrics: true });
+    scheduleAdvancedHighlights(node, { classify: false });
+    assert(frames.length === 1, "A layout event must share the pending forced settings refresh");
+    flushFrame();
+    flushFrame();
+    assert(renders.length > beforeSettings.renders, "The initial settings refresh must render the prompt");
+    assert(metricCopies.length === beforeSettings.metrics + 2, "A coalesced layout event must not drop forced text metrics");
+    const afterSettings = { renders: renders.length, metrics: metricCopies.length };
+    scheduleAdvancedHighlights(node, { classify: false });
+    flushFrame();
+    flushFrame();
+    assert(metricCopies.length === afterSettings.metrics, "Forced metric copying must not persist into later layout refreshes");
+    assert(renders.length === afterSettings.renders, "A later layout refresh must reuse HTML after the settings refresh is consumed");
+    assert(requests.length === beforeSettings.requests, "Geometry refreshes must not reclassify unchanged text");
+    assert(frames.length === 0, "Both layout passes must finish without leaving scheduled work");
+  } finally {
+    if (previousRequestFrame === undefined) {
+      delete globalThis.requestAnimationFrame;
+    } else {
+      globalThis.requestAnimationFrame = previousRequestFrame;
+    }
+  }
 } finally {
   if (previousTextareaClass === undefined) {
     delete globalThis.HTMLTextAreaElement;

--- a/tests/frontend_prompt_studio_scroll_refresh_smoke.mjs
+++ b/tests/frontend_prompt_studio_scroll_refresh_smoke.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+// Execute the production global-overlay scheduler with a deterministic clock.
+const source = readFileSync(new URL("../web/js/prompt_studio/highlight.js", import.meta.url), "utf8");
+const start = source.indexOf("let promptHighlightRefreshRaf = 0;");
+const end = source.indexOf("function installPromptHighlightOverlayRefresh", start);
+assert(start >= 0 && end > start);
+let now = 0;
+let nextId = 0;
+let refreshes = 0;
+const frames = new Map();
+const timers = new Map();
+const context = vm.createContext({
+  document: { querySelectorAll() { refreshes += 1; return []; } },
+  requestAnimationFrame(callback) { const id = ++nextId; frames.set(id, callback); return id; },
+  setTimeout(callback, delay) { const id = ++nextId; timers.set(id, { callback, at: now + delay }); return id; },
+  clearTimeout(id) { timers.delete(id); },
+});
+vm.runInContext(`${source.slice(start, end)}\nglobalThis.schedule = requestConnectedHighlightOverlayRefresh;`, context);
+function flushTimers() {
+  for (const [id, timer] of [...timers]) {
+    if (timer.at <= now) { timers.delete(id); timer.callback(); }
+  }
+}
+for (let frame = 0; frame < 60; frame++) {
+  now = frame * 1000 / 60;
+  flushTimers();
+  for (let event = 0; event < 3; event++) context.schedule();
+  assert.equal(timers.size, 1, "Continuous wheel events must share one final stabilization timer");
+  const batch = [...frames.values()];
+  frames.clear();
+  for (const callback of batch) callback();
+}
+assert.equal(refreshes, 60, "One whole-editor measurement per animation frame during the gesture");
+now += 100;
+flushTimers();
+assert.equal(refreshes, 61, "Exactly one final refresh after the gesture");
+assert.equal(timers.size, 0);
+assert.equal(frames.size, 0);
+console.log("Prompt Studio canvas scroll refresh smoke passed: 180 requests, 61 passes, no pending work.");

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -44,6 +44,11 @@ try {
         throw "Frontend highlight overlay core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_scroll_refresh_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Prompt Studio scroll refresh smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_profile_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO profile core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/popup_geometry.js
+++ b/web/js/autocomplete/popup_geometry.js
@@ -91,7 +91,11 @@ export function calculateAutocompletePopupGeometry(
     inputRect.bottom,
   );
   const left = clamp(caretLeft, 4, Math.max(4, viewport.width - width - 4));
-  const top = caretBottom + lineHeight + 12;
+  const top = clamp(
+    caretBottom + lineHeight + 12,
+    4,
+    Math.max(4, viewport.height - 8 - 56),
+  );
   const maxHeight = Math.max(56, viewport.height - top - 8);
   return {
     left,

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -215,6 +215,7 @@ let promptStudioLoraAutocomplete = true;
 let popup = null;
 let activeState = null;
 let activeRefreshFrame = null;
+let activeRefreshNeedsUpdate = false;
 let middlePanForwardCleanup = null;
 const autocompleteInputOwner = {};
 const hookedAutocompleteInputs = new Set();
@@ -625,23 +626,29 @@ function invalidateAutocompleteDataRequests() {
   }
 }
 
-function refreshActiveAutocomplete() {
+function refreshActiveAutocomplete(positionOnly = false) {
   pruneDisconnectedAutocompleteInputs();
   if (!activeState?.input || document.activeElement !== activeState.input || !autocompleteEnabledForState(activeState)) {
     hidePopup();
     return;
   }
-  activeState.reposition?.();
-  activeState.refresh?.();
+  if (positionOnly) {
+    activeState.reposition?.();
+  } else {
+    activeState.refresh?.();
+  }
 }
 
-function scheduleActiveRefresh() {
+function scheduleActiveRefresh({ positionOnly = false } = {}) {
+  activeRefreshNeedsUpdate ||= !positionOnly;
   if (activeRefreshFrame != null) {
-    cancelAnimationFrame(activeRefreshFrame);
+    return;
   }
   activeRefreshFrame = requestAnimationFrame(() => {
     activeRefreshFrame = null;
-    refreshActiveAutocomplete();
+    const refreshPositionOnly = !activeRefreshNeedsUpdate;
+    activeRefreshNeedsUpdate = false;
+    refreshActiveAutocomplete(refreshPositionOnly);
   });
 }
 
@@ -1810,14 +1817,14 @@ function handleAutocompleteScroll(event) {
   if (popup?.contains(event.target)) {
     return;
   }
-  scheduleActiveRefresh();
+  scheduleActiveRefresh({ positionOnly: true });
 }
 
 function handleAutocompleteWheel(event) {
   if (popup?.contains(event.target)) {
     return;
   }
-  scheduleActiveRefresh();
+  scheduleActiveRefresh({ positionOnly: true });
 }
 
 function hookNode(node, nodeData, attempt = 0) {
@@ -1946,6 +1953,7 @@ function disposeAutocompleteEntryUi() {
     cancelAnimationFrame(activeRefreshFrame);
     activeRefreshFrame = null;
   }
+  activeRefreshNeedsUpdate = false;
   middlePanForwardCleanup?.();
   middlePanForwardCleanup = null;
   hidePopup();

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -519,6 +519,7 @@ function ensureStyle() {
   style.textContent = `
     .easyuse-anima-autocomplete {
       position: fixed;
+      box-sizing: border-box;
       z-index: 100000;
       max-width: 520px;
       min-width: 280px;

--- a/web/js/prompt_studio/advanced_highlights.js
+++ b/web/js/prompt_studio/advanced_highlights.js
@@ -10,6 +10,7 @@ import {
   highlightOverlayHtml,
   overlayBounds,
   overlayScrollbarPadding,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 } from "./highlight.js";
 import {
@@ -76,13 +77,15 @@ function updateAdvancedFieldHighlight(node, field, textarea, tokens = null, forc
   if (forceCopyMetrics) {
     copyInputTextMetrics(textarea, overlay);
   }
-  syncOverlayBounds(textarea, overlay);
   const currentTokens = highlightTokensForText(
     value,
     state.lastText,
     tokens || state.tokens || [],
   );
-  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, textarea.placeholder || "", textarea);
+  setHighlightOverlayHtml(overlay, highlightOverlayHtml(
+    value, currentTokens, textarea.placeholder || "", textarea,
+  ));
+  syncOverlayBounds(textarea, overlay);
 }
 
 function scheduleAdvancedFieldHighlight(node, field, textarea) {
@@ -220,12 +223,9 @@ function refreshAdvancedHighlights(node, { classify = true, forceCopyMetrics = f
     if (overlay.style.height !== height) overlay.style.height = height;
     if (overlay.style.paddingRight !== padding.right) overlay.style.paddingRight = padding.right;
     if (overlay.style.paddingBottom !== padding.bottom) overlay.style.paddingBottom = padding.bottom;
+    setHighlightOverlayHtml(overlay, htmlContent);
     if (overlay.scrollTop !== scrollTop) overlay.scrollTop = scrollTop;
     if (overlay.scrollLeft !== scrollLeft) overlay.scrollLeft = scrollLeft;
-
-    if (overlay.innerHTML !== htmlContent) {
-      overlay.innerHTML = htmlContent;
-    }
 
     if (classify && (state.lastText !== value || !Array.isArray(state.tokens))) {
       scheduleAdvancedFieldHighlight(node, field, textarea);
@@ -249,6 +249,7 @@ function scheduleAdvancedHighlights(node, options = {}) {
   requestAnimationFrame(() => {
     node.__easyuseAnimaAdvancedHighlightScheduled = false;
     const refreshOptions = node.__easyuseAnimaAdvancedHighlightOptions || {};
+    node.__easyuseAnimaAdvancedHighlightOptions = null;
     refreshAdvancedHighlights(node, refreshOptions);
     requestAnimationFrame(() => refreshAdvancedHighlights(node, { classify: false, forceCopyMetrics: refreshOptions.forceCopyMetrics === true }));
   });

--- a/web/js/prompt_studio/highlight.js
+++ b/web/js/prompt_studio/highlight.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { easyuseAnimaClassifyPrompt } from "../easyuse_anima_api.js";
+import { easyuseAnimaLanguage } from "../easyuse_anima_i18n.js";
 import {
   SECTION_STYLES,
   AUTOCOMPLETE_TOOLTIP_SECTIONS,
@@ -23,6 +24,7 @@ import {
   createHighlightOverlayRenderer,
   overlayBounds,
   overlayScrollbarPadding,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 } from "./highlight_overlay_core.js";
 
@@ -148,6 +150,7 @@ const renderHighlightedText = createPromptHighlightRenderer({
 const highlightOverlayHtml = createHighlightOverlayRenderer({
   escapeHtml,
   renderHighlightedText,
+  getRenderKey: () => `${easyuseAnimaLanguage()}:${PROMPT_STUDIO_SETTINGS.renderRevision}`,
 });
 
 function requestOverlaySync(input, forceCopyMetrics = false) {
@@ -257,6 +260,7 @@ function ensureHighlightOverlay(input) {
 }
 
 let promptHighlightRefreshRaf = 0;
+let promptHighlightRefreshTimer = null;
 
 function refreshConnectedHighlightOverlays(applyTextStyle) {
   const inputs = Array.from(document.querySelectorAll(".easyuse-anima-highlight-input"));
@@ -329,13 +333,17 @@ function refreshConnectedHighlightOverlays(applyTextStyle) {
 }
 
 function requestConnectedHighlightOverlayRefresh(applyTextStyle) {
+  clearTimeout(promptHighlightRefreshTimer);
+  promptHighlightRefreshTimer = setTimeout(() => {
+    promptHighlightRefreshTimer = null;
+    refreshConnectedHighlightOverlays(applyTextStyle);
+  }, 80);
   if (promptHighlightRefreshRaf) {
     return;
   }
   promptHighlightRefreshRaf = requestAnimationFrame(() => {
     promptHighlightRefreshRaf = 0;
     refreshConnectedHighlightOverlays(applyTextStyle);
-    setTimeout(() => refreshConnectedHighlightOverlays(applyTextStyle), 80);
   });
 }
 
@@ -402,5 +410,6 @@ export {
   renderHighlightedText,
   requestConnectedHighlightOverlayRefresh,
   requestOverlaySync,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 };

--- a/web/js/prompt_studio/highlight_overlay_core.js
+++ b/web/js/prompt_studio/highlight_overlay_core.js
@@ -73,6 +73,11 @@ function cssPixel(value) {
  */
 function hasVisibleVerticalScrollbar(input, style) {
   const overflowY = String(style.overflowY || "").trim().toLowerCase();
+  // Node 2.0 reserves a stable gutter even while autosizing hides the scrollbar.
+  if (String(style.scrollbarGutter || "").includes("stable")
+    && ["auto", "scroll", "hidden"].includes(overflowY)) {
+    return true;
+  }
   if (overflowY === "scroll") {
     return true;
   }

--- a/web/js/prompt_studio/highlight_overlay_core.js
+++ b/web/js/prompt_studio/highlight_overlay_core.js
@@ -178,8 +178,10 @@ function highlightOverlayPreviewHtml(value, tokens, preview, renderHighlightedTe
  * @param {Object} dependencies
  * @param {HighlightTextRenderer} dependencies.renderHighlightedText
  * @param {(value: unknown) => string} dependencies.escapeHtml
+ * @param {() => string} [dependencies.getRenderKey]
  */
-function createHighlightOverlayRenderer({ renderHighlightedText, escapeHtml }) {
+function createHighlightOverlayRenderer({ renderHighlightedText, escapeHtml, getRenderKey = () => "" }) {
+  const cache = new WeakMap();
   /**
    * @param {unknown} value
    * @param {Array<any>} tokens
@@ -188,13 +190,35 @@ function createHighlightOverlayRenderer({ renderHighlightedText, escapeHtml }) {
    */
   return function highlightOverlayHtml(value, tokens, placeholder = "", input = null) {
     const text = String(value || "");
+    const tokenIdentity = tokens?.length ? tokens : null;
+    const preview = input?.__easyuseAnimaAutocompletePreview;
+    const previewKey = [
+      preview?.sourceValue, preview?.value, preview?.color,
+      preview?.candidateStart, preview?.candidateEnd, preview?.ghostStart, preview?.ghostEnd,
+    ];
+    const renderKey = getRenderKey();
+    const previous = input ? cache.get(input) : null;
+    if (previous && previous.text === text
+      && previous.tokens === tokenIdentity && previous.placeholder === placeholder
+      && previous.renderKey === renderKey
+      && previewKey.every((part, index) => part === previous.previewKey[index])) {
+      return previous.html;
+    }
+    const html = render(text, tokens, placeholder, preview);
+    if (input) {
+      cache.set(input, { text, tokens: tokenIdentity, placeholder, previewKey, renderKey, html });
+    }
+    return html;
+  };
+
+  function render(text, tokens, placeholder, preview) {
     if (!text) {
       return `<span style="opacity: 0.45">${escapeHtml(placeholder)}</span>`;
     }
     const previewHtml = highlightOverlayPreviewHtml(
       text,
       tokens,
-      input?.__easyuseAnimaAutocompletePreview,
+      preview,
       renderHighlightedText,
       escapeHtml,
     );
@@ -203,7 +227,20 @@ function createHighlightOverlayRenderer({ renderHighlightedText, escapeHtml }) {
     }
     const html = renderHighlightedText(text, tokens);
     return text.endsWith("\n") ? `${html} ` : html;
-  };
+  }
+}
+
+// Each overlay has one content owner; comparing our last string avoids a DOM
+// serialization read and preserves the existing nodes on caret/geometry updates.
+const overlayContents = new WeakMap();
+
+/** @param {HTMLElement} overlay @param {string} html */
+function setHighlightOverlayHtml(overlay, html) {
+  if (overlayContents.get(overlay) === html) {
+    return;
+  }
+  overlay.innerHTML = html;
+  overlayContents.set(overlay, html);
 }
 
 /**
@@ -253,5 +290,6 @@ export {
   createHighlightOverlayRenderer,
   overlayBounds,
   overlayScrollbarPadding,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 };

--- a/web/js/prompt_studio/highlight_ui.js
+++ b/web/js/prompt_studio/highlight_ui.js
@@ -4,6 +4,7 @@ import {
   copyInputTextMetrics,
   ensureHighlightOverlay,
   highlightOverlayHtml,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 } from "./highlight.js";
 import {
@@ -44,14 +45,16 @@ function updateHighlight(node, widget, tokens = widget.__easyuseAnimaTokens || [
   if (forceCopyMetrics) {
     copyInputTextMetrics(input, overlay);
   }
-  syncOverlayBounds(input, overlay);
   const value = displayText(node, widget, input);
   const currentTokens = highlightTokensForText(
     value,
     widget.__easyuseAnimaLastClassifiedText,
     tokens,
   );
-  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, input.placeholder || "", input);
+  setHighlightOverlayHtml(overlay, highlightOverlayHtml(
+    value, currentTokens, input.placeholder || "", input,
+  ));
+  syncOverlayBounds(input, overlay);
 }
 
 export {

--- a/web/js/prompt_studio/regional/editor_adapter.js
+++ b/web/js/prompt_studio/regional/editor_adapter.js
@@ -1,11 +1,12 @@
 // @ts-check
 
 import { easyuseAnimaClassifyPrompt, easyuseAnimaGetSettings } from "../../easyuse_anima_api.js";
-import { easyuseAnimaText } from "../../easyuse_anima_i18n.js";
+import { easyuseAnimaLanguage, easyuseAnimaText } from "../../easyuse_anima_i18n.js";
 import { createPromptHighlightRenderer } from "../highlight_core.js";
 import {
   copyInputTextMetrics,
   createHighlightOverlayRenderer,
+  setHighlightOverlayHtml,
   syncOverlayBounds,
 } from "../highlight_overlay_core.js";
 import {
@@ -231,6 +232,7 @@ const SECTION_STYLES = {
 };
 
 const PROMPT_STUDIO_COMMON_SETTINGS = {
+  renderRevision: 0,
   weightSyntaxUnderline: false,
   trainedTagTooltip: true,
 };
@@ -971,6 +973,7 @@ function parseColorSettings(value) {
 }
 
 function applyPromptStudioCommonSettings(settings) {
+  PROMPT_STUDIO_COMMON_SETTINGS.renderRevision += 1;
   PROMPT_STUDIO_COMMON_SETTINGS.weightSyntaxUnderline =
     settings?.["prompt_studio.weight_syntax_underline"] === "true";
   PROMPT_STUDIO_COMMON_SETTINGS.trainedTagTooltip =
@@ -1152,6 +1155,7 @@ const renderHighlightedText = createPromptHighlightRenderer({
 const highlightOverlayHtml = createHighlightOverlayRenderer({
   escapeHtml,
   renderHighlightedText,
+  getRenderKey: () => `${easyuseAnimaLanguage()}:${PROMPT_STUDIO_COMMON_SETTINGS.renderRevision}`,
 });
 
 export function requestPromptStudioOverlaySync(input, forceCopyMetrics = false) {
@@ -1298,13 +1302,15 @@ export function updatePromptStudioFieldHighlight(node, field, textarea, tokens =
   if (forceCopyMetrics) {
     copyInputTextMetrics(textarea, overlay);
   }
-  syncOverlayBounds(textarea, overlay);
   const currentTokens = highlightTokensForText(
     value,
     state.lastText,
     tokens || state.tokens || [],
   );
-  overlay.innerHTML = highlightOverlayHtml(value, currentTokens, textarea.placeholder || "", textarea);
+  setHighlightOverlayHtml(overlay, highlightOverlayHtml(
+    value, currentTokens, textarea.placeholder || "", textarea,
+  ));
+  syncOverlayBounds(textarea, overlay);
 }
 
 export function schedulePromptStudioFieldHighlight(node, field, textarea, { namespace = "variant" } = {}) {

--- a/web/js/prompt_studio/settings.js
+++ b/web/js/prompt_studio/settings.js
@@ -15,6 +15,7 @@ import {
 } from "./utils.js";
 
 const PROMPT_STUDIO_SETTINGS = {
+  renderRevision: 0,
   typoIndicator: true,
   weightSyntaxUnderline: false,
   // Keep the legacy setting key, but use it only for paint-only emphasis.
@@ -52,6 +53,7 @@ function applyPromptStudioTextStyle(input) {
 }
 
 function applyPromptStudioSettings(settings, { hideTrainedTagTooltip = null } = {}) {
+  PROMPT_STUDIO_SETTINGS.renderRevision += 1;
   PROMPT_STUDIO_SETTINGS.typoIndicator = settings?.["prompt_studio.typo_indicator"] !== "false";
   PROMPT_STUDIO_SETTINGS.weightSyntaxUnderline = settings?.["prompt_studio.weight_syntax_underline"] === "true";
   PROMPT_STUDIO_SETTINGS.commentEmphasis = settings?.["prompt_studio.comment_italic"] !== "false";


### PR DESCRIPTION
Related to #757. Main promotion: #759.

Prompt Studio rebuilt unchanged highlight HTML and replaced overlay DOM during caret, scroll, and layout refreshes. Long scrolled fields could also place autocomplete outside the viewport, and Node 2.0's reserved scrollbar gutter made highlight wrapping 15px wider than its textarea.

Changes:
- Cache highlight output per input with invalidation for text, classification tokens, preview content, language, and settings; skip unchanged DOM writes.
- Coalesce scroll settling work, avoid duplicate autocomplete measurement, and consume Advanced forced-metric refresh options.
- Keep autocomplete within the viewport, and include Node 2.0's stable scrollbar gutter in overlay padding.
- Preserve stored settings, node APIs, field values, and workflow serialization.

Validation:
- Focused production-module regression checks cover cache/DOM identity, scheduling, preview/settings invalidation, viewport placement, and gutter width. New defect cases fail before their fixes and pass afterward.
- 180 canvas refresh requests over 60 frames produce 61 passes with no pending work.
- Fresh Legacy Canvas and Node 2.0 documents on isolated ComfyUI 0.34.0 / frontend 1.49.6: 4,607-character paste/restore, Classic/Advanced/Regional highlight alignment, scrolled autocomplete selection, save/reopen, and successful queue evidence for each node on both surfaces.
- Reproduced popup y=1177.61 in a 720px viewport now stays at y=656..712 and follows scrolling; Node 2.0 effective textarea/overlay widths both equal 477px.
- Source, installed, and HTTP bytes match across the complete 74-module entrypoint dependency closure. Temporary diagnostics are removed.
- Independent implementation and promotion reviews approved the final changes.

The original intermittent v1.1.3 exception was unspecified; this change fixes the confirmed current defects. Initial host graph-initialization/preload console messages were recorded separately from action-time checks; no new error was observed during the exercised flows.

Base → Head: `a0c066b533a90327c83e1b8c85d5ea9fee9e00e0` → `a4d3fe291ac9e66f7d9c7bdb574cbcc1665cbbbf`.
Full final-candidate gate passed: 1,645 Python tests (3 skipped), 125 JavaScript files, TypeScript 6.0.3, ownership/static/diff checks.