### PR TITLE
fix(naia): 검증된 리다이렉트 차단을 main에 반영

### DIFF
--- a/easyuse_anima/naia/client.py
+++ b/easyuse_anima/naia/client.py
@@ -81,6 +81,17 @@ def _build_naia_random_url(host: str, port: int, allow_remote_api: bool = False)
     return f"http://{url_host}:{int(port)}/api/comfyui/random"
 
 
+def _reject_naia_redirect(response, **_kwargs):
+    # Requests prepares the next request even with allow_redirects=False.
+    # Reject before it parses an untrusted Location header.
+    if 300 <= response.status_code < 400:
+        try:
+            response.close()
+        finally:
+            raise RuntimeError("[EasyUse Anima] NAIA API redirects are not allowed.") from None
+    return response
+
+
 def _post_random(host: str, port: int, body: dict, allow_remote_api: bool = False) -> dict:
     try:
         import requests
@@ -92,7 +103,10 @@ def _post_random(host: str, port: int, body: dict, allow_remote_api: bool = Fals
         # Explicit user-configured NAIA API call. Default use is localhost-only;
         # remote hosts require allow_remote_api=True. The response is parsed as
         # JSON and is never executed as code.
-        response = requests.post(url, json=body, timeout=HTTP_TIMEOUT)
+        response = requests.post(
+            url, json=body, timeout=HTTP_TIMEOUT, allow_redirects=False,
+            hooks={"response": _reject_naia_redirect},
+        )
     except requests.RequestException as exc:
         raise RuntimeError(f"[EasyUse Anima] NAIA API request failed: {exc}")
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22735,7 +22735,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 85
+            "line": 96
           }
         ],
         "classification": "external",
@@ -22743,7 +22743,7 @@
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 86,
+        "line": 97,
         "name": null,
         "optional": true,
         "requested": "requests",
@@ -57116,29 +57116,37 @@
           },
           {
             "async": false,
-            "end_line": 110,
+            "end_line": 92,
             "kind": "function",
             "line": 84,
-            "loc": 27,
+            "loc": 9,
+            "qualified_name": "_reject_naia_redirect"
+          },
+          {
+            "async": false,
+            "end_line": 124,
+            "kind": "function",
+            "line": 95,
+            "loc": 30,
             "qualified_name": "_post_random"
           },
           {
             "async": false,
-            "end_line": 132,
+            "end_line": 146,
             "kind": "function",
-            "line": 113,
+            "line": 127,
             "loc": 20,
             "qualified_name": "_parse_random_response"
           }
         ],
         "is_package": false,
-        "loc": 134,
+        "loc": 148,
         "module": "easyuse_anima.naia.client",
-        "normalized_git_blob_sha1": "38aa1aa65bb2d20a1adc5db7a2f21c43d055ef39",
+        "normalized_git_blob_sha1": "2c6f8ceb97f40a854550e8a6c31003411bc32221",
         "path": "easyuse_anima/naia/client.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 13
         }
       },
@@ -69589,14 +69597,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 85
+            "line": 96
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 86,
+        "line": 97,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/naia/client.py"
@@ -73898,14 +73906,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 85
+            "line": 96
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "requests",
         "kind": "static_import",
-        "line": 86,
+        "line": 97,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/naia/client.py"

--- a/tests/test_naia_settings.py
+++ b/tests/test_naia_settings.py
@@ -1,5 +1,11 @@
+import json
 import unittest
+from io import BytesIO
 from unittest.mock import patch
