### PR TITLE
fix(registry): 게시 전 패키지 버전과 changelog 일치 검사

### DIFF
--- a/.github/scripts/extract_release_changelog.py
+++ b/.github/scripts/extract_release_changelog.py
@@ -74,11 +74,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--release", type=Path, default=Path("RELEASE.md"))
     parser.add_argument("--metadata", type=Path, default=Path(".github/registry/metadata.json"))
     parser.add_argument("--registry-changelog-dir", type=Path, default=Path(".github/registry/changelogs"))
-    parser.add_argument("--version", default="", help="Version to extract. Defaults to pyproject version.")
+    parser.add_argument("--version", default="", help="Expected package version. Must match pyproject.toml.")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    version = args.version.strip() or _pyproject_version(args.pyproject)
+    package_version = _pyproject_version(args.pyproject)
+    version = args.version.strip() or package_version
+    if version != package_version:
+        raise ValueError(
+            f"Requested version {version} does not match package version {package_version}"
+        )
     changelog = (
         _registry_changelog_file(args.registry_changelog_dir, version)
         or _metadata_changelog(args.metadata, version)

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -12,7 +12,7 @@ on:
           - "publish"
           - "metadata"
       version:
-        description: "Optional version to publish. Uses .github/registry/changelogs first, then RELEASE.md."
+        description: "Optional expected package version. Must match pyproject.toml; leave blank to use it."
         required: false
         default: ""
       dry_run:

--- a/tests/test_registry_release_copy.py
+++ b/tests/test_registry_release_copy.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
 import re
+import tempfile
 import tomllib
 import unittest
 from pathlib import Path
@@ -10,6 +14,54 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 METADATA_PATH = ROOT / ".github" / "registry" / "metadata.json"
 RELEASE_PATH = ROOT / "RELEASE.md"
+
+
+class RegistryPublishVersionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "extract_release_changelog", ROOT / ".github/scripts/extract_release_changelog.py",
+        )
+        self.extractor = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.extractor)
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.pyproject = self.root / "pyproject.toml"
+        self.pyproject.write_text('[project]\nversion = "3.2.1"\n', encoding="utf-8")
+        self.changelogs = self.root / "changelogs"
+        self.changelogs.mkdir()
+        (self.changelogs / "3.2.1.txt").write_text("Current release notes\n", encoding="utf-8")
+        (self.changelogs / "3.2.0.txt").write_text("Older release notes\n", encoding="utf-8")
+        self.output = self.root / "output.txt"
+
+    def _run(self, version: str | None = None) -> int:
+        arguments = [
+            "--pyproject", str(self.pyproject),
+            "--registry-changelog-dir", str(self.changelogs),
+            "--output", str(self.output),
+        ]
+        if version is not None:
+            arguments.extend(["--version", version])
+        with contextlib.redirect_stdout(io.StringIO()):
+            return self.extractor.main(arguments)
+
+    def test_omitted_or_matching_version_extracts_package_changelog(self) -> None:
+        for version in (None, "", "3.2.1", " 3.2.1 "):
+            with self.subTest(version=version):
+                self.assertEqual(self._run(version), 0)
+                self.assertEqual(self.output.read_text(encoding="utf-8"), "Current release notes\n")
+
+    def test_mismatched_version_cannot_overwrite_output_with_old_changelog(self) -> None:
+        self.output.write_text("Existing output\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "does not match.*3.2.1"):
+            self._run("3.2.0")
+        self.assertEqual(self.output.read_text(encoding="utf-8"), "Existing output\n")
+
+    def test_explicit_version_cannot_skip_package_identity(self) -> None:
+        self.pyproject.unlink()
+        with self.assertRaises(FileNotFoundError):
+            self._run("3.2.1")
+        self.assertFalse(self.output.exists())
 
 
 class RegistryReleaseCopyTests(unittest.TestCase):


### PR DESCRIPTION
관련 #762.

게시 workflow의 version 입력이 실제 패키지 버전을 바꾸지 않는데도 다른 버전의 changelog를 선택할 수 있었습니다. 이제 extractor가 `pyproject.toml`을 먼저 읽고, 입력이 비어 있거나 같은 버전일 때만 changelog를 생성합니다. 불일치는 파일 쓰기와 publish step 전에 중단합니다.

- 공개 node/API·저장 형식·runtime 변경 없음.
- workflow 설명을 expected package version으로 수정하고 trigger·권한·action pin·metadata 모드를 보존했습니다.
- 수정 전 회귀 2건 실패, 수정 후 실제 extractor 3 tests와 workflow 계약 5 tests 통과. 독립 리뷰 완료.
- Registry 게시나 metadata 변경은 실행하지 않았습니다. 최신 상태의 승인 추적은 #677입니다.

Base → Head: `2374936098e9c62050b42d922da9ea3795ce695b` → `2b224ccef8c51520338d61fdec60052b6e2b5652`.
최종 full: Python 1,652개(3 skipped), JS 125개, TypeScript 6.0.3 통과. runtime은 검증한 이미지 수정 #771과 동일하므로 해당 격리 ComfyUI 0.34.0 실행 증거를 재사용합니다.