### PR TITLE
fix(aio): Spectrum 누락 오류의 설치 주소 수정

### DIFF
--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -503,7 +503,7 @@ def _apply_aio_spectrum_correction_patch_for_comfy_sampler(
     patch_cls = _require_custom_node_class(
         "DiTCFGFSGPatch",
         "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
     )
     use_smc = _as_bool(corrections.get("smc_cfg"), False)
     use_cfgpp = _as_bool(corrections.get("cfgpp"), False)
@@ -562,7 +562,7 @@ def _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
     node_id, patch_cls = _require_any_custom_node_class(
         ("DiTSpectrumPatchAdvanced", "DiTSpectrumPatch"),
         "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
     )
     patcher = patch_cls()
     patch = getattr(patcher, "patch", None)

--- a/easyuse_anima/aio/sampling.py
+++ b/easyuse_anima/aio/sampling.py
@@ -128,7 +128,7 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
     sampler_cls = _require_custom_node_class(
         "SpectrumKSamplerAdvanced",
         "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
     )
     spectrum = sampler_settings.get("spectrum", {})
     if not isinstance(spectrum, dict):
@@ -254,7 +254,7 @@ def _sample_latent_with_spectrum_spd(
     spd_cls = _require_custom_node_class(
         "SpectrumSPDKSampler",
         "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
     )
     spd = sampler_settings.get("spd", {})
     if not isinstance(spd, dict):

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -51162,7 +51162,7 @@
         "is_package": false,
         "loc": 618,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "bf7c225f4b9d586102816c633d0f531ffb2e6001",
+        "normalized_git_blob_sha1": "537177c6bcd423c622da1b749a62baaa91293338",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
@@ -53212,7 +53212,7 @@
         "is_package": false,
         "loc": 455,
         "module": "easyuse_anima.aio.sampling",
-        "normalized_git_blob_sha1": "139c6037c7868367923e1c353e871f9ca4e6d7dd",
+        "normalized_git_blob_sha1": "b2ed2796b6b4f259e0b82f6afc1776e839c899b2",
         "path": "easyuse_anima/aio/sampling.py",
         "top_level": {
           "class_count": 0,

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -1405,44 +1405,53 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         self.assertNotIn("compat_policy", calls[0])
 
     def test_missing_spectrum_model_patch_dependency_names_required_node_pack(self):
-        settings = generation_normalization._normalize_aio_generation_settings(json.dumps({
-            "sampler": {
-                "backend": "comfy_ksampler",
-                "spectrum": {
-                    "enabled": True,
-                },
-            },
-        }))
+        for feature in ("spectrum", "dit_corrections"):
+            with self.subTest(feature=feature):
+                settings = generation_normalization._normalize_aio_generation_settings(json.dumps({
+                    "sampler": {
+                        "backend": "comfy_ksampler",
+                        "spectrum": {"enabled": feature == "spectrum"},
+                        "dit_corrections": {"enabled": feature == "dit_corrections"},
+                    },
+                }))
 
-        with patch_comfy_helper(aio_nodes, "_find_comfy_node_class", return_value=None):
-            with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler"):
-                model_preparation._apply_aio_spectrum_model_patches_for_comfy_sampler(
-                    "base_model",
-                    "clip",
-                    "positive",
-                    settings["sampler"],
+                with patch_comfy_helper(aio_nodes, "_find_comfy_node_class", return_value=None):
+                    with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler") as missing:
+                        model_preparation._apply_aio_spectrum_model_patches_for_comfy_sampler(
+                            "base_model",
+                            "clip",
+                            "positive",
+                            settings["sampler"],
+                        )
+                self.assertIn(
+                    "https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
+                    str(missing.exception),
                 )
 
     def test_missing_spectrum_sampler_dependency_names_required_node_pack(self):
-        settings = generation_normalization._normalize_aio_generation_settings(json.dumps({
-            "sampler": {
-                "backend": "spectrum_mod_guidance_advanced",
-            },
-        }))
+        for backend in ("spectrum_mod_guidance_advanced", "spectrum_spd_speed"):
+            with self.subTest(backend=backend):
+                settings = generation_normalization._normalize_aio_generation_settings(json.dumps({
+                    "sampler": {"backend": backend},
+                }))
 
-        with patch_comfy_helper(aio_nodes, "_find_comfy_node_class", return_value=None):
-            with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler"):
-                sampling._sample_latent_with_aio_backend(
-                    model=None,
-                    clip=None,
-                    positive=None,
-                    negative=None,
-                    latent_image=None,
-                    sampler_settings=settings["sampler"],
-                    mod_guidance_settings=settings["mod_guidance"],
-                    use_mod_guidance=True,
-                    quality_tags="quality",
-                    quality_neg="negative quality",
+                with patch_comfy_helper(aio_nodes, "_find_comfy_node_class", return_value=None):
+                    with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler") as missing:
+                        sampling._sample_latent_with_aio_backend(
+                            model=None,
+                            clip=None,
+                            positive=None,
+                            negative=None,
+                            latent_image=None,
+                            sampler_settings=settings["sampler"],
+                            mod_guidance_settings=settings["mod_guidance"],
+                            use_mod_guidance=True,
+                            quality_tags="quality",
+                            quality_neg="negative quality",
+                        )
+                self.assertIn(
+                    "https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
+                    str(missing.exception),
                 )
 
     def test_spectrum_advanced_sampler_filters_unsupported_keywords(self):


### PR DESCRIPTION
관련 #763.

Spectrum 의존성이 없을 때 네 실행 경로가 존재하지 않는 `blepping/ComfyUI-Spectrum-KSampler`를 설치 주소로 안내했습니다. 유지관리되는 `sorryhyun/ComfyUI-Spectrum-KSampler` 주소로 고칩니다.

- sampler advanced/SPD 및 forecast/correction 누락 오류의 링크만 변경합니다. node ID, signature, 모델·샘플링·fallback 동작은 그대로입니다.
- 원 주소 404와 교정 주소 200을 공식 GitHub API에서 확인했습니다.
- 기존 focused 2 methods를 확장하여 실제 누락 경로 4개를 검증했습니다. source fingerprint만 공식 analyzer로 갱신했습니다. Python AST·diff 검사 통과.

Base → Head: `9f172f2d47ff8bf9a6e78850237fd12b87b99f0d` → `e7d6b42c39b5d6060196cedd4535e39c5d94cdbb`.
최종 dev full: Python 1,654개(3 skipped), JS 125개, TypeScript 6.0.3 통과. 모델 실행 변경은 없으며 누락 오류 경계를 테스트했습니다. main #781도 full 및 격리 설치 확인 후 병합됐습니다.