+
+import requests
+from requests.adapters import BaseAdapter
+from requests.models import Response
 
 from easyuse_anima.naia import random_prompt as naia_random_prompt
 from easyuse_anima.naia.client import (
@@ -9,10 +15,35 @@ from easyuse_anima.naia.client import (
     _build_naia_random_url,
     _fit_to_1mp,
     _parse_random_response,
+    _post_random,
 )
 from easyuse_anima.naia.resolution import _advanced_resolution_from_selection
 from easyuse_anima.nodes import naia_nodes
 from easyuse_anima.nodes.naia_nodes import EasyUseAnimaNAIARandomPrompt
+
+
+class NaiaResponseAdapter(BaseAdapter):
+    def __init__(self, payload, *, status_code=200, location=None):
+        self.payload = payload
+        self.status_code = status_code
+        self.location = location
+        self.requests = []
+        self.responses = []
+
+    def send(self, request, **kwargs):
+        self.requests.append(request)
+        response = Response()
+        response.request = request
+        response.url = request.url
+        response.status_code = self.status_code if len(self.requests) == 1 else 200
+        if len(self.requests) == 1 and self.location is not None:
+            response.headers["Location"] = self.location
+        response.raw = BytesIO(json.dumps(self.payload).encode("utf-8"))
+        self.responses.append(response)
+        return response
+
+    def close(self):
+        pass
 
 
 def settings(**overrides):
@@ -395,6 +426,71 @@ class NaiaSettingsTests(unittest.TestCase):
             with self.subTest(host=host):
                 with self.assertRaisesRegex(RuntimeError, "hostname or IP address"):
                     _build_naia_random_url(host, 7243, allow_remote_api=True)
+
+    def test_naia_rejects_redirects_without_forwarding_prompt(self):
+        body = {"prompt": "synthetic prompt"}
+        cases = (
+            (307, "https://outside.invalid/collect"),
+            (308, "https://outside.invalid/collect"),
+            (307, "http://[redirect-secret]/collect"),
+            (308, "http://[redirect-secret]/collect"),
+        )
+        for status_code, location in cases:
+            with self.subTest(status_code=status_code, location=location):
+                adapter = NaiaResponseAdapter(
+                    {"ok": True, "prompt": "redirect response body"},
+                    status_code=status_code,
+                    location=location,
+                )
+                with requests.Session() as session:
+                    session.trust_env = False
+                    session.mount("http://", adapter)
+                    session.mount("https://", adapter)
+                    with patch.object(requests, "post", session.post):
+                        with self.assertRaises(RuntimeError) as raised:
+                            _post_random("127.0.0.1", 7243, body)
+
+                self.assertEqual(
+                    str(raised.exception),
+                    "[EasyUse Anima] NAIA API redirects are not allowed.",
+                )
+                self.assertEqual(len(adapter.requests), 1)
+                self.assertTrue(adapter.responses[0].raw.closed)
+                self.assertEqual(
+                    adapter.requests[0].url,
+                    "http://127.0.0.1:7243/api/comfyui/random",
+                )
+                self.assertEqual(json.loads(adapter.requests[0].body), body)
+
+    def test_naia_direct_local_and_enabled_remote_requests_keep_success(self):
+        payload = {
+            "ok": True,
+            "prompt": "generated prompt",
+            "negative_prompt": "generated negative",
+            "width": 1024,
+            "height": 1024,
+        }
+        body = {"prompt": "synthetic prompt"}
+        for host, allow_remote in (("127.0.0.1", False), ("naia.example", True)):
+            with self.subTest(host=host, allow_remote=allow_remote):
+                adapter = NaiaResponseAdapter(payload)
+                with requests.Session() as session:
+                    session.trust_env = False
+                    session.mount("http://", adapter)
+                    session.mount("https://", adapter)
+                    with patch.object(requests, "post", session.post):
+                        result = _post_random(
+                            host, 7243, body, allow_remote_api=allow_remote,
+                        )
+
+                self.assertEqual(result, payload)
+                self.assertEqual(len(adapter.requests), 1)
+                self.assertEqual(adapter.requests[0].method, "POST")
+                self.assertEqual(
+                    adapter.requests[0].url,
+                    f"http://{host}:7243/api/comfyui/random",
+                )
+                self.assertEqual(json.loads(adapter.requests[0].body), body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #761.

NAIA local-only 설정은 첫 주소만 검사하여 localhost의 307/308 응답을 따라 prompt JSON을 다른 주소로 다시 전송할 수 있었습니다. 모든 3xx를 Requests response hook에서 거절하고 응답을 닫아 두 번째 전송을 차단합니다. `allow_redirects=False`에서도 Requests가 Location을 파싱하므로 hook은 그 전에 실행합니다.

- 정상 200 응답, localhost 기본값, 명시적 remote opt-in, timeout과 JSON 응답 계약 보존.
- 307/308 및 잘못된 Location은 요청 1건·고정 오류·닫힌 응답을 확인했습니다. 합성 prompt와 실제 Requests Session + fake adapter를 사용하여 외부 전송 없이 수정 전 실패를 재현했습니다.
- focused NAIA 16개와 canonical backend 분석 기준 1개 통과. 독립 강화 리뷰에서 확인한 Location 파싱 오류 유출도 보완 후 재검토 통과.
- 리다이렉트를 사용하는 NAIA 배포는 최종 API 주소를 직접 설정해야 합니다. 공개 node ID와 저장 설정은 그대로 유지합니다.

Base → Head: `18e415c0a4e091c4fd89d94dc5e7d271f682375c` → `67290c08299110f0eb51458ab8d6ad46f666c060`.
최종 main full: Python 1,620개(3 skipped), JS 123개, TypeScript 6.0.3 통과. dev #775도 full 후 병합됐습니다.
격리 실행: ComfyUI 0.34.0 / frontend 1.49.6에서 마지막 main 통합 후보의 NAIA owner가 이 PR과 동일함을 확인하고 실제 queue를 실행했습니다. 200 정상 출력, 307·308·잘못된 Location은 고정 오류, 각 source POST 1건 및 loopback redirect destination 수신 0건을 확인했습니다. 임시 설정은 byte 단위로 복원했고 fixture·서버·본 작업 history를 정리했습니다. 무관한 WAS pack의 numba 미설치 경고가 있었으나 EasyUse import와 대상 실행은 성공했습니다.