### PR TITLE
fix(api): Origin과 Host의 동시 파싱 실패를 거절

### DIFF
--- a/easyuse_anima/api/requests.py
+++ b/easyuse_anima/api/requests.py
@@ -80,10 +80,12 @@ def validate_same_origin_json_request(request) -> None:
 
     origin = _request_header(request, "Origin")
     host = _request_header(request, "Host")
+    origin_authority = _origin_authority(origin)
+    host_authority = _host_authority(host, origin)
     if (
-        not origin
-        or not host
-        or _origin_authority(origin) != _host_authority(host, origin)
+        origin_authority is None
+        or host_authority is None
+        or origin_authority != host_authority
     ):
         raise ApiContractError(
             403,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -54020,65 +54020,65 @@
           },
           {
             "async": false,
-            "end_line": 101,
+            "end_line": 103,
             "kind": "function",
             "line": 70,
-            "loc": 32,
+            "loc": 34,
             "qualified_name": "validate_same_origin_json_request"
           },
           {
             "async": true,
-            "end_line": 120,
+            "end_line": 122,
             "kind": "function",
-            "line": 104,
+            "line": 106,
             "loc": 17,
             "qualified_name": "parse_json_object"
           },
           {
             "async": false,
-            "end_line": 137,
+            "end_line": 139,
             "kind": "function",
-            "line": 123,
+            "line": 125,
             "loc": 15,
             "qualified_name": "json_object"
           },
           {
             "async": false,
-            "end_line": 157,
+            "end_line": 159,
             "kind": "function",
-            "line": 140,
+            "line": 142,
             "loc": 18,
             "qualified_name": "json_string"
           },
           {
             "async": false,
-            "end_line": 171,
+            "end_line": 173,
             "kind": "function",
-            "line": 160,
+            "line": 162,
             "loc": 12,
             "qualified_name": "json_boolean"
           },
           {
             "async": false,
-            "end_line": 191,
+            "end_line": 193,
             "kind": "function",
-            "line": 174,
+            "line": 176,
             "loc": 18,
             "qualified_name": "json_integer"
           },
           {
             "async": false,
-            "end_line": 211,
+            "end_line": 213,
             "kind": "function",
-            "line": 194,
+            "line": 196,
             "loc": 18,
             "qualified_name": "json_uuid_string"
           }
         ],
         "is_package": false,
-        "loc": 221,
+        "loc": 223,
         "module": "easyuse_anima.api.requests",
-        "normalized_git_blob_sha1": "8ed4b07094f18fde0711c0eff73719d3d1d9332a",
+        "normalized_git_blob_sha1": "9cabc63faa543b3710e2a6667499b10ee4d1b828",
         "path": "easyuse_anima/api/requests.py",
         "top_level": {
           "class_count": 0,

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -3284,6 +3284,17 @@ class ApiRequestContractTests(unittest.TestCase):
                 "Content-Type": "application/json",
                 "Host": "127.0.0.1:8188",
             },
+            {
+                "Content-Type": "application/json",
+                "Host": "invalid/authority",
+                "Origin": "null",
+            },
+            {
+                "Content-Type": "application/json",
+                "Host": "127.0.0.1:invalid",
+                "Origin": "http://127.0.0.1:invalid",
+                "Sec-Fetch-Site": "same-origin",
+            },
         )
 
         with (
@@ -3293,11 +3304,12 @@ class ApiRequestContractTests(unittest.TestCase):
             for route in self.POST_ROUTES:
                 for headers in cases:
                     with self.subTest(route=route, headers=headers):
-                        response = asyncio.run(
-                            routes.handlers[route](
-                                JsonRequest({}, headers=headers)
+                        request = JsonRequest({}, headers=headers)
+                        with patch.object(request, "json", wraps=request.json) as parse_body:
+                            response = asyncio.run(
+                                routes.handlers[route](request)
                             )
-                        )
+                            parse_body.assert_not_awaited()
                         self.assertEqual(response["status"], 403)
                         self.assertEqual(
                             response["payload"]["code"],


### PR DESCRIPTION
관련 #772.

Origin과 Host를 모두 파싱할 수 없으면 두 결과가 `None`으로 같아 공통 동일 출처 검사가 JSON 처리로 진행했습니다. 이제 파싱 결과가 하나라도 없으면 기존 `403 / cross_origin_request`를 반환합니다.

- 정상 동일 출처, Content-Type, Sec-Fetch-Site, response shape, 공개 node/API와 저장 형식을 보존합니다.
- 두 malformed 조합 × 공통 POST 경로 10개에서 수정 전 본문 파싱 진입과 일부 작업 제출을 확인했습니다. 수정 후 body 파싱과 작업 제출 전에 모두 거절합니다.
- focused ApiRequestContractTests 17개, canonical analyzer 일치 1개, compile/diff 통과. 추가된 동작은 형식 검사이며 인증 체계를 변경하지 않습니다.
- 합성 요청으로 재현했습니다. 일반 브라우저가 이 Host를 만들어 공격한다는 재현은 아닙니다.

Base → Head: `5273834c52f90a0a6dbe21472de8ade8d1175918` → `ba94866bee1a0c8698d3a232cf76b0914e189ef5`.
최종 dev full: Python 1,654개(3 skipped), JS 125개, TypeScript 6.0.3 통과. main #782도 검증 후 병합됐습니다.
격리 HTTP 확인(ComfyUI 0.34.0 / frontend 1.49.6): Origin=null/Host=invalid/authority를 POST 10개에 보내 모두 EasyUse `403 / cross_origin_request`를 받았습니다. 정상 동일 출처의 malformed JSON은 `400 / malformed_json`으로 유지됐습니다. 설치한 요청 owner의 source 일치와 node-pack import도 확인했습니다.

한계: invalid-port 조합은 ComfyUI core `origin_only_middleware`의 `parsed.port`에서 먼저 ValueError/HTTP 500이 발생하여 EasyUse route까지 도달하지 않습니다. 전체 HTTP probe를 모두 통과했다고 표시하지 않으며, core 소유의 후속은 #780에 기록했습니다. EasyUse 공통 handler 수준에서는 이 조합도 body 파싱 전 거절하는 회귀를 통과했습니다. 임시 서버·설정을 정리했습니다